### PR TITLE
Running Linter as Part of CI Jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.5"
 # command to install dependencies
 install: "pip install -r requirements.txt"
-before_script: ./lint.sh all
+before_script: 
+  - export PY_VERSION=`python -c 'import sys; print sys.version_info.major'`
+  - if [ $PY_VERSION == '2' ]; then ./lint.sh all; fi
 # command to run tests
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.5"
 # command to install dependencies
 install: "pip install -r requirements.txt"
+before_script: ./lint.sh all
 # command to run tests
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
 install: "pip install -r requirements.txt"
 before_script: 
   - export PY_VERSION=`python -c 'import sys; print sys.version_info.major'`
-  - if [ $PY_VERSION == '2' ]; then ./lint.sh all; fi
+  - if [[ "$PY_VERSION" == '2' ]]; then ./lint.sh all; fi
 # command to run tests
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.5"
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: pytest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/firebase/firebase-admin-python.svg?branch=master)](https://travis-ci.org/firebase/firebase-admin-python)
+
 # Firebase Admin Python SDK
 
 ## Table of Contents

--- a/lint.sh
+++ b/lint.sh
@@ -17,11 +17,6 @@
 function lintAllFiles () {
   echo "Running linter on module $1"
   pylint --disable=$2 $1
-  rc=$?
-  if [ $rc -ne 0 ]
-  then
-    exit $rc
-  fi
 }
 
 function lintChangedFiles () {
@@ -30,21 +25,30 @@ function lintChangedFiles () {
   do
     echo "Running linter on $f"
     pylint --disable=$2 $f
-    rc=$?
-    if [ $rc -ne 0 ]
-    then
-      exit $rc
-    fi
   done
 }
 
+set -o errexit
+set -o nounset
+
 SKIP_FOR_TESTS="redefined-outer-name,protected-access,missing-docstring"
 
-if [[ $1 = "all" ]]
+if [[ "$#" -eq 1 && "$1" = "all" ]]
 then
-  lintAllFiles firebase_admin
-  lintAllFiles tests $SKIP_FOR_TESTS
+  CHECK_ALL=true  
+elif [[ "$#" -eq  0 ]]
+then
+  CHECK_ALL=false
 else
-  lintChangedFiles firebase_admin
-  lintChangedFiles tests $SKIP_FOR_TESTS
+  echo "Usage: ./lint.sh [all]"
+  exit 1
+fi
+
+if [[ "$CHECK_ALL" = true ]]
+then
+  lintAllFiles "firebase_admin" ""
+  lintAllFiles "tests" "$SKIP_FOR_TESTS"
+else
+  lintChangedFiles "firebase_admin" ""
+  lintChangedFiles "tests" "$SKIP_FOR_TESTS"
 fi

--- a/lint.sh
+++ b/lint.sh
@@ -17,6 +17,11 @@
 function lintAllFiles () {
   echo "Running linter on module $1"
   pylint --disable=$2 $1
+  rc=$?
+  if [ $rc -ne 0 ]
+  then
+    exit $rc
+  fi
 }
 
 function lintChangedFiles () {
@@ -25,6 +30,11 @@ function lintChangedFiles () {
   do
     echo "Running linter on $f"
     pylint --disable=$2 $f
+    rc=$?
+    if [ $rc -ne 0 ]
+    then
+      exit $rc
+    fi
   done
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pylint >= 1.6.4
+pylint == 1.6.4
 pytest >= 3.0.6
 pytest-cov >= 2.4.0
 tox >= 2.6.0


### PR DESCRIPTION
* Returning non-zero exit codes from `lint.sh` when lint errors are encountered.
* Configuring Travis to run linter before running tests (it will fail the build, on non-zero exit codes)