### PR TITLE
Fixing a failing test

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -29,7 +29,7 @@ from tests import testutils
 
 
 def check_scopes(g_credential):
-    assert isinstance(g_credential, google.auth.credentials.Scoped)
+    assert isinstance(g_credential, google.auth.credentials.ReadOnlyScoped)
     assert sorted(credentials._scopes) == sorted(g_credential.scopes)
 
 


### PR DESCRIPTION
 (failure caused by a change made in google-auth v1.1.1 that went out today)

Low-level details:
* `Scoped` extends `ReadOnlyScoped`
* Starting from v1.1.1 some oauth2 credential types extend from `ReadOnlyScoped` instead of `Scoped`.