### PR TITLE
Remove unnecessary checks on update with etag

### DIFF
--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -23,7 +23,7 @@ from firebase_admin import credentials
 
 # Declaring module version as per https://www.python.org/dev/peps/pep-0396/#specification
 # Update this accordingly for each release.
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 _apps = {}
 _apps_lock = threading.RLock()

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -201,10 +201,6 @@ class Reference(object):
 
     def _update_with_etag(self, value, etag):
         """Sets the data at this location to the specified value, if the etag matches."""
-        if not value or not isinstance(value, dict):
-            raise ValueError('Value argument must be a non-empty dictionary.')
-        if None in value.keys() or None in value.values():
-            raise ValueError('Dictionary must not contain None keys or values.')
         if not isinstance(etag, six.string_types):
             raise ValueError('ETag must be a string.')
 

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -178,6 +178,15 @@ class TestWriteOperations(object):
         assert new_value == expected
         assert ref.get() == expected
 
+    def test_transaction_scalar(self, testref):
+        python = testref.parent
+        ref = python.child('users/count')
+        ref.set(42)
+        new_value = ref.transaction(lambda x: x + 1 if x else 1)
+        expected = 43
+        assert new_value == expected
+        assert ref.get() == expected
+
     def test_delete(self, testref):
         python = testref.parent
         ref = python.child('users').push('foo')

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -318,6 +318,18 @@ class TestReference(object):
         assert recorder[1].method == 'PUT'
         assert json.loads(recorder[1].body.decode()) == {'foo1': 'bar1', 'foo2': 'bar2'}
 
+    def test_transaction_scalar(self):
+        ref = db.reference('/test/count')
+        data = 42
+        recorder = self.instrument(ref, json.dumps(data))
+
+        new_value = ref.transaction(lambda x: x + 1 if x else 1)
+        assert new_value == 43
+        assert len(recorder) == 2
+        assert recorder[0].method == 'GET'
+        assert recorder[1].method == 'PUT'
+        assert json.loads(recorder[1].body.decode()) == 43
+
     def test_transaction_error(self):
         ref = db.reference('/test')
         data = {'foo1': 'bar1'}


### PR DESCRIPTION
This PR fixes https://github.com/firebase/firebase-admin-python/issues/62 by removing unnecessary checks in function `_update_with_etag`.

## Why remove the checks instead of updating the docs?

1. To be more consistent with Java/Node API
2. It is specified in the docs that transaction is a `set()` operation, however, the current code checks the value as if it's an `update()` operation.

Code of `set()`, notice how it doesn't do this check at all and is using `put` like `transaction()`
https://github.com/firebase/firebase-admin-python/blob/99c48ef28692a263ef4171b1b0c15489584b9aab/firebase_admin/db.py#L146-L161

Code of `update()`, instead of using `put`, it's using `patch`. The original author might have borrowed the code from here:
https://github.com/firebase/firebase-admin-python/blob/99c48ef28692a263ef4171b1b0c15489584b9aab/firebase_admin/db.py#L186-L200

/cc @alexanderwhatley @hiranya911

