### PR TITLE
Fixing start_at, end_at, equal_to queries to accept False values

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -442,7 +442,7 @@ class Query(object):
           Query: The updated Query instance.
 
         Raises:
-          ValueError: If the value is empty or None.
+          ValueError: If the value is None.
         """
         if start is None:
             raise ValueError('Start value must not be None.')
@@ -462,7 +462,7 @@ class Query(object):
           Query: The updated Query instance.
 
         Raises:
-          ValueError: If the value is empty or None.
+          ValueError: If the value is None.
         """
         if end is None:
             raise ValueError('End value must not be None.')
@@ -481,7 +481,7 @@ class Query(object):
           Query: The updated Query instance.
 
         Raises:
-          ValueError: If the value is empty or None.
+          ValueError: If the value is None.
         """
         if value is None:
             raise ValueError('Equal to value must not be None.')

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -444,8 +444,8 @@ class Query(object):
         Raises:
           ValueError: If the value is empty or None.
         """
-        if not start:
-            raise ValueError('Start value must not be empty or None.')
+        if start is None:
+            raise ValueError('Start value must not be None.')
         self._params['startAt'] = json.dumps(start)
         return self
 
@@ -464,8 +464,8 @@ class Query(object):
         Raises:
           ValueError: If the value is empty or None.
         """
-        if not end:
-            raise ValueError('End value must not be empty or None.')
+        if end is None:
+            raise ValueError('End value must not be None.')
         self._params['endAt'] = json.dumps(end)
         return self
 
@@ -483,8 +483,8 @@ class Query(object):
         Raises:
           ValueError: If the value is empty or None.
         """
-        if not value:
-            raise ValueError('Equal to value must not be empty or None.')
+        if value is None:
+            raise ValueError('Equal to value must not be None.')
         self._params['equalTo'] = json.dumps(value)
         return self
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -694,15 +694,30 @@ class TestQuery(object):
         with pytest.raises(ValueError):
             query.start_at(None)
 
+    @pytest.mark.parametrize('arg', ['', 'foo', True, False, 0, 1, dict()])
+    def test_valid_start_at(self, arg):
+        query = self.ref.order_by_child('foo').start_at(arg)
+        assert query._querystr == 'orderBy="foo"&startAt={0}'.format(json.dumps(arg))
+
     def test_end_at_none(self):
         query = self.ref.order_by_child('foo')
         with pytest.raises(ValueError):
             query.end_at(None)
 
+    @pytest.mark.parametrize('arg', ['', 'foo', True, False, 0, 1, dict()])
+    def test_valid_end_at(self, arg):
+        query = self.ref.order_by_child('foo').end_at(arg)
+        assert query._querystr == 'endAt={0}&orderBy="foo"'.format(json.dumps(arg))
+
     def test_equal_to_none(self):
         query = self.ref.order_by_child('foo')
         with pytest.raises(ValueError):
             query.equal_to(None)
+
+    @pytest.mark.parametrize('arg', ['', 'foo', True, False, 0, 1, dict()])
+    def test_valid_equal_to(self, arg):
+        query = self.ref.order_by_child('foo').equal_to(arg)
+        assert query._querystr == 'equalTo={0}&orderBy="foo"'.format(json.dumps(arg))
 
     def test_range_query(self, initquery):
         query, order_by = initquery


### PR DESCRIPTION
`start_at()`, `end_at()` and `equal_to()` method in the `Query` class currently does not accept `False` as a valid argument (along with a bunch of other false values such as empty string and empty dict). This PR relaxes the argument checks so these values are supported.

Resolves #88. Related to #89.