### PR TITLE
Some Minor Fixes to Integration Tests

### DIFF
--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -22,7 +22,7 @@ _id_toolkit_url = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/ve
 
 
 def _sign_in(custom_token, api_key):
-    body = {'token' : custom_token, 'returnSecureToken' : True}
+    body = {'token' : custom_token.decode(), 'returnSecureToken' : True}
     params = {'key' : api_key}
     resp = requests.request('post', _id_toolkit_url, params=params, json=body)
     resp.raise_for_status()

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -29,9 +29,9 @@ def update_rules():
         new_rules = json.load(rules_file)
     client = db.reference()._client
     rules = client.request('get', '/.settings/rules.json')
-    existing = rules.get('rules', dict()).get('_adminsdk')
+    existing = rules.get('rules')
     if existing != new_rules:
-        rules['rules']['_adminsdk'] = new_rules
+        rules['rules'] = new_rules
         client.request('put', '/.settings/rules.json', json=rules)
 
 @pytest.fixture(scope='module')

--- a/tests/data/dinosaurs_index.json
+++ b/tests/data/dinosaurs_index.json
@@ -1,25 +1,27 @@
 {
-    "python": {
-        "dinodb": {
-            "dinosaurs": {
-                ".indexOn": ["height", "ratings/pos"]
+    "_adminsdk": {
+        "python": {
+            "dinodb": {
+                "dinosaurs": {
+                    ".indexOn": ["height", "ratings/pos"]
+                },
+                "scores": {
+                    ".indexOn": ".value"
+                }
             },
-            "scores": {
-                ".indexOn": ".value"
+            "protected": {
+                "$uid": {
+                    ".read": "auth != null",
+                    ".write": "$uid === auth.uid"
+                }
+            },
+            "admin": {
+                ".read": "false",
+                ".write": "false"
+            },
+            "public": {
+                ".read": "true"
             }
-        },
-        "protected": {
-            "$uid": {
-                ".read": "auth != null",
-                ".write": "$uid === auth.uid"
-            }
-        },
-        "admin": {
-            ".read": "false",
-            ".write": "false"
-        },
-        "public": {
-            ".read": "true"
         }
     }
 }


### PR DESCRIPTION
* Custom tokens minted by the `auth` modules are binary typed (i.e. `str` in Python 2.x and `bytes` in Python 3.x). Therefore in Python 3.x they need to be decoded before they can be put into a JSON structure. This was causing a test failure in Python 3.x (see #37). This patch fixes it.
* The `db` integration test was only updating the security rules for a specific child node (_adminsdk). But as it turns out, in Firebase RTDB [shallow rules take precedence](https://firebase.google.com/docs/database/security/#section-authentication). This means if there's already a shallow rule configured in the target database, the integration tests can fail (see #45). This patch fixes it by overwriting the entire rules configuration in the test fixture.

