### PR TITLE
Implementing a httpTimeout option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .cache/
 .tox/
 *.egg-info/
+build/
+dist/
 *~
 scripts/cert.json
 scripts/apikey.txt

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -45,7 +45,9 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
     Args:
       credential: A credential object used to initialize the SDK (optional). If none is provided,
           Google Application Default Credentials are used.
-      options: A dictionary of configuration options (optional).
+      options: A dictionary of configuration options (optional). Supported options include
+          ``databaseURL``, ``storageBucket`` and ``httpTimeout``. If ``httpTimeout`` is not set,
+          HTTP connections initiated by client modules such as ``db`` will not timeout.
       name: Name of the app (optional).
 
     Returns:

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -686,7 +686,8 @@ class _Client(_http_client.JsonHttpClient):
           auth_override: A dictionary representing auth variable overrides or None (optional).
               Default value provides admin privileges. A None value here provides un-authenticated
               guest privileges.
-          timeout: HTTP request timeout in seconds (optional).
+          timeout: HTTP request timeout in seconds (optional). If not set connections will never
+              timeout, which is the default behavior of the underlying requests library.
         """
         _http_client.JsonHttpClient.__init__(
             self, credential=credential, base_url=base_url, headers={'User-Agent': _USER_AGENT})

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -673,7 +673,7 @@ class _Client(_http_client.JsonHttpClient):
 
     _DEFAULT_AUTH_OVERRIDE = '_admin_'
 
-    def __init__(self, credential, base_url, auth_override=_DEFAULT_AUTH_OVERRIDE):
+    def __init__(self, credential, base_url, auth_override=_DEFAULT_AUTH_OVERRIDE, timeout=None):
         """Creates a new _Client from the given parameters.
 
         This exists primarily to enable testing. For regular use, obtain _Client instances by
@@ -686,6 +686,7 @@ class _Client(_http_client.JsonHttpClient):
           auth_override: A dictionary representing auth variable overrides or None (optional).
               Default value provides admin privileges. A None value here provides un-authenticated
               guest privileges.
+          timeout: HTTP request timeout in seconds (optional).
         """
         _http_client.JsonHttpClient.__init__(
             self, credential=credential, base_url=base_url, headers={'User-Agent': _USER_AGENT})
@@ -694,14 +695,16 @@ class _Client(_http_client.JsonHttpClient):
             self._auth_override = 'auth_variable_override={0}'.format(encoded)
         else:
             self._auth_override = None
+        self._timeout = timeout
 
     @classmethod
     def from_app(cls, app):
         """Creates a new _Client for a given App"""
+        credential = app.credential.get_credential()
         db_url = cls._get_db_url(app)
         auth_override = cls._get_auth_override(app)
-        credential = app.credential.get_credential()
-        return _Client(credential, db_url, auth_override)
+        timeout = app.options.get('httpTimeout')
+        return _Client(credential, db_url, auth_override, timeout)
 
     @classmethod
     def _get_db_url(cls, app):
@@ -737,6 +740,10 @@ class _Client(_http_client.JsonHttpClient):
     def auth_override(self):
         return self._auth_override
 
+    @property
+    def timeout(self):
+        return self._timeout
+
     def request(self, method, url, **kwargs):
         """Makes an HTTP call using the Python requests library.
 
@@ -762,6 +769,8 @@ class _Client(_http_client.JsonHttpClient):
             else:
                 params = self._auth_override
             kwargs['params'] = params
+        if self._timeout:
+            kwargs['timeout'] = self._timeout
         try:
             return super(_Client, self).request(method, url, **kwargs)
         except requests.exceptions.RequestException as error:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest >= 3.0.6
 pytest-cov >= 2.4.0
 tox >= 2.6.0
 
-google-auth >= 1.0.0
+google-auth >= 1.1.0
 google-cloud-storage >= 1.2.0
 requests >= 2.13.0
 six >= 1.6.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if sys.version_info < (2, 7):
 long_description = ('The Firebase Admin Python SDK enables server-side (backend) Python developers '
                     'to integrate Firebase into their services and applications.')
 install_requires = [
-    'google-auth>=1.0.0',
+    'google-auth>=1.1.0',
     'google-cloud-storage>=1.2.0',
     'requests>=2.13.0',
     'six>=1.6.1'

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -19,6 +19,7 @@ import os
 
 import google.auth
 from google.auth import crypt
+from google.auth import exceptions
 from google.oauth2 import credentials as gcredentials
 from google.oauth2 import service_account
 from firebase_admin import credentials
@@ -114,7 +115,7 @@ class TestApplicationDefault(object):
                              indirect=True)
     def test_nonexisting_path(self, app_default):
         del app_default
-        with pytest.raises(IOError):
+        with pytest.raises(exceptions.DefaultCredentialsError):
             credentials.ApplicationDefault()
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -100,7 +100,7 @@ class MockAdapter(adapters.HTTPAdapter):
         self._recorder = recorder
 
     def send(self, request, **kwargs):
-        del kwargs
+        request._extra_kwargs = kwargs
         self._recorder.append(request)
         resp = models.Response()
         resp.url = request.url


### PR DESCRIPTION
Related to #71.

A new 'httpTimeout' option is introduced which will be used to control the timeout of all outbound requests made by the `db` module. In the future, we can use the same in other modules too.

```
firebase_admin.initialize_app(credential, {
    'databaseURL' : test_url,
    'httpTimeout': 60 # timeout in seconds
})
```