### PR TITLE
Implementing support for APNS mutable-content field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
--
+- [added] Added the `mutable_content` optional field to the `messaging.Aps`
+  type.
+- [added] Added support for specifying arbitrary custom key-value
+  fields in the `messaging.Aps` type.
 
 # v2.9.1
 

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -343,21 +343,21 @@ class Aps(object):
             notification (optional).
         category: String identifier representing the message type (optional).
         thread_id: An app-specific string identifier for grouping messages (optional).
-        content_mutable: A boolean indicating whether to support mutating notifications at
+        mutable_content: A boolean indicating whether to support mutating notifications at
             the client using app extensions (optional).
         custom_fields: A dict of custom key-value pairs to be included in the Aps dictionary
             (optional).
     """
 
     def __init__(self, alert=None, badge=None, sound=None, content_available=None, category=None,
-                 thread_id=None, content_mutable=None, custom_fields=None):
+                 thread_id=None, mutable_content=None, custom_fields=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound
         self.content_available = content_available
         self.category = category
         self.thread_id = thread_id
-        self.content_mutable = content_mutable
+        self.mutable_content = mutable_content
         self.custom_fields = custom_fields
 
 
@@ -630,8 +630,8 @@ class _MessageEncoder(json.JSONEncoder):
         }
         if aps.content_available is True:
             result['content-available'] = 1
-        if aps.content_mutable is True:
-            result['content-mutable'] = 1
+        if aps.mutable_content is True:
+            result['mutable-content'] = 1
         if aps.custom_fields is not None:
             if not isinstance(aps.custom_fields, dict):
                 raise ValueError('Aps.custom_fields must be a dict.')

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -345,12 +345,12 @@ class Aps(object):
         thread_id: An app-specific string identifier for grouping messages (optional).
         mutable_content: A boolean indicating whether to support mutating notifications at
             the client using app extensions (optional).
-        custom_fields: A dict of custom key-value pairs to be included in the Aps dictionary
+        custom_data: A dict of custom key-value pairs to be included in the Aps dictionary
             (optional).
     """
 
     def __init__(self, alert=None, badge=None, sound=None, content_available=None, category=None,
-                 thread_id=None, mutable_content=None, custom_fields=None):
+                 thread_id=None, mutable_content=None, custom_data=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound
@@ -358,7 +358,7 @@ class Aps(object):
         self.category = category
         self.thread_id = thread_id
         self.mutable_content = mutable_content
-        self.custom_fields = custom_fields
+        self.custom_data = custom_data
 
 
 class ApsAlert(object):
@@ -632,11 +632,11 @@ class _MessageEncoder(json.JSONEncoder):
             result['content-available'] = 1
         if aps.mutable_content is True:
             result['mutable-content'] = 1
-        if aps.custom_fields is not None:
-            if not isinstance(aps.custom_fields, dict):
-                raise ValueError('Aps.custom_fields must be a dict.')
-            for key, val in aps.custom_fields.items():
-                _Validators.check_string('Aps.custom_fields key', key)
+        if aps.custom_data is not None:
+            if not isinstance(aps.custom_data, dict):
+                raise ValueError('Aps.custom_data must be a dict.')
+            for key, val in aps.custom_data.items():
+                _Validators.check_string('Aps.custom_data key', key)
                 if key in result:
                     raise ValueError('Multiple specifications for {0} in Aps.'.format(key))
                 result[key] = val

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -343,16 +343,22 @@ class Aps(object):
             notification (optional).
         category: String identifier representing the message type (optional).
         thread_id: An app-specific string identifier for grouping messages (optional).
+        content_mutable: A boolean indicating whether to support mutating notifications at
+            the client using app extensions (optional).
+        custom_fields: A dict of custom key-value pairs to be included in the Aps dictionary
+            (optional).
     """
 
     def __init__(self, alert=None, badge=None, sound=None, content_available=None, category=None,
-                 thread_id=None):
+                 thread_id=None, content_mutable=None, custom_fields=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound
         self.content_available = content_available
         self.category = category
         self.thread_id = thread_id
+        self.content_mutable = content_mutable
+        self.custom_fields = custom_fields
 
 
 class ApsAlert(object):
@@ -624,6 +630,16 @@ class _MessageEncoder(json.JSONEncoder):
         }
         if aps.content_available is True:
             result['content-available'] = 1
+        if aps.content_mutable is True:
+            result['content-mutable'] = 1
+        if aps.custom_fields is not None:
+            if not isinstance(aps.custom_fields, dict):
+                raise ValueError('Aps.custom_fields must be a dict.')
+            for key, val in aps.custom_fields.items():
+                _Validators.check_string('Aps.custom_fields key', key)
+                if key in result:
+                    raise ValueError('Multiple specifications for {0} in Aps.'.format(key))
+                result[key] = val
         return cls.remove_null_values(result)
 
     @classmethod

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -537,11 +537,9 @@ class TestAPNSPayloadEncoder(object):
 
 class TestApsEncoder(object):
 
-    def _check_aps(self, aps):
-        with pytest.raises(ValueError) as excinfo:
-            check_encoding(messaging.Message(
-                topic='topic', apns=messaging.APNSConfig(payload=messaging.APNSPayload(aps=aps))))
-        return excinfo
+    def _encode_aps(self, aps):
+        return check_encoding(messaging.Message(
+            topic='topic', apns=messaging.APNSConfig(payload=messaging.APNSPayload(aps=aps))))
 
     @pytest.mark.parametrize('data', NON_OBJECT_ARGS)
     def test_invalid_aps(self, data):
@@ -555,35 +553,40 @@ class TestApsEncoder(object):
     @pytest.mark.parametrize('data', NON_STRING_ARGS)
     def test_invalid_alert(self, data):
         aps = messaging.Aps(alert=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.alert must be a string or an instance of ApsAlert class.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', [list(), tuple(), dict(), 'foo'])
     def test_invalid_badge(self, data):
         aps = messaging.Aps(badge=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.badge must be a number.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', NON_STRING_ARGS)
     def test_invalid_sound(self, data):
         aps = messaging.Aps(sound=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.sound must be a string.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', NON_STRING_ARGS)
     def test_invalid_category(self, data):
         aps = messaging.Aps(category=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.category must be a string.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', NON_STRING_ARGS)
     def test_invalid_thread_id(self, data):
         aps = messaging.Aps(thread_id=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.thread_id must be a string.'
         assert str(excinfo.value) == expected
 
@@ -592,20 +595,23 @@ class TestApsEncoder(object):
         if isinstance(data, dict):
             return
         aps = messaging.Aps(custom_data=data)
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.custom_data must be a dict.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', [True, False, 1, 0])
     def test_invalid_custom_field_name(self, data):
         aps = messaging.Aps(custom_data={data: 'foo'})
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Aps.custom_data key must be a string.'
         assert str(excinfo.value) == expected
 
     def test_multiple_field_specifications(self):
         aps = messaging.Aps(thread_id='foo', custom_data={'thread-id': 'foo'})
-        excinfo = self._check_aps(aps)
+        with pytest.raises(ValueError) as excinfo:
+            self._encode_aps(aps)
         expected = 'Multiple specifications for thread-id in Aps.'
         assert str(excinfo.value) == expected
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -619,7 +619,7 @@ class TestApsEncoder(object):
                         badge=42,
                         sound='s',
                         content_available=True,
-                        content_mutable=True,
+                        mutable_content=True,
                         category='c',
                         thread_id='t'
                     ),
@@ -635,7 +635,7 @@ class TestApsEncoder(object):
                         'badge': 42,
                         'sound': 's',
                         'content-available': 1,
-                        'content-mutable': 1,
+                        'mutable-content': 1,
                         'category': 'c',
                         'thread-id': 't',
                     },

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -588,23 +588,23 @@ class TestApsEncoder(object):
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', ['', list(), tuple(), True, False, 1, 0, ])
-    def test_invalid_custom_field_dict(self, data):
+    def test_invalid_custom_data_dict(self, data):
         if isinstance(data, dict):
             return
-        aps = messaging.Aps(custom_fields=data)
+        aps = messaging.Aps(custom_data=data)
         excinfo = self._check_aps(aps)
-        expected = 'Aps.custom_fields must be a dict.'
+        expected = 'Aps.custom_data must be a dict.'
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize('data', [True, False, 1, 0])
     def test_invalid_custom_field_name(self, data):
-        aps = messaging.Aps(custom_fields={data: 'foo'})
+        aps = messaging.Aps(custom_data={data: 'foo'})
         excinfo = self._check_aps(aps)
-        expected = 'Aps.custom_fields key must be a string.'
+        expected = 'Aps.custom_data key must be a string.'
         assert str(excinfo.value) == expected
 
     def test_multiple_field_specifications(self):
-        aps = messaging.Aps(thread_id='foo', custom_fields={'thread-id': 'foo'})
+        aps = messaging.Aps(thread_id='foo', custom_data={'thread-id': 'foo'})
         excinfo = self._check_aps(aps)
         expected = 'Multiple specifications for thread-id in Aps.'
         assert str(excinfo.value) == expected
@@ -644,14 +644,14 @@ class TestApsEncoder(object):
         }
         check_encoding(msg, expected)
 
-    def test_aps_custom_fields(self):
+    def test_aps_custom_data(self):
         msg = messaging.Message(
             topic='topic',
             apns=messaging.APNSConfig(
                 payload=messaging.APNSPayload(
                     aps=messaging.Aps(
                         alert='alert text',
-                        custom_fields={'k1': 'v1', 'k2': 1},
+                        custom_data={'k1': 'v1', 'k2': 1},
                     ),
                 )
             )


### PR DESCRIPTION
Added `mutable_content` and `custom_data` arguments to `Aps.__init__()`.

Resolves #136