### PR TITLE
Moved package information to __about__.py to avoid dependency issues

### DIFF
--- a/firebase_admin/__about__.py
+++ b/firebase_admin/__about__.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""About information (version, etc) for Firebase Admin SDK."""
+
+__version__ = '2.9.0'
+__title__ = 'firebase_admin'
+__author__ = 'Firebase'
+__license__ = 'Apache License 2.0'
+__url__ = 'https://firebase.google.com/docs/admin/setup/'

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -21,11 +21,8 @@ import threading
 import six
 
 from firebase_admin import credentials
+from firebase_admin.__about__ import __version__
 
-
-# Declaring module version as per https://www.python.org/dev/peps/pep-0396/#specification
-# Update this accordingly for each release.
-__version__ = '2.9.0'
 
 _apps = {}
 _apps_lock = threading.RLock()

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -55,9 +55,9 @@ if ! parseVersion "$VERSION"; then
     exit 1
 fi
 
-CUR_VERSION=$(grep "^__version__ =" ../firebase_admin/__init__.py | awk '{print $3}' | sed "s/'//g")
+CUR_VERSION=$(grep "^__version__ =" ../firebase_admin/__about__.py | awk '{print $3}' | sed "s/'//g")
 if [ -z "$CUR_VERSION" ]; then
-    echo "[ERROR] Failed to find the current version. Check firebase_admin/__init__.py for version declaration."
+    echo "[ERROR] Failed to find the current version. Check firebase_admin/__about__.py for version declaration."
     exit 1
 fi
 if ! parseVersion "$CUR_VERSION"; then
@@ -119,12 +119,12 @@ fi
 ##################################
 
 HOST=$(uname)
-echo "[INFO] Updating __init__.py and CHANGELOG.md"
+echo "[INFO] Updating __about__.py and CHANGELOG.md"
 if [ $HOST == "Darwin" ]; then
-    sed -i "" -e "s/__version__ = '$CUR_VERSION'/__version__ = '$VERSION'/" "../firebase_admin/__init__.py"
+    sed -i "" -e "s/__version__ = '$CUR_VERSION'/__version__ = '$VERSION'/" "../firebase_admin/__about__.py"
     sed -i "" -e "1 s/# Unreleased//" "../CHANGELOG.md"
 else
-    sed -i -e "s/__version__ = '$CUR_VERSION'/__version__ = '$VERSION'/" "../firebase_admin/__init__.py"
+    sed -i -e "s/__version__ = '$CUR_VERSION'/__version__ = '$VERSION'/" "../firebase_admin/__about__.py"
     sed -i -e "1 s/# Unreleased//" "../CHANGELOG.md"
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,17 @@ import sys
 from setuptools import find_packages
 from setuptools import setup
 
-import firebase_admin
-
 
 if sys.version_info < (2, 7):
     print('firebase_admin requires python2 version >= 2.7 or python3.', file=sys.stderr)
     sys.exit(1)
+
+# Read in the package meta data per recommendations from:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+about_path = path.join(path.dirname(path.abspath(__file__)), 'firebase_admin', '__about__.py')
+about = {}
+with open(about_path) as fp:
+    exec(fp.read(), about)  # pylint: disable=exec-used
 
 
 long_description = ('The Firebase Admin Python SDK enables server-side (backend) Python developers '
@@ -43,16 +48,14 @@ extras_require = {
     ':python_version<"3.4"': ('enum34>=1.0.4',),
 }
 
-version = firebase_admin.__version__
-
 setup(
-    name='firebase_admin',
-    version=version,
+    name=about['__title__'],
+    version=about['__version__'],
     description='Firebase Admin Python SDK',
     long_description=long_description,
-    url='https://firebase.google.com/docs/admin/setup/',
-    author='Firebase',
-    license='Apache License 2.0',
+    url=about['__url__'],
+    author=about['__author__'],
+    license=about['__license__'],
     keywords='firebase cloud development',
     extras_require=extras_require,
     install_requires=install_requires,


### PR DESCRIPTION
This resolves #133 [warehouse](https://github.com/pypa/warehouse/blob/master/warehouse/__about__.py) style.

Happy to add more or remove more from `__about__.py`, just picked out what seemed like the obvious ones.