### PR TITLE
Temporarily removing the get_if_changed() method from db public API

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -147,7 +147,7 @@ class Reference(object):
         else:
             return self._client.body('get', self._add_suffix())
 
-    def get_if_changed(self, etag):
+    def _get_if_changed(self, etag):
         """Gets data in this location only if the specified ETag does not match.
 
         Args:

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -134,8 +134,8 @@ class Reference(object):
 
         Returns:
           object: If etag is False returns the decoded JSON value of the current database location.
-              If etag is True, returns a 2-tuple consisting of the decoded JSON value and the Etag
-              associated with the current database location.
+          If etag is True, returns a 2-tuple consisting of the decoded JSON value and the Etag
+          associated with the current database location.
 
         Raises:
           ApiCallError: If an error occurs while communicating with the remote database server.
@@ -193,7 +193,7 @@ class Reference(object):
     def set_if_unchanged(self, expected_etag, value):
         """Conditonally sets the data at this location to the given value.
 
-        Sets the data at this location to the given value, only if expected_etag is same as the
+        Sets the data at this location to the given value only if ``expected_etag`` is same as the
         ETag value in the database.
 
         Args:
@@ -201,9 +201,9 @@ class Reference(object):
           value: JSON-serializable value to be set at this location.
 
         Returns:
-          object: A 3-tuple consisting of a boolean, a decoded JSON value and an ETag. The boolean
-              indicates whether the set operation was successful or not. The decoded JSON and the
-              ETag corresponds to the latest value in this database location.
+          tuple: A 3-tuple consisting of a boolean, a decoded JSON value and an ETag. The boolean
+          indicates whether the set operation was successful or not. The decoded JSON and the
+          ETag corresponds to the latest value in this database location.
 
         Raises:
           ValueError: If the value is None, or if expected_etag is not a string.
@@ -291,18 +291,18 @@ class Reference(object):
         returning a value.
 
         Args:
-            transaction_update: A function which will be passed the current data stored at this
-                location. The function should return the new value it would like written. If
-                an exception is raised, the transaction will be aborted, and the data at this
-                location will not be modified. The exceptions raised by this function are
-                propagated to the caller of the transaction method.
+          transaction_update: A function which will be passed the current data stored at this
+              location. The function should return the new value it would like written. If
+              an exception is raised, the transaction will be aborted, and the data at this
+              location will not be modified. The exceptions raised by this function are
+              propagated to the caller of the transaction method.
 
         Returns:
-            object: New value of the current database Reference (only if the transaction commits).
+          object: New value of the current database Reference (only if the transaction commits).
 
         Raises:
-            TransactionError: If the transaction aborts after exhausting all retry attempts.
-            ValueError: If transaction_update is not a function.
+          TransactionError: If the transaction aborts after exhausting all retry attempts.
+          ValueError: If transaction_update is not a function.
         """
         if not callable(transaction_update):
             raise ValueError('transaction_update must be a function.')

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -90,7 +90,7 @@ class TestReadOperations(object):
         assert isinstance(etag, six.string_types)
 
     def test_get_if_changed(self, testref, testdata):
-        success, data, etag = testref.get_if_changed('wrong_etag')
+        success, data, etag = testref._get_if_changed('wrong_etag')
         assert success is True
         assert data == testdata
         assert isinstance(etag, six.string_types)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -160,13 +160,13 @@ class TestReference(object):
         ref = db.reference('/test')
         recorder = self.instrument(ref, json.dumps(data))
 
-        assert ref.get_if_changed('invalid-etag') == (True, data, MockAdapter.ETAG)
+        assert ref._get_if_changed('invalid-etag') == (True, data, MockAdapter.ETAG)
         assert len(recorder) == 1
         assert recorder[0].method == 'GET'
         assert recorder[0].url == 'https://test.firebaseio.com/test.json'
         assert recorder[0].headers['if-none-match'] == 'invalid-etag'
 
-        assert ref.get_if_changed(MockAdapter.ETAG) == (False, None, None)
+        assert ref._get_if_changed(MockAdapter.ETAG) == (False, None, None)
         assert len(recorder) == 2
         assert recorder[1].method == 'GET'
         assert recorder[1].url == 'https://test.firebaseio.com/test.json'
@@ -176,7 +176,7 @@ class TestReference(object):
     def test_get_if_changed_invalid_etag(self, etag):
         ref = db.reference('/test')
         with pytest.raises(ValueError):
-            ref.get_if_changed(etag)
+            ref._get_if_changed(etag)
 
     @pytest.mark.parametrize('data', valid_values)
     def test_order_by_query(self, data):


### PR DESCRIPTION
This method is affected by a bug in the REST API, and the RTDB team is currently working on a fix. Will add the method back, once the fix is live.

Related to #66 and #59 