### PR TITLE
Support for creating custom tokens without service account credentials

### DIFF
--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -51,7 +51,7 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
           Google Application Default Credentials are used.
       options: A dictionary of configuration options (optional). Supported options include
           ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``,
-          ``service_account_id`` and ``httpTimeout``. If ``httpTimeout`` is not set, HTTP
+          ``serviceAccountId`` and ``httpTimeout``. If ``httpTimeout`` is not set, HTTP
           connections initiated by client modules such as ``db`` will not time out.
       name: Name of the app (optional).
     Returns:

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -50,9 +50,9 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
       credential: A credential object used to initialize the SDK (optional). If none is provided,
           Google Application Default Credentials are used.
       options: A dictionary of configuration options (optional). Supported options include
-          ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``
-          and ``httpTimeout``. If ``httpTimeout`` is not set, HTTP connections initiated by client
-          modules such as ``db`` will not time out.
+          ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``,
+          ``service_account_id`` and ``httpTimeout``. If ``httpTimeout`` is not set, HTTP
+          connections initiated by client modules such as ``db`` will not time out.
       name: Name of the app (optional).
     Returns:
       App: A newly initialized instance of App.

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -119,7 +119,7 @@ class TokenGenerator(object):
 
         # Attempt to discover a service account email from the local Metadata service. Use it
         # with the IAM service to sign bytes.
-        resp = self.request(url=METADATA_SERVICE_URL)
+        resp = self.request(url=METADATA_SERVICE_URL, headers={'Metadata-Flavor': 'Google'})
         service_account = resp.data.decode()
         return _SigningProvider.from_iam(self.request, google_cred, service_account)
 

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -130,10 +130,12 @@ class TokenGenerator(object):
             try:
                 self._signing_provider = self._init_signing_provider()
             except Exception as error:
+                url = 'https://firebase.google.com/docs/auth/admin/create-custom-tokens'
                 raise ValueError(
                     'Failed to determine service account: {0}. Make sure to initialize the SDK '
-                    'with a service account credential. Alternatively, specify a service account '
-                    'with iam.serviceAccounts.signBlob permission.'.format(error))
+                    'with service account credentials or specify a service account ID with '
+                    'iam.serviceAccounts.signBlob permission. Please refer to {1} for more '
+                    'details on creating custom tokens.'.format(error, url))
         return self._signing_provider
 
     def create_custom_token(self, uid, developer_claims=None):

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -108,7 +108,7 @@ class TokenGenerator(object):
 
         # If the SDK was initialized with a service account email, use it with the IAM service
         # to sign bytes.
-        service_account = self.app.options.get('service_account')
+        service_account = self.app.options.get('service_account_id')
         if service_account:
             return _SigningProvider.from_iam(self.request, google_cred, service_account)
 

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -108,7 +108,7 @@ class TokenGenerator(object):
 
         # If the SDK was initialized with a service account email, use it with the IAM service
         # to sign bytes.
-        service_account = self.app.options.get('service_account_id')
+        service_account = self.app.options.get('serviceAccountId')
         if service_account:
             return _SigningProvider.from_iam(self.request, google_cred, service_account)
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -68,10 +68,13 @@ def create_custom_token(uid, developer_claims=None, app=None):
 
     Raises:
         ValueError: If input parameters are invalid.
+        AuthError: If an error occurs while creating the token using the remote IAM service.
     """
     token_generator = _get_auth_service(app).token_generator
-    return token_generator.create_custom_token(uid, developer_claims)
-
+    try:
+        return token_generator.create_custom_token(uid, developer_claims)
+    except _token_gen.ApiCallError as error:
+        raise AuthError(error.code, str(error), error.detail)
 
 def verify_id_token(id_token, app=None, check_revoked=False):
     """Verifies the signature and data for the provided JWT.

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -64,7 +64,7 @@ def test_custom_token_without_service_account(api_key):
     google_cred = firebase_admin.get_app().credential.get_credential()
     cred = CredentialWrapper.from_existing_credential(google_cred)
     custom_app = firebase_admin.initialize_app(cred, {
-        'service_account': google_cred.service_account_email,
+        'service_account_id': google_cred.service_account_email,
     }, 'temp-app')
     try:
         custom_token = auth.create_custom_token('user1', app=custom_app)

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -64,7 +64,7 @@ def test_custom_token_without_service_account(api_key):
     google_cred = firebase_admin.get_app().credential.get_credential()
     cred = CredentialWrapper.from_existing_credential(google_cred)
     custom_app = firebase_admin.initialize_app(cred, {
-        'service_account_id': google_cred.service_account_email,
+        'serviceAccountId': google_cred.service_account_email,
     }, 'temp-app')
     try:
         custom_token = auth.create_custom_token('user1', app=custom_app)

--- a/snippets/auth/index.py
+++ b/snippets/auth/index.py
@@ -50,6 +50,15 @@ def initialize_sdk_with_refresh_token():
     # [END initialize_sdk_with_refresh_token]
     firebase_admin.delete_app(default_app)
 
+def initialize_sdk_with_service_account_id():
+    # [START initialize_sdk_with_service_account_id]
+    options = {
+        'service_account_id': 'my-client-id@my-project-id.iam.gserviceaccount.com',
+    }
+    firebase_admin.initialize_app(options=options)
+    # [END initialize_sdk_with_service_account_id]
+    firebase_admin.delete_app(firebase_admin.get_app())
+
 def access_services_default():
     cred = credentials.Certificate('path/to/service.json')
     # [START access_services_default]

--- a/snippets/auth/index.py
+++ b/snippets/auth/index.py
@@ -53,7 +53,7 @@ def initialize_sdk_with_refresh_token():
 def initialize_sdk_with_service_account_id():
     # [START initialize_sdk_with_service_account_id]
     options = {
-        'service_account_id': 'my-client-id@my-project-id.iam.gserviceaccount.com',
+        'serviceAccountId': 'my-client-id@my-project-id.iam.gserviceaccount.com',
     }
     firebase_admin.initialize_app(options=options)
     # [END initialize_sdk_with_service_account_id]

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -199,7 +199,7 @@ class TestCreateCustomToken(object):
             auth.create_custom_token(MOCK_UID, app=user_mgt_app)
 
     def test_sign_with_iam(self):
-        options = {'service_account_id': 'test-service-account'}
+        options = {'serviceAccountId': 'test-service-account'}
         app = firebase_admin.initialize_app(
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:
@@ -213,7 +213,7 @@ class TestCreateCustomToken(object):
             firebase_admin.delete_app(app)
 
     def test_sign_with_iam_error(self):
-        options = {'service_account_id': 'test-service-account'}
+        options = {'serviceAccountId': 'test-service-account'}
         app = firebase_admin.initialize_app(
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -199,7 +199,7 @@ class TestCreateCustomToken(object):
             auth.create_custom_token(MOCK_UID, app=user_mgt_app)
 
     def test_sign_with_iam(self):
-        options = {'service_account': 'test-service-account'}
+        options = {'service_account_id': 'test-service-account'}
         app = firebase_admin.initialize_app(
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:
@@ -213,7 +213,7 @@ class TestCreateCustomToken(object):
             firebase_admin.delete_app(app)
 
     def test_sign_with_iam_error(self):
-        options = {'service_account': 'test-service-account'}
+        options = {'service_account_id': 'test-service-account'}
         app = firebase_admin.initialize_app(
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:
@@ -226,7 +226,7 @@ class TestCreateCustomToken(object):
         finally:
             firebase_admin.delete_app(app)
 
-    def test_sign_with_iam_without_service_account(self):
+    def test_sign_with_discovered_service_account(self):
         request = testutils.MockRequest(200, 'discovered-service-account')
         app = firebase_admin.initialize_app(testutils.MockCredential(), name='iam-signer-app')
         try:

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -241,6 +241,8 @@ class TestCreateCustomToken(object):
             custom_token = auth.create_custom_token(MOCK_UID, app=app).decode()
             assert custom_token.endswith('.' + signature)
             self._verify_signer(custom_token, 'discovered-service-account')
+            assert len(request.log) == 2
+            assert request.log[0][1]['headers'] == {'Metadata-Flavor': 'Google'}
         finally:
             firebase_admin.delete_app(app)
 

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -203,10 +203,10 @@ class TestCreateCustomToken(object):
         app = firebase_admin.initialize_app(
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:
-            signature = base64.b64encode('test')
+            signature = base64.b64encode(b'test').decode()
             iam_resp = '{{"signature": "{0}"}}'.format(signature)
             _overwrite_iam_request(app, testutils.MockRequest(200, iam_resp))
-            custom_token = auth.create_custom_token(MOCK_UID, app=app)
+            custom_token = auth.create_custom_token(MOCK_UID, app=app).decode()
             assert custom_token.endswith('.' + signature)
             self._verify_signer(custom_token, 'test-service-account')
         finally:
@@ -235,10 +235,10 @@ class TestCreateCustomToken(object):
             auth_service = auth._get_auth_service(app)
             assert auth_service.token_generator.signing_provider is not None
             # Now invoke the IAM signer.
-            signature = base64.b64encode('test')
+            signature = base64.b64encode(b'test').decode()
             request.response = testutils.MockResponse(
                 200, '{{"signature": "{0}"}}'.format(signature))
-            custom_token = auth.create_custom_token(MOCK_UID, app=app)
+            custom_token = auth.create_custom_token(MOCK_UID, app=app).decode()
             assert custom_token.endswith('.' + signature)
             self._verify_signer(custom_token, 'discovered-service-account')
         finally:

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -247,7 +247,7 @@ class TestCreateCustomToken(object):
     def _verify_signer(self, token, signer):
         segments = token.split('.')
         assert len(segments) == 3
-        body = json.loads(base64.b64decode(segments[1]))
+        body = json.loads(base64.b64decode(segments[1]).decode())
         assert body['iss'] == signer
         assert body['sub'] == signer
 

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -14,6 +14,7 @@
 
 """Test cases for the firebase_admin._token_gen module."""
 
+import base64
 import datetime
 import json
 import os
@@ -109,8 +110,11 @@ def _instrument_user_manager(app, status, payload):
 
 def _overwrite_cert_request(app, request):
     auth_service = auth._get_auth_service(app)
-    token_verifier = auth_service.token_verifier
-    token_verifier.request = request
+    auth_service.token_verifier.request = request
+
+def _overwrite_iam_request(app, request):
+    auth_service = auth._get_auth_service(app)
+    auth_service.token_generator.request = request
 
 @pytest.fixture(scope='module')
 def auth_app():
@@ -193,6 +197,59 @@ class TestCreateCustomToken(object):
     def test_noncert_credential(self, user_mgt_app):
         with pytest.raises(ValueError):
             auth.create_custom_token(MOCK_UID, app=user_mgt_app)
+
+    def test_sign_with_iam(self):
+        options = {'service_account': 'test-service-account'}
+        app = firebase_admin.initialize_app(
+            testutils.MockCredential(), name='iam-signer-app', options=options)
+        try:
+            signature = base64.b64encode('test')
+            iam_resp = '{{"signature": "{0}"}}'.format(signature)
+            _overwrite_iam_request(app, testutils.MockRequest(200, iam_resp))
+            custom_token = auth.create_custom_token(MOCK_UID, app=app)
+            assert custom_token.endswith('.' + signature)
+            self._verify_signer(custom_token, 'test-service-account')
+        finally:
+            firebase_admin.delete_app(app)
+
+    def test_sign_with_iam_error(self):
+        options = {'service_account': 'test-service-account'}
+        app = firebase_admin.initialize_app(
+            testutils.MockCredential(), name='iam-signer-app', options=options)
+        try:
+            iam_resp = '{"error": {"code": 403, "message": "test error"}}'
+            _overwrite_iam_request(app, testutils.MockRequest(403, iam_resp))
+            with pytest.raises(auth.AuthError) as excinfo:
+                auth.create_custom_token(MOCK_UID, app=app)
+            assert excinfo.value.code == _token_gen.TOKEN_SIGN_ERROR
+            assert iam_resp in str(excinfo.value)
+        finally:
+            firebase_admin.delete_app(app)
+
+    def test_sign_with_iam_without_service_account(self):
+        request = testutils.MockRequest(200, 'discovered-service-account')
+        app = firebase_admin.initialize_app(testutils.MockCredential(), name='iam-signer-app')
+        try:
+            _overwrite_iam_request(app, request)
+            # Force initialization of the signing provider. This will invoke the Metadata service.
+            auth_service = auth._get_auth_service(app)
+            assert auth_service.token_generator.signing_provider is not None
+            # Now invoke the IAM signer.
+            signature = base64.b64encode('test')
+            request.response = testutils.MockResponse(
+                200, '{{"signature": "{0}"}}'.format(signature))
+            custom_token = auth.create_custom_token(MOCK_UID, app=app)
+            assert custom_token.endswith('.' + signature)
+            self._verify_signer(custom_token, 'discovered-service-account')
+        finally:
+            firebase_admin.delete_app(app)
+
+    def _verify_signer(self, token, signer):
+        segments = token.split('.')
+        assert len(segments) == 3
+        body = json.loads(base64.b64decode(segments[1]))
+        assert body['iss'] == signer
+        assert body['sub'] == signer
 
 
 class TestCreateSessionCookie(object):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -77,6 +77,18 @@ class MockRequest(transport.Request):
         return self.response
 
 
+class MockFailedRequest(transport.Request):
+    """A mock HTTP request that fails by raising an exception."""
+
+    def __init__(self, error):
+        self.error = error
+        self.log = []
+
+    def __call__(self, *args, **kwargs):
+        self.log.append((args, kwargs))
+        raise self.error
+
+
 class MockGoogleCredential(credentials.Credentials):
     """A mock Google authentication credential."""
     def refresh(self, request):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -70,8 +70,10 @@ class MockRequest(transport.Request):
 
     def __init__(self, status, response):
         self.response = MockResponse(status, response)
+        self.log = []
 
     def __call__(self, *args, **kwargs):
+        self.log.append((args, kwargs))
         return self.response
 
 


### PR DESCRIPTION
Currently the SDK must be initialized with service account credentials in order to be able to call FirebaseAuth.createCustomToken(). With this PR, the SDK will attempt to sign custom tokens by calling the IAM service in the cloud when the service account credentials are not provided.

```
# Following will work in GCP managed runtimes where the Metadata service is present
firebase_admin.initialize_app()
token = auth.create_custom_token(uid)
```

```
# Following will work anywhere
options = {
    'service_account_id': 'test-service-account@project-id.iam.gserviceaccount.com',
}
firebase_admin.initialize_app(options=options)
token = auth.create_custom_token(uid)
```

go/firebase-admin-sign
go/firebase-admin-iam-sign