### PR TITLE
Implementing the API changes proposed in the final review

### DIFF
--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -198,7 +198,7 @@ class App(object):
     def options(self):
         return self._options
 
-    def get_token(self):
+    def _get_token(self):
         """Returns an OAuth2 bearer token.
 
         This method may return a cached token. But it handles cache invalidation, and therefore

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -48,7 +48,7 @@ def default_app(request):
     if not project_id:
         raise ValueError('Failed to determine project ID from service account certificate.')
     cred = credentials.Certificate(cert_path)
-    ops = {'dbURL' : 'https://{0}.firebaseio.com'.format(project_id)}
+    ops = {'databaseURL' : 'https://{0}.firebaseio.com'.format(project_id)}
     return firebase_admin.initialize_app(cred, ops)
 
 @pytest.fixture(scope='session')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -166,7 +166,7 @@ class TestFirebaseApp(object):
         mock_response = {'access_token': 'mock_access_token_1', 'expires_in': 3600}
         credentials._request = testutils.MockRequest(200, json.dumps(mock_response))
 
-        assert init_app.get_token() == 'mock_access_token_1'
+        assert init_app._get_token() == 'mock_access_token_1'
 
         mock_response = {'access_token': 'mock_access_token_2', 'expires_in': 3600}
         credentials._request = testutils.MockRequest(200, json.dumps(mock_response))
@@ -175,9 +175,9 @@ class TestFirebaseApp(object):
         # should return same token from cache
         firebase_admin._clock = lambda: expiry - datetime.timedelta(
             seconds=firebase_admin._CLOCK_SKEW_SECONDS + 1)
-        assert init_app.get_token() == 'mock_access_token_1'
+        assert init_app._get_token() == 'mock_access_token_1'
 
         # should return new token from RPC call
         firebase_admin._clock = lambda: expiry - datetime.timedelta(
             seconds=firebase_admin._CLOCK_SKEW_SECONDS)
-        assert init_app.get_token() == 'mock_access_token_2'
+        assert init_app._get_token() == 'mock_access_token_2'


### PR DESCRIPTION
* Removing priority operations from the API (we can add these later if there's a demand for it).
* `App.get_token()` method has been renamed and removed from the public API.
* Numerous method renames.
* `dbURL` option renamed to `databaseURL`.
* Updated affected test cases.

Related to #28 