### PR TITLE
Handling FCM canonical error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [changed] Improved error handling in FCM by mapping more server-side
+  errors to client-side error codes.
 
 # v2.9.0
 

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -716,11 +716,18 @@ class _MessagingService(object):
     INTERNAL_ERROR = 'internal-error'
     UNKNOWN_ERROR = 'unknown-error'
     FCM_ERROR_CODES = {
-        'APNS_AUTH_ERROR': 'authentication-error',
+        # FCM v1 canonical error codes
+        'NOT_FOUND': 'registration-token-not-registered',
+        'PERMISSION_DENIED': 'mismatched-credential',
+        'RESOURCE_EXHAUSTED': 'message-rate-exceeded',
+        'UNAUTHENTICATED': 'invalid-apns-credentials',
+
+        # FCM v1 new error codes
+        'APNS_AUTH_ERROR': 'invalid-apns-credentials',
         'INTERNAL': INTERNAL_ERROR,
         'INVALID_ARGUMENT': 'invalid-argument',
         'QUOTA_EXCEEDED': 'message-rate-exceeded',
-        'SENDER_ID_MISMATCH': 'authentication-error',
+        'SENDER_ID_MISMATCH': 'mismatched-credential',
         'UNAVAILABLE': 'server-unavailable',
         'UNREGISTERED': 'registration-token-not-registered',
     }

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -855,6 +855,26 @@ class TestSend(object):
         body = {'message': messaging._MessagingService.JSON_ENCODER.default(msg)}
         assert json.loads(recorder[0].body.decode()) == body
 
+    @pytest.mark.parametrize('status', HTTP_ERRORS)
+    def test_send_canonical_error_code(self, status):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        _, recorder = self._instrument_messaging_service(status=status, payload=payload)
+        msg = messaging.Message(topic='foo')
+        with pytest.raises(messaging.ApiCallError) as excinfo:
+            messaging.send(msg)
+        assert str(excinfo.value) == 'test error'
+        assert str(excinfo.value.code) == 'registration-token-not-registered'
+        assert len(recorder) == 1
+        assert recorder[0].method == 'POST'
+        assert recorder[0].url == self._get_url('explicit-project-id')
+        body = {'message': messaging._MessagingService.JSON_ENCODER.default(msg)}
+        assert json.loads(recorder[0].body.decode()) == body
+
 
 class TestTopicManagement(object):
 


### PR DESCRIPTION
The error codes defined in https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode are embedded in the details section of the error response. The top-level error code (`status` field in the response) may take additional values such as `NOT_FOUND` and `UNAUTHENTICATED` (the so called canonical error codes):

```
{
  "error":{
    "code":404,
    "message":"Requested entity was not found.",
    "status":"NOT_FOUND",
    "details: [
      {
         "@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError",
         "errorCode":"UNREGISTERED"
      }
    ]
  }
}
```

This PR updates the FCM implementation to handle these additional error codes and map them to correct client-side errors.