### PR TITLE
Dropping py33 from the list of validation environments

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -94,7 +94,7 @@ else
 fi
 
 echo "[INFO] Running unit tests"
-tox --workdir ..
+tox
 
 echo "[INFO] Running integration tests"
 pytest ../integration --cert cert.json --apikey apikey.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py33,py35,py36,pypy,cover
+envlist = py27,py35,py36,pypy,cover
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
This version of Python is no longer supported upstream, and it's becoming hard to find good installation candidates. Some of our dependencies (e.g. Firestore) are not officially supported on py33. We still test this environment in our CI environment, but we can safely remove it from the local release verification script.