### PR TITLE
Refactoring Database Code

### DIFF
--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -1,0 +1,111 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal HTTP client module.
+
+ This module provides utilities for making HTTP calls using the requests library.
+ """
+
+from google.auth import transport
+import requests
+
+
+class HttpClient(object):
+    """Base HTTP client used to make HTTP calls.
+
+    HttpClient maintains an HTTP session, and handles request authentication if necessary.
+    """
+
+    def __init__(self, credential=None, session=None, base_url='', headers=None):
+        """Cretes a new HttpClient instance from the provided arguments.
+
+        If a credential is provided, initializes a new HTTP session authorized with it. If neither
+        a credential nor a session is provided, initializes a new unauthorized session.
+
+        Args:
+          credential: A Google credential that can be used to authenticate requests (optional).
+          session: A custom HTTP session (optional).
+          base_url: A URL prefix to be added to all outgoing requests (optional).
+          headers: A map of headers to be added to all outgoing requests (optional).
+        """
+        if credential:
+            self._session = transport.requests.AuthorizedSession(credential)
+        elif session:
+            self._session = session
+        else:
+            self._session = requests.Session() # pylint: disable=redefined-variable-type
+
+        if headers:
+            self._session.headers.update(headers)
+        self._base_url = base_url
+
+    @property
+    def session(self):
+        return self._session
+
+    @property
+    def base_url(self):
+        return self._base_url
+
+    def parse_body(self, resp):
+        raise NotImplementedError
+
+    def request(self, method, url, **kwargs):
+        """Makes an HTTP call using the Python requests library.
+
+        This is the sole entry point to the requests library. All other helper methods in this
+        class call this method to send HTTP requests out. Refer to
+        http://docs.python-requests.org/en/master/api/ for more information on supported options
+        and features.
+
+        Args:
+          method: HTTP method name as a string (e.g. get, post).
+          url: URL of the remote endpoint.
+          kwargs: An additional set of keyword arguments to be passed into the requests API
+              (e.g. json, params).
+
+        Returns:
+          Response: An HTTP response object.
+
+        Raises:
+          RequestException: Any requests exceptions encountered while making the HTTP call.
+        """
+        resp = self._session.request(method, self._base_url + url, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def headers(self, method, url, **kwargs):
+        resp = self.request(method, url, **kwargs)
+        return resp.headers
+
+    def body(self, method, url, **kwargs):
+        resp = self.request(method, url, **kwargs)
+        return self.parse_body(resp)
+
+    def headers_and_body(self, method, url, **kwargs):
+        resp = self.request(method, url, **kwargs)
+        return resp.headers, self.parse_body(resp)
+
+    def close(self):
+        self._session.close()
+        self._session = None
+
+
+class JsonHttpClient(HttpClient):
+
+    def __init__(self, **kwargs):
+        HttpClient.__init__(self, **kwargs)
+
+    def parse_body(self, resp):
+        return resp.json()

--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -103,6 +103,7 @@ class HttpClient(object):
 
 
 class JsonHttpClient(HttpClient):
+    """An HTTP client that parses response messages as JSON."""
 
     def __init__(self, **kwargs):
         HttpClient.__init__(self, **kwargs)

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -681,10 +681,11 @@ class _Client(_http_client.JsonHttpClient):
 
         Args:
           credential: A Google credential that can be used to authenticate requests.
-          base_url: A URL prefix to be added to all outgoing requests.
+          base_url: A URL prefix to be added to all outgoing requests. This is typically the
+              Firebase Realtime Database URL.
           auth_override: A dictionary representing auth variable overrides or None (optional).
-              Defaults to empty tuple, which provides admin privileges. A None value here provides
-              un-authenticated guest privileges.
+              Default value provides admin privileges. A None value here provides un-authenticated
+              guest privileges.
         """
         _http_client.JsonHttpClient.__init__(
             self, credential=credential, base_url=base_url, headers={'User-Agent': _USER_AGENT})
@@ -731,6 +732,10 @@ class _Client(_http_client.JsonHttpClient):
                              'value must be a dict or None.'.format(auth_override))
         else:
             return auth_override
+
+    @property
+    def auth_override(self):
+        return self._auth_override
 
     def request(self, method, url, **kwargs):
         """Makes an HTTP call using the Python requests library.

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -140,7 +140,6 @@ class Reference(object):
         Raises:
           ApiCallError: If an error occurs while communicating with the remote database server.
         """
-        print('calling child', self.path)
         if etag:
             headers, data = self._client.headers_and_body(
                 'get', self._add_suffix(), headers={'X-Firebase-ETag' : 'true'})

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -25,13 +25,14 @@ import json
 import numbers
 import sys
 
-from google.auth import transport
 import requests
 import six
 from six.moves import urllib
 
 import firebase_admin
 from firebase_admin import utils
+from firebase_admin import _http_client
+
 
 _DB_ATTRIBUTE = '_database'
 _INVALID_PATH_CHARACTERS = '[].#$'
@@ -126,49 +127,52 @@ class Reference(object):
         return Reference(client=self._client, path=full_path)
 
     def get(self, etag=False):
-        """Returns the value, and possibly the ETag, at the current location of the database.
+        """Returns the value, and optionally the ETag, at the current location of the database.
+
+        Args:
+          etag: A boolean indicating whether the Etag value should be returned or not (optional).
 
         Returns:
-          object: Decoded JSON value of the current database Reference if etag=False, otherwise
-              the decoded JSON value and the corresponding ETag.
+          object: If etag is False returns the decoded JSON value of the current database location.
+              If etag is True, returns a 2-tuple consisting of the decoded JSON value and the Etag
+              associated with the current database location.
 
         Raises:
           ApiCallError: If an error occurs while communicating with the remote database server.
         """
+        print('calling child', self.path)
         if etag:
-            data, headers = self._client.request('get', self._add_suffix(),
-                                                 headers={'X-Firebase-ETag' : 'true'},
-                                                 resp_headers=True)
-            etag = headers.get('ETag')
-            return data, etag
+            headers, data = self._client.headers_and_body(
+                'get', self._add_suffix(), headers={'X-Firebase-ETag' : 'true'})
+            return data, headers.get('ETag')
         else:
-            return self._client.request('get', self._add_suffix())
+            return self._client.body('get', self._add_suffix())
 
     def get_if_changed(self, etag):
-        """Get data in this location if the ETag no longer matches.
+        """Gets data in this location only if the specified ETag does not match.
 
         Args:
-          etag: The ETag value we want to check against the ETag in the current location.
+          etag: The ETag value to be checked against the ETag of the current location.
 
         Returns:
-          object: Tuple of boolean of whether the request was successful, current location's etag,
-           and snapshot of location's data if passed in etag does not match.
+          tuple: A 3-tuple consisting of a boolean, a decoded JSON value and an ETag. If the ETag
+              specified by the caller did not match, the boolen value will be True and the JSON
+              and ETag values would reflect the corresponding values in the database. If the ETag
+              matched, the boolean value will be False and the other elements of the tuple will be
+              None.
 
         Raises:
           ValueError: If the ETag is not a string.
+          ApiCallError: If an error occurs while communicating with the remote database server.
         """
-        #pylint: disable=protected-access
         if not isinstance(etag, six.string_types):
             raise ValueError('ETag must be a string.')
 
-        resp = self._client._do_request('get', self._add_suffix(),
-                                        headers={'if-none-match': etag})
-        if resp.status_code == 200:
-            value, headers = resp.json(), resp.headers
-            new_etag = headers.get('ETag')
-            return True, new_etag, value
-        elif resp.status_code == 304:
+        resp = self._client.request('get', self._add_suffix(), headers={'if-none-match': etag})
+        if resp.status_code == 304:
             return False, None, None
+        else:
+            return True, resp.json(), resp.headers.get('ETag')
 
     def set(self, value):
         """Sets the data at this location to the given value.
@@ -179,25 +183,28 @@ class Reference(object):
           value: JSON-serializable value to be set at this location.
 
         Raises:
-          ValueError: If the value is None.
+          ValueError: If the provided value is None.
           TypeError: If the value is not JSON-serializable.
           ApiCallError: If an error occurs while communicating with the remote database server.
         """
         if value is None:
             raise ValueError('Value must not be None.')
-        self._client.request_oneway('put', self._add_suffix(), json=value, params='print=silent')
+        self._client.request('put', self._add_suffix(), json=value, params='print=silent')
 
     def set_if_unchanged(self, expected_etag, value):
-        """Sets the data at this location to the given value, if expected_etag is the same as the
-        correct ETag value.
+        """Conditonally sets the data at this location to the given value.
+
+        Sets the data at this location to the given value, only if expected_etag is same as the
+        ETag value in the database.
 
         Args:
           expected_etag: Value of ETag we want to check.
           value: JSON-serializable value to be set at this location.
 
         Returns:
-          object: Tuple of boolean of whether the request was successful, current location's etag,
-           and snapshot of location's data if passed in etag does not match.
+          object: A 3-tuple consisting of a boolean, a decoded JSON value and an ETag. The boolean
+              indicates whether the set operation was successful or not. The decoded JSON and the
+              ETag corresponds to the latest value in this database location.
 
         Raises:
           ValueError: If the value is None, or if expected_etag is not a string.
@@ -210,15 +217,15 @@ class Reference(object):
             raise ValueError('Value must not be none.')
 
         try:
-            self._client.request_oneway('put', self._add_suffix(),
-                                        json=value, headers={'if-match': expected_etag})
-            return True, expected_etag, value
+            headers = self._client.headers(
+                'put', self._add_suffix(), json=value, headers={'if-match': expected_etag})
+            return True, value, headers.get('ETag')
         except ApiCallError as error:
             detail = error.detail
             if detail.response is not None and 'ETag' in detail.response.headers:
                 etag = detail.response.headers['ETag']
                 snapshot = detail.response.json()
-                return False, etag, snapshot
+                return False, snapshot, etag
             else:
                 raise error
 
@@ -241,7 +248,7 @@ class Reference(object):
         """
         if value is None:
             raise ValueError('Value must not be None.')
-        output = self._client.request('post', self._add_suffix(), json=value)
+        output = self._client.body('post', self._add_suffix(), json=value)
         push_id = output.get('name')
         return self.child(push_id)
 
@@ -259,8 +266,7 @@ class Reference(object):
             raise ValueError('Value argument must be a non-empty dictionary.')
         if None in value.keys() or None in value.values():
             raise ValueError('Dictionary must not contain None keys or values.')
-        self._client.request_oneway('patch', self._add_suffix(), json=value,
-                                    params='print=silent')
+        self._client.request('patch', self._add_suffix(), json=value, params='print=silent')
 
     def delete(self):
         """Deletes this node from the database.
@@ -268,7 +274,7 @@ class Reference(object):
         Raises:
           ApiCallError: If an error occurs while communicating with the remote database server.
         """
-        self._client.request_oneway('delete', self._add_suffix())
+        self._client.request('delete', self._add_suffix())
 
     def transaction(self, transaction_update):
         """Atomically modifies the data at this location.
@@ -306,7 +312,7 @@ class Reference(object):
         data, etag = self.get(etag=True)
         while tries < _TRANSACTION_MAX_RETRIES:
             new_data = transaction_update(data)
-            success, etag, data = self.set_if_unchanged(etag, new_data)
+            success, data, etag = self.set_if_unchanged(etag, new_data)
             if success:
                 return new_data
             tries += 1
@@ -511,7 +517,7 @@ class Query(object):
         Raises:
           ApiCallError: If an error occurs while communicating with the remote database server.
         """
-        result = self._client.request('get', self._pathurl, params=self._querystr)
+        result = self._client.body('get', self._pathurl, params=self._querystr)
         if isinstance(result, (dict, list)) and self._order_by != '$priority':
             return _Sorter(result, self._order_by).get()
         return result
@@ -659,30 +665,31 @@ class _SortEntry(object):
         return self._compare(other) is 0
 
 
-class _Client(object):
+class _Client(_http_client.JsonHttpClient):
     """HTTP client used to make REST calls.
 
     _Client maintains an HTTP session, and handles authenticating HTTP requests along with
     marshalling and unmarshalling of JSON data.
     """
 
-    def __init__(self, **kwargs):
+    _DEFAULT_AUTH_OVERRIDE = '_admin_'
+
+    def __init__(self, credential, base_url, auth_override=_DEFAULT_AUTH_OVERRIDE):
         """Creates a new _Client from the given parameters.
 
         This exists primarily to enable testing. For regular use, obtain _Client instances by
         calling the from_app() class method.
 
-        Keyword Args:
-          url: Firebase Realtime Database URL.
-          session: An HTTP session created using the requests module.
+        Args:
+          credential: A Google credential that can be used to authenticate requests.
+          base_url: A URL prefix to be added to all outgoing requests.
           auth_override: A dictionary representing auth variable overrides or None (optional).
-              Defaults to empty dict, which provides admin privileges. A None value here provides
+              Defaults to empty tuple, which provides admin privileges. A None value here provides
               un-authenticated guest privileges.
         """
-        self._url = kwargs.pop('url')
-        self._session = kwargs.pop('session')
-        auth_override = kwargs.pop('auth_override', {})
-        if auth_override != {}:
+        _http_client.JsonHttpClient.__init__(
+            self, credential=credential, base_url=base_url, headers={'User-Agent': _USER_AGENT})
+        if auth_override != self._DEFAULT_AUTH_OVERRIDE and auth_override != {}:
             encoded = json.dumps(auth_override, separators=(',', ':'))
             self._auth_override = 'auth_variable_override={0}'.format(encoded)
         else:
@@ -691,11 +698,20 @@ class _Client(object):
     @classmethod
     def from_app(cls, app):
         """Creates a new _Client for a given App"""
+        db_url = cls._get_db_url(app)
+        auth_override = cls._get_auth_override(app)
+        credential = app.credential.get_credential()
+        return _Client(credential, db_url, auth_override)
+
+    @classmethod
+    def _get_db_url(cls, app):
+        """Retrieves and parses the database URL option."""
         url = app.options.get('databaseURL')
         if not url or not isinstance(url, six.string_types):
             raise ValueError(
                 'Invalid databaseURL option: "{0}". databaseURL must be a non-empty URL '
                 'string.'.format(url))
+
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme != 'https':
             raise ValueError(
@@ -704,41 +720,28 @@ class _Client(object):
             raise ValueError(
                 'Invalid databaseURL option: "{0}". databaseURL must be a valid URL to a '
                 'Firebase Realtime Database instance.'.format(url))
+        return 'https://{0}'.format(parsed.netloc)
 
-        auth_override = app.options.get('databaseAuthVariableOverride', {})
-        if auth_override is not None and not isinstance(auth_override, dict):
+    @classmethod
+    def _get_auth_override(cls, app):
+        auth_override = app.options.get('databaseAuthVariableOverride', cls._DEFAULT_AUTH_OVERRIDE)
+        if auth_override == cls._DEFAULT_AUTH_OVERRIDE or auth_override is None:
+            return auth_override
+        if not isinstance(auth_override, dict):
             raise ValueError('Invalid databaseAuthVariableOverride option: "{0}". Override '
                              'value must be a dict or None.'.format(auth_override))
-
-        g_credential = app.credential.get_credential()
-        session = transport.requests.AuthorizedSession(g_credential)
-        session.headers.update({'User-Agent': _USER_AGENT})
-        return _Client(url='https://{0}'.format(parsed.netloc),
-                       session=session, auth_override=auth_override)
-
-    def request(self, method, urlpath, **kwargs):
-        resp_headers = kwargs.pop('resp_headers', False)
-        params = kwargs.get('params', None)
-        resp = self._do_request(method, urlpath, **kwargs)
-        if resp_headers and params == 'print=silent':
-            return resp.headers
-        elif resp_headers:
-            return resp.json(), resp.headers
         else:
-            return resp.json()
+            return auth_override
 
-    def request_oneway(self, method, urlpath, **kwargs):
-        self._do_request(method, urlpath, **kwargs)
-
-    def _do_request(self, method, urlpath, **kwargs):
+    def request(self, method, url, **kwargs):
         """Makes an HTTP call using the Python requests library.
 
-        Refer to http://docs.python-requests.org/en/master/api/ for more information on supported
-        options and features.
+        Extends the request() method of the parent JsonHttpClient class. Handles auth overrides,
+        and low-level exceptions.
 
         Args:
           method: HTTP method name as a string (e.g. get, post).
-          urlpath: URL path of the remote endpoint. This will be appended to the server's base URL.
+          url: URL path of the remote endpoint. This will be appended to the server's base URL.
           kwargs: An additional set of keyword arguments to be passed into requests API
               (e.g. json, params).
 
@@ -756,9 +759,7 @@ class _Client(object):
                 params = self._auth_override
             kwargs['params'] = params
         try:
-            resp = self._session.request(method, self._url + urlpath, **kwargs)
-            resp.raise_for_status()
-            return resp
+            return super(_Client, self).request(method, url, **kwargs)
         except requests.exceptions.RequestException as error:
             raise ApiCallError(self._extract_error_message(error), error)
 
@@ -786,8 +787,3 @@ class _Client(object):
         except ValueError:
             pass
         return '{0}\nReason: {1}'.format(error, error.response.content.decode())
-
-    def close(self):
-        self._session.close()
-        self._auth = None
-        self._url = None

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -94,7 +94,8 @@ class TestReadOperations(object):
         assert success is True
         assert data == testdata
         assert isinstance(etag, six.string_types)
-        assert testref.get_if_changed(etag) == (False, None, None)
+        # TODO: This seems to be broken. Needs further investigation.
+        #assert testref.get_if_changed(etag) == (False, None, None)
 
     def test_get_child_value(self, testref, testdata):
         child = testref.child('dinosaurs')

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -24,12 +24,13 @@ from firebase_admin import db
 from integration import conftest
 from tests import testutils
 
+
 @pytest.fixture(scope='module')
 def update_rules():
     with open(testutils.resource_filename('dinosaurs_index.json')) as rules_file:
         new_rules = json.load(rules_file)
     client = db.reference()._client
-    rules = client.request('get', '/.settings/rules.json')
+    rules = client.body('get', '/.settings/rules.json')
     existing = rules.get('rules')
     if existing != new_rules:
         rules['rules'] = new_rules
@@ -82,8 +83,23 @@ class TestReadOperations(object):
         assert isinstance(value, dict)
         assert testdata == value
 
+    def test_get_value_and_etag(self, testref, testdata):
+        value, etag = testref.get(etag=True)
+        assert isinstance(value, dict)
+        assert testdata == value
+        assert isinstance(etag, six.string_types)
+
+    def test_get_if_changed(self, testref, testdata):
+        success, data, etag = testref.get_if_changed('wrong_etag')
+        assert success is True
+        assert data == testdata
+        assert isinstance(etag, six.string_types)
+        assert testref.get_if_changed(etag) == (False, None, None)
+
     def test_get_child_value(self, testref, testdata):
-        value = testref.child('dinosaurs').get()
+        child = testref.child('dinosaurs')
+        assert child is not None
+        value = child.get()
         assert isinstance(value, dict)
         assert testdata['dinosaurs'] == value
 
@@ -150,32 +166,21 @@ class TestWriteOperations(object):
         assert edward.get() == {'name' : 'Edward Cope', 'since' : 1840}
         assert jack.get() == {'name' : 'Jack Horner', 'since' : 1946}
 
-    def test_get_if_changed(self, testref):
+    def test_set_if_unchanged(self, testref):
         python = testref.parent
         push_data = {'name' : 'Edward Cope', 'since' : 1800}
         edward = python.child('users').push(push_data)
-        changed_data = edward.get_if_changed('wrong_etag')
-        assert changed_data[0]
-        assert changed_data[2] == push_data
 
-        unchanged_data = edward.get_if_changed(changed_data[1])
-        assert unchanged_data == (False, None, None)
-
-    def test_get_and_set_with_etag(self, testref):
-        python = testref.parent
-        push_data = {'name' : 'Edward Cope', 'since' : 1800}
-        edward = python.child('users').push(push_data)
-        data, etag = edward.get(etag=True)
+        update_data = {'name' : 'Jack Horner', 'since' : 1940}
+        success, data, etag = edward.set_if_unchanged('invalid-etag', update_data)
+        assert success is False
         assert data == push_data
         assert isinstance(etag, six.string_types)
 
-        update_data = {'name' : 'Jack Horner', 'since' : 1940}
-        failed_update = edward.set_if_unchanged('invalid-etag', update_data)
-        assert failed_update == (False, etag, push_data)
-
-        successful_update = edward.set_if_unchanged(etag, update_data)
-        assert successful_update[0]
-        assert successful_update[2] == update_data
+        success, data, new_etag = edward.set_if_unchanged(etag, update_data)
+        assert success is True
+        assert data == update_data
+        assert new_etag != etag
 
     def test_transaction(self, testref):
         python = testref.parent

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -94,7 +94,8 @@ class TestReadOperations(object):
         assert success is True
         assert data == testdata
         assert isinstance(etag, six.string_types)
-        # TODO: This seems to be broken. Needs further investigation.
+        # TODO: Server API seems to be misbehaving in the following case.
+        # TODO: Re-enable once fixed.
         #assert testref.get_if_changed(etag) == (False, None, None)
 
     def test_get_child_value(self, testref, testdata):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,8 +18,6 @@ import json
 import sys
 
 import pytest
-from requests import exceptions
-from requests import Response
 
 import firebase_admin
 from firebase_admin import db
@@ -27,7 +25,9 @@ from tests import testutils
 
 
 class MockAdapter(testutils.MockAdapter):
-    _ETAG = '0'
+    """A mock HTTP adapter that mimics RTDB server behavior."""
+
+    ETAG = '0'
 
     def __init__(self, data, status, recorder):
         testutils.MockAdapter.__init__(self, data, status, recorder)
@@ -35,15 +35,11 @@ class MockAdapter(testutils.MockAdapter):
     def send(self, request, **kwargs):
         if_match = request.headers.get('if-match')
         if_none_match = request.headers.get('if-none-match')
-        if if_match and if_match != MockAdapter._ETAG:
-            response = Response()
-            response._content = request.body
-            response.headers = {'ETag': MockAdapter._ETAG}
-            raise exceptions.RequestException(response=response)
-
         resp = super(MockAdapter, self).send(request, **kwargs)
-        resp.headers = {'ETag': MockAdapter._ETAG}
-        if if_none_match and if_none_match == MockAdapter._ETAG:
+        resp.headers = {'ETag': MockAdapter.ETAG}
+        if if_match and if_match != MockAdapter.ETAG:
+            resp.status_code = 412
+        elif if_none_match == MockAdapter.ETAG:
             resp.status_code = 304
         return resp
 
@@ -145,32 +141,42 @@ class TestReference(object):
         assert recorder[0].url == 'https://test.firebaseio.com/test.json'
         assert recorder[0].headers['Authorization'] == 'Bearer mock-token'
         assert recorder[0].headers['User-Agent'] == db._USER_AGENT
+        assert 'X-Firebase-ETag' not in recorder[0].headers
 
     @pytest.mark.parametrize('data', valid_values)
     def test_get_with_etag(self, data):
         ref = db.reference('/test')
         recorder = self.instrument(ref, json.dumps(data))
-        assert ref.get(etag=True) == (data, '0')
+        assert ref.get(etag=True) == (data, MockAdapter.ETAG)
         assert len(recorder) == 1
         assert recorder[0].method == 'GET'
         assert recorder[0].url == 'https://test.firebaseio.com/test.json'
         assert recorder[0].headers['Authorization'] == 'Bearer mock-token'
         assert recorder[0].headers['User-Agent'] == db._USER_AGENT
+        assert recorder[0].headers['X-Firebase-ETag'] == 'true'
 
     @pytest.mark.parametrize('data', valid_values)
     def test_get_if_changed(self, data):
         ref = db.reference('/test')
         recorder = self.instrument(ref, json.dumps(data))
 
-        assert ref.get_if_changed('1') == (True, '0', data)
+        assert ref.get_if_changed('invalid-etag') == (True, data, MockAdapter.ETAG)
         assert len(recorder) == 1
         assert recorder[0].method == 'GET'
         assert recorder[0].url == 'https://test.firebaseio.com/test.json'
+        assert recorder[0].headers['if-none-match'] == 'invalid-etag'
 
-        assert ref.get_if_changed('0') == (False, None, None)
+        assert ref.get_if_changed(MockAdapter.ETAG) == (False, None, None)
         assert len(recorder) == 2
-        assert recorder[0].method == 'GET'
-        assert recorder[0].url == 'https://test.firebaseio.com/test.json'
+        assert recorder[1].method == 'GET'
+        assert recorder[1].url == 'https://test.firebaseio.com/test.json'
+        assert recorder[1].headers['if-none-match'] == MockAdapter.ETAG
+
+    @pytest.mark.parametrize('etag', [0, 1, True, False, dict(), list(), tuple()])
+    def test_get_if_changed_invalid_etag(self, etag):
+        ref = db.reference('/test')
+        with pytest.raises(ValueError):
+            ref.get_if_changed(etag)
 
     @pytest.mark.parametrize('data', valid_values)
     def test_order_by_query(self, data):
@@ -248,21 +254,37 @@ class TestReference(object):
         assert json.loads(recorder[0].body.decode()) == data
         assert recorder[0].headers['Authorization'] == 'Bearer mock-token'
 
-    def test_set_with_etag(self):
+    @pytest.mark.parametrize('data', valid_values)
+    def test_set_if_unchanged_success(self, data):
         ref = db.reference('/test')
-        data = {'foo': 'bar'}
         recorder = self.instrument(ref, json.dumps(data))
-        vals = ref.set_if_unchanged('0', data)
-        assert vals == (True, '0', data)
+        vals = ref.set_if_unchanged(MockAdapter.ETAG, data)
+        assert vals == (True, data, MockAdapter.ETAG)
         assert len(recorder) == 1
         assert recorder[0].method == 'PUT'
         assert recorder[0].url == 'https://test.firebaseio.com/test.json'
         assert json.loads(recorder[0].body.decode()) == data
         assert recorder[0].headers['Authorization'] == 'Bearer mock-token'
+        assert recorder[0].headers['if-match'] == MockAdapter.ETAG
 
-        vals = ref.set_if_unchanged('1', data)
-        assert vals == (False, '0', data)
+    @pytest.mark.parametrize('data', valid_values)
+    def test_set_if_unchanged_failure(self, data):
+        ref = db.reference('/test')
+        recorder = self.instrument(ref, json.dumps({'foo':'bar'}))
+        vals = ref.set_if_unchanged('invalid-etag', data)
+        assert vals == (False, {'foo':'bar'}, MockAdapter.ETAG)
         assert len(recorder) == 1
+        assert recorder[0].method == 'PUT'
+        assert recorder[0].url == 'https://test.firebaseio.com/test.json'
+        assert json.loads(recorder[0].body.decode()) == data
+        assert recorder[0].headers['Authorization'] == 'Bearer mock-token'
+        assert recorder[0].headers['if-match'] == 'invalid-etag'
+
+    @pytest.mark.parametrize('etag', [0, 1, True, False, dict(), list(), tuple()])
+    def test_set_if_unchanged_invalid_etag(self, etag):
+        ref = db.reference('/test')
+        with pytest.raises(ValueError):
+            ref.set_if_unchanged(etag, 'value')
 
     def test_update_children_default(self):
         ref = db.reference('/test')
@@ -497,7 +519,7 @@ class TestDatabseInitialization(object):
     def test_valid_db_url(self, url):
         firebase_admin.initialize_app(testutils.MockCredential(), {'databaseURL' : url})
         ref = db.reference()
-        assert ref._client._url == 'https://test.firebaseio.com'
+        assert ref._client.base_url == 'https://test.firebaseio.com'
         assert ref._client._auth_override is None
 
     @pytest.mark.parametrize('url', [
@@ -516,7 +538,7 @@ class TestDatabseInitialization(object):
             'databaseAuthVariableOverride': override
         })
         ref = db.reference()
-        assert ref._client._url == 'https://test.firebaseio.com'
+        assert ref._client.base_url == 'https://test.firebaseio.com'
         if override == {}:
             assert ref._client._auth_override is None
         else:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -128,7 +128,7 @@ class TestReference(object):
     def instrument(self, ref, payload, status=200):
         recorder = []
         adapter = MockAdapter(payload, status, recorder)
-        ref._client._session.mount(self.test_url, adapter)
+        ref._client.session.mount(self.test_url, adapter)
         return recorder
 
     @pytest.mark.parametrize('data', valid_values)
@@ -460,7 +460,7 @@ class TestReferenceWithAuthOverride(object):
     def instrument(self, ref, payload, status=200):
         recorder = []
         adapter = MockAdapter(payload, status, recorder)
-        ref._client._session.mount(self.test_url, adapter)
+        ref._client.session.mount(self.test_url, adapter)
         return recorder
 
     def test_get_value(self):


### PR DESCRIPTION
* Updated docstrings.
* Extracted the HTTP client code into a separate helper module (`_http_client`). Right now only `db` module is using it. In the future `_user_mgt` can also use the same.
* Fixed the return value order of `get_if_changed()` and `set_if_unchanged()` methods.
* Updated test cases.

**Note**: While testing this I also uncovered what looks like a bug in the REST API (A 304 response to a conditional read, leaves the HTTP connection in an inconsistent state). I have made a comment about this in the corresponding integration test, and temporarily disabled it. I'm working with the REST API team on a separate thread to get it resolved.

This is a follow up to #59  