### PR TITLE
Added integration tests for auth module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .tox/
 *.egg-info/
 *~
+scripts/cert.json
+scripts/apikey.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,25 @@ You can also get a code coverage report by launching pytest as follows:
 pytest --cov=firebase_admin --cov=tests
 ```
 
+### Integration Testing
+
+A suite of integration tests are available under the `integration/` directory.
+These tests are designed to run against an actual Firebase project. Create a new
+project in the [Firebase Console](https://console.firebase.google.com), if you
+do not already have one suitable for running the tests aginst. Then obtain the
+following credentials from the project:
+
+1. *Service account certificate*: This can be downloaded as a JSON file from
+   the "Settings > Service Accounts" tab of the Firebase console.
+2. *Web API key*: This is displayed in the "Settings > General" tab of the
+   console. Copy it and save to a new text file.
+
+Now you can invoke the integration test suite as follows:
+
+```
+pytest integration/ --cert path/to/service_acct.json --apikey path/to/apikey.txt
+```
+
 ### Testing in Different Environments
 
 Sometimes we want to run unit tests in multiple environments (e.g. different Python versions), and
@@ -213,6 +232,7 @@ pyenv local 2.7.6 3.3.0 pypy2-5.6.0
 Here are some highlights of the directory structure and notable source files
 
 * `firebase_admin/` - Source directory for the `firebase_admin` module.
+* `integration/` - Integration tests.
 * `tests/` - Unit tests.
   * `data/` - Provides mocks for several variables as well as mock service account keys.
 * `.github/` - Contribution instructions as well as issue and pull request templates.

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -24,6 +24,8 @@ from firebase_admin import credentials
 def pytest_addoption(parser):
     parser.addoption(
         '--cert', action='store', help='Service account certificate file for integration tests.')
+    parser.addoption(
+        '--apikey', action='store', help='API key file for integration tests.')
 
 def _get_cert_path(request):
     cert = request.config.getoption('--cert')
@@ -48,3 +50,13 @@ def default_app(request):
     cred = credentials.Certificate(cert_path)
     ops = {'dbURL' : 'https://{0}.firebaseio.com'.format(project_id)}
     return firebase_admin.initialize_app(cred, ops)
+
+@pytest.fixture(scope='session')
+def api_key(request):
+    path = request.config.getoption('--apikey')
+    if not path:
+        raise ValueError('API key file not specified. Make sure to specify the "--apikey" '
+                         'command-line option.')
+    with open(path) as keyfile:
+        return keyfile.read().strip()
+ 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -1,0 +1,44 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for firebase_admin.auth module."""
+import requests
+
+from firebase_admin import auth
+
+
+_id_toolkit_url = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken'
+
+
+def _sign_in(custom_token, api_key):
+    body = {'token' : custom_token, 'returnSecureToken' : True}
+    params = {'key' : api_key}
+    resp = requests.request('post', _id_toolkit_url, params=params, json=body)
+    resp.raise_for_status()
+    return resp.json().get('idToken')
+
+def test_custom_token(api_key):
+    custom_token = auth.create_custom_token('user1')
+    id_token = _sign_in(custom_token, api_key)
+    claims = auth.verify_id_token(id_token)
+    assert claims['uid'] == 'user1'
+
+def test_custom_token_with_claims(api_key):
+    dev_claims = {'premium' : True, 'subscription' : 'silver'}
+    custom_token = auth.create_custom_token('user2', dev_claims)
+    id_token = _sign_in(custom_token, api_key)
+    claims = auth.verify_id_token(id_token)
+    assert claims['uid'] == 'user2'
+    assert claims['premium'] is True
+    assert claims['subscription'] == 'silver'

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -77,10 +77,12 @@ fi
 
 if [[ ! -e "cert.json" ]]; then
     echo "[ERROR] cert.json file is required to run integration tests."
+    exit 1
 fi
 
 if [[ ! -e "apikey.txt" ]]; then
     echo "[ERROR] apikey.txt file is required to run integration tests."
+    exit 1
 fi
 
 HOST=$(uname)

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -75,6 +75,14 @@ if [[ `git status --porcelain` ]]; then
     exit 1
 fi
 
+if [[ ! -e "cert.json" ]]; then
+    echo "[ERROR] cert.json file is required to run integration tests."
+fi
+
+if [[ ! -e "apikey.txt" ]]; then
+    echo "[ERROR] apikey.txt file is required to run integration tests."
+fi
+
 HOST=$(uname)
 echo "[INFO] Updating version number in firebase_admin/__init__.py"
 if [ $HOST == "Darwin" ]; then
@@ -85,5 +93,8 @@ fi
 
 echo "[INFO] Running unit tests"
 tox --workdir ..
+
+echo "[INFO] Running integration tests"
+pytest ../integration --cert cert.json --apikey apikey.txt
 
 echo "[INFO] This repo has been prepared for a release. Create a branch and commit the changes."


### PR DESCRIPTION
#31 introduced an integration test suite to the SDK. But until now we have only had tests for the (experimental) `database` module. This PR adds integration tests for the `auth` module. Additionally:

* Updated `CONTRIBUTING.md` with information about running integration tests.
* Updated `prepare_release.sh` script to run integration tests when creating release builds. The credentials for tests are read from the `scripts/` directory itself.
