### PR TITLE
Fixing Some Nits in Tests

### DIFF
--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -49,6 +49,7 @@ def testref(update_rules):
     Returns:
         Reference: A reference to the test dinosaur database.
     """
+    del update_rules
     ref = db.reference('_adminsdk/python/dinodb')
     ref.set(testdata())
     return ref
@@ -238,6 +239,7 @@ class TestAdvancedQueries(object):
 
 @pytest.fixture(scope='module')
 def override_app(request, update_rules):
+    del update_rules
     cred, project_id = conftest.integration_conf(request)
     ops = {
         'databaseURL' : 'https://{0}.firebaseio.com'.format(project_id),
@@ -249,6 +251,7 @@ def override_app(request, update_rules):
 
 @pytest.fixture(scope='module')
 def none_override_app(request, update_rules):
+    del update_rules
     cred, project_id = conftest.integration_conf(request)
     ops = {
         'databaseURL' : 'https://{0}.firebaseio.com'.format(project_id),

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -138,10 +138,15 @@ class TestWriteOperations(object):
 
     def test_update_nested_children(self, testref):
         python = testref.parent
-        ref = python.child('users').push({'name' : 'Edward Cope', 'since' : 1800})
-        nested_key = '{0}/since'.format(ref.key)
-        python.child('users').update({nested_key: 1840})
-        assert ref.get() == {'name' : 'Edward Cope', 'since' : 1840}
+        edward = python.child('users').push({'name' : 'Edward Cope', 'since' : 1800})
+        jack = python.child('users').push({'name' : 'Jack Horner', 'since' : 1940})
+        delta = {
+            '{0}/since'.format(edward.key) : 1840,
+            '{0}/since'.format(jack.key) : 1946
+        }
+        python.child('users').update(delta)
+        assert edward.get() == {'name' : 'Edward Cope', 'since' : 1840}
+        assert jack.get() == {'name' : 'Jack Horner', 'since' : 1946}
 
     def test_delete(self, testref):
         python = testref.parent

--- a/lint.sh
+++ b/lint.sh
@@ -31,7 +31,7 @@ function lintChangedFiles () {
 set -o errexit
 set -o nounset
 
-SKIP_FOR_TESTS="redefined-outer-name,protected-access,missing-docstring,unused-argument"
+SKIP_FOR_TESTS="redefined-outer-name,protected-access,missing-docstring"
 
 if [[ "$#" -eq 1 && "$1" = "all" ]]
 then

--- a/lint.sh
+++ b/lint.sh
@@ -31,7 +31,7 @@ function lintChangedFiles () {
 set -o errexit
 set -o nounset
 
-SKIP_FOR_TESTS="redefined-outer-name,protected-access,missing-docstring"
+SKIP_FOR_TESTS="redefined-outer-name,protected-access,missing-docstring,unused-argument"
 
 if [[ "$#" -eq 1 && "$1" = "all" ]]
 then
@@ -48,7 +48,9 @@ if [[ "$CHECK_ALL" = true ]]
 then
   lintAllFiles "firebase_admin" ""
   lintAllFiles "tests" "$SKIP_FOR_TESTS"
+  lintAllFiles "integration" "$SKIP_FOR_TESTS"
 else
   lintChangedFiles "firebase_admin" ""
   lintChangedFiles "tests" "$SKIP_FOR_TESTS"
+  lintAllFiles "integration" "$SKIP_FOR_TESTS"
 fi

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -81,7 +81,7 @@ class TestApplicationDefault(object):
 
     @pytest.mark.parametrize('app_default', [testutils.resource_filename('service_account.json')],
                              indirect=True)
-    def test_init(self, app_default): # pylint: disable=unused-argument
+    def test_init(self, app_default):
         credential = credentials.ApplicationDefault()
         assert credential.project_id == 'mock-project-id'
 
@@ -98,7 +98,7 @@ class TestApplicationDefault(object):
 
     @pytest.mark.parametrize('app_default', [testutils.resource_filename('non_existing.json')],
                              indirect=True)
-    def test_nonexisting_path(self, app_default): # pylint: disable=unused-argument
+    def test_nonexisting_path(self, app_default):
         with pytest.raises(IOError):
             credentials.ApplicationDefault()
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -82,6 +82,7 @@ class TestApplicationDefault(object):
     @pytest.mark.parametrize('app_default', [testutils.resource_filename('service_account.json')],
                              indirect=True)
     def test_init(self, app_default):
+        del app_default
         credential = credentials.ApplicationDefault()
         assert credential.project_id == 'mock-project-id'
 
@@ -99,6 +100,7 @@ class TestApplicationDefault(object):
     @pytest.mark.parametrize('app_default', [testutils.resource_filename('non_existing.json')],
                              indirect=True)
     def test_nonexisting_path(self, app_default):
+        del app_default
         with pytest.raises(IOError):
             credentials.ApplicationDefault()
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -37,6 +37,7 @@ class MockAdapter(adapters.HTTPAdapter):
         self._recorder = recorder
 
     def send(self, request, **kwargs):
+        del kwargs
         self._recorder.append(request)
         resp = models.Response()
         resp.url = request.url

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -36,7 +36,7 @@ class MockAdapter(adapters.HTTPAdapter):
         self._status = status
         self._recorder = recorder
 
-    def send(self, request, **kwargs): # pylint: disable=unused-argument
+    def send(self, request, **kwargs):
         self._recorder.append(request)
         resp = models.Response()
         resp.url = request.url


### PR DESCRIPTION
* Added `integration/` directory to linter
* Skipping `unused-argument` check for tests. This condition occurs far too often in tests (when setting up pytest fixtures)
* Updated a db integration test case to check for multiple updates.