### PR TITLE
'?' is now an illegal character for the REST API

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -34,7 +34,7 @@ from firebase_admin import _utils
 
 
 _DB_ATTRIBUTE = '_database'
-_INVALID_PATH_CHARACTERS = '[].#$'
+_INVALID_PATH_CHARACTERS = '[].?#$'
 _RESERVED_FILTERS = ('$key', '$value', '$priority')
 _USER_AGENT = 'Firebase/HTTP/{0}/{1}.{2}/AdminPython'.format(
     firebase_admin.__version__, sys.version_info.major, sys.version_info.minor)


### PR DESCRIPTION
Having a '?' character in a path raised an ApiCallError (405 Client Error: Method Not Allowed for url: -fakeURLwith?-.json Reason: append .json to your request URI to use the REST API. ).

It is indeed not the right error. 

This pull request allows the correct error to be raised ( ValueError : 'Invalid path: "{0}". Path contains illegal characters.' ).