### PR TITLE
Fixed and refactored the db.Reference.listen() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [added] The `db.Reference` type now provides a `listen()` API for
+  receiving realtime update events from the Firebase Database.
 - [added] The `db.reference()` method now optionally takes a `url`
   parameter. This can be used to access multiple Firebase Databases
   in the same project more easily. 

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -1,3 +1,5 @@
+# Copyright 2017 Google Inc.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SSEClient module to stream realtime updates in the Firebase Database"""
+"""SSEClient module to stream realtime updates in the Firebase Database."""
 
 import re
 import time
@@ -26,7 +28,7 @@ end_of_field = re.compile(r'\r\n\r\n|\r\r|\n\n')
 
 
 class KeepAuthSession(transport.requests.AuthorizedSession):
-    """A session that does not drop Authentication on redirects between domains"""
+    """A session that does not drop authentication on redirects between domains."""
 
     def __init__(self, credential):
         super(KeepAuthSession, self).__init__(credential)
@@ -36,21 +38,24 @@ class KeepAuthSession(transport.requests.AuthorizedSession):
 
 
 class SSEClient(object):
-    """SSE Client Class"""
+    """SSE client implementation."""
 
-    def __init__(self, url, session, retry=3000, **kwargs):
+    def __init__(self, url, session, retry=None, **kwargs):
         """Initializes the SSEClient.
 
         Args:
-          url: the url to connect to.
-          session: the requests session.
-          retry: the retry interval in ms.
-          **kwargs: extra kwargs will be sent to ``requests.get()``.
+          url: The remote url to connect to.
+          session: The requests session.
+          retry: The retry interval in milliseconds (optional).
+          **kwargs: Extra kwargs that will be sent to ``requests.get()`` (optional).
         """
         self.should_connect = True
         self.url = url
         self.last_id = None
-        self.retry = retry
+        if retry is None:
+            self.retry = 3000
+        else:
+            self.retry = retry
         self.session = session
         self.requests_kwargs = kwargs
 
@@ -67,7 +72,6 @@ class SSEClient(object):
 
     def close(self):
         """Closes the SSEClient instance."""
-        # TODO: check if AttributeError is needed to be caught here
         self.should_connect = False
         self.retry = 0
         self.resp.close()

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -52,10 +52,7 @@ class SSEClient(object):
         self.should_connect = True
         self.url = url
         self.last_id = None
-        if retry is None:
-            self.retry = 3000
-        else:
-            self.retry = retry
+        self.retry = retry or 3000
         self.session = session
         self.requests_kwargs = kwargs
 
@@ -79,14 +76,11 @@ class SSEClient(object):
     def _connect(self):
         """Connects to the server using requests."""
         if self.should_connect:
-            success = False
-            while not success:
-                if self.last_id:
-                    self.requests_kwargs['headers']['Last-Event-ID'] = self.last_id
-                self.resp = self.session.get(self.url, stream=True, **self.requests_kwargs)
-                self.resp_iterator = self.resp.iter_content(decode_unicode=True)
-                self.resp.raise_for_status()
-                success = True
+            if self.last_id:
+                self.requests_kwargs['headers']['Last-Event-ID'] = self.last_id
+            self.resp = self.session.get(self.url, stream=True, **self.requests_kwargs)
+            self.resp_iterator = self.resp.iter_content(decode_unicode=True)
+            self.resp.raise_for_status()
         else:
             raise StopIteration()
 

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -10,14 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SSEClient module to handle streaming of realtime changes on the database
-to the firebase-admin-sdk
-"""
+"""SSEClient module to stream realtime updates in the Firebase Database"""
 
 import re
 import time
 import warnings
-import six
+
+from google.auth import transport
 import requests
 
 
@@ -26,8 +25,12 @@ import requests
 end_of_field = re.compile(r'\r\n\r\n|\r\r|\n\n')
 
 
-class KeepAuthSession(requests.Session):
+class KeepAuthSession(transport.requests.AuthorizedSession):
     """A session that does not drop Authentication on redirects between domains"""
+
+    def __init__(self, credential):
+        super(KeepAuthSession, self).__init__(credential)
+
     def rebuild_auth(self, prepared_request, response):
         pass
 
@@ -35,18 +38,18 @@ class KeepAuthSession(requests.Session):
 class SSEClient(object):
     """SSE Client Class"""
 
-    def __init__(self, url, session, last_id=None, retry=3000, **kwargs):
-        """Initialize the SSEClient
+    def __init__(self, url, session, retry=3000, **kwargs):
+        """Initializes the SSEClient.
+
         Args:
-          url: the url to connect to
-          session: the requests.session()
-          last_id: optional id
-          retry: the interval in ms
-          **kwargs: extra kwargs will be sent to requests.get
+          url: the url to connect to.
+          session: the requests session.
+          retry: the retry interval in ms.
+          **kwargs: extra kwargs will be sent to ``requests.get()``.
         """
         self.should_connect = True
         self.url = url
-        self.last_id = last_id
+        self.last_id = None
         self.retry = retry
         self.session = session
         self.requests_kwargs = kwargs
@@ -56,50 +59,35 @@ class SSEClient(object):
         headers['Cache-Control'] = 'no-cache'
         # The 'Accept' header is not required, but explicit > implicit
         headers['Accept'] = 'text/event-stream'
-
         self.requests_kwargs['headers'] = headers
 
         # Keep data here as it streams in
         self.buf = u''
-
         self._connect()
 
     def close(self):
-        """Close the SSE Client instance"""
-        # TODO: check if AttributeError is needed to catch here
+        """Closes the SSEClient instance."""
+        # TODO: check if AttributeError is needed to be caught here
         self.should_connect = False
         self.retry = 0
         self.resp.close()
-        #  self.resp.raw._fp.fp.raw._sock.shutdown(socket.SHUT_RDWR)
-        #  self.resp.raw._fp.fp.raw._sock.close()
-
 
     def _connect(self):
-        """connects to the server using requests"""
+        """Connects to the server using requests."""
         if self.should_connect:
             success = False
             while not success:
                 if self.last_id:
                     self.requests_kwargs['headers']['Last-Event-ID'] = self.last_id
-                # Use session if set.  Otherwise fall back to requests module.
-                self.requester = self.session or requests
-                self.resp = self.requester.get(self.url, stream=True, **self.requests_kwargs)
-
+                self.resp = self.session.get(self.url, stream=True, **self.requests_kwargs)
                 self.resp_iterator = self.resp.iter_content(decode_unicode=True)
-
-                # TODO: Ensure we're handling redirects.  Might also stick the 'origin'
-                # attribute on Events like the Javascript spec requires.
                 self.resp.raise_for_status()
                 success = True
         else:
             raise StopIteration()
 
     def _event_complete(self):
-        """Checks if the event is completed by matching regular expression
-
-        Returns:
-           boolean: True if the regex matched meaning end of event, else False
-        """
+        """Checks if the event is completed by matching regular expression."""
         return re.search(end_of_field, self.buf) is not None
 
     def __iter__(self):
@@ -113,8 +101,6 @@ class SSEClient(object):
             except (StopIteration, requests.RequestException):
                 time.sleep(self.retry / 1000.0)
                 self._connect()
-
-
                 # The SSE spec only supports resuming from a whole message, so
                 # if we have half a message we should throw it out.
                 head, sep, tail = self.buf.rpartition('\n')
@@ -123,56 +109,54 @@ class SSEClient(object):
 
         split = re.split(end_of_field, self.buf)
         head = split[0]
-        tail = "".join(split[1:])
+        tail = ''.join(split[1:])
 
         self.buf = tail
-        msg = Event.parse(head)
+        event = Event.parse(head)
 
-        if msg.data == "credential is no longer valid":
+        if event.data == 'credential is no longer valid':
             self._connect()
             return None
-
-        if msg.data == 'null':
+        elif event.data == 'null':
             return None
 
         # If the server requests a specific retry delay, we need to honor it.
-        if msg.retry:
-            self.retry = msg.retry
+        if event.retry:
+            self.retry = event.retry
 
         # last_id should only be set if included in the message.  It's not
         # forgotten if a message omits it.
-        if msg.event_id:
-            self.last_id = msg.event_id
+        if event.event_id:
+            self.last_id = event.event_id
+        return event
 
-        return msg
-
-    if six.PY2:
-        next = __next__
+    def next(self):
+        return self.__next__()
 
 
 class Event(object):
-    """Event class to handle the events fired by SSE"""
+    """Event represents the events fired by SSE."""
 
     sse_line_pattern = re.compile('(?P<name>[^:]*):?( ?(?P<value>.*))?')
 
-    def __init__(self, data='', event='message', event_id=None, retry=None):
+    def __init__(self, data='', event_type='message', event_id=None, retry=None):
         self.data = data
-        self.event = event
+        self.event_type = event_type
         self.event_id = event_id
         self.retry = retry
 
     @classmethod
     def parse(cls, raw):
-        """Given a possibly-multiline string representing an SSE message, parse it
-        and return a Event object.
+        """Given a possibly-multiline string representing an SSE message, parses it
+        and returns an Event object.
 
         Args:
-          raw: the raw data to parse
+          raw: the raw data to parse.
 
         Returns:
-          Event: newly intialized Event() object with the parameters  initialized
+          Event: newly intialized ``Event`` object with the parameters  initialized.
         """
-        msg = cls()
+        event = cls()
         for line in raw.split('\n'):
             match = cls.sse_line_pattern.match(line)
             if match is None:
@@ -185,22 +169,17 @@ class Event(object):
             if name == '':
                 # line began with a ":", so is a comment.  Ignore
                 continue
-
-            if name == 'data':
+            elif name == 'data':
                 # If we already have some data, then join to it with a newline.
                 # Else this is it.
-                if msg.data:
-                    msg.data = '%s\n%s' % (msg.data, value)
+                if event.data:
+                    event.data = '%s\n%s' % (event.data, value)
                 else:
-                    msg.data = value
+                    event.data = value
             elif name == 'event':
-                msg.event = value
+                event.event_type = value
             elif name == 'id':
-                msg.event_id = value
+                event.event_id = value
             elif name == 'retry':
-                msg.retry = int(value)
-
-        return msg
-
-    def __str__(self):
-        return self.data
+                event.retry = int(value)
+        return event

--- a/tests/test_sseclient.py
+++ b/tests/test_sseclient.py
@@ -90,7 +90,7 @@ class TestSSEClient(object):
 
 
 class TestEvent(object):
-    """Test cases for Events"""
+    """Test cases for server-side events"""
 
     def test_normal(self):
         data = 'event: put\ndata: {"path":"/","data":"testdata"}'

--- a/tests/test_sseclient.py
+++ b/tests/test_sseclient.py
@@ -1,20 +1,20 @@
-"""Tests for firebase_admin.sseclient."""
+"""Tests for firebase_admin._sseclient."""
 import json
-import six
+
 import requests
+import six
 
 from firebase_admin import _sseclient
 from tests.testutils import MockAdapter
 
 
-class MockSSEClient(MockAdapter):
-    def __init__(self, payload):
+class MockSSEClientAdapter(MockAdapter):
+    def __init__(self, payload, recorder):
         status = 200
-        recorder = []
         MockAdapter.__init__(self, payload, status, recorder)
 
     def send(self, request, **kwargs):
-        resp = requests.models.Response()
+        resp = super(MockSSEClientAdapter, self).send(request, **kwargs)
         resp.url = request.url
         resp.status_code = self._status
         resp.raw = six.BytesIO(self._data.encode())
@@ -28,29 +28,51 @@ class TestSSEClient(object):
     test_url = "https://test.firebaseio.com"
 
 
-    def init_sse(self):
-        payload = 'event: put\ndata: {"path":"/","data":"testevent"}\n\n'
-
-        adapter = MockSSEClient(payload)
-        session = _sseclient.KeepAuthSession()
+    def init_sse(self, payload, recorder=None):
+        if recorder is None:
+            recorder = []
+        adapter = MockSSEClientAdapter(payload, recorder)
+        session = requests.Session()
         session.mount(self.test_url, adapter)
-
-        sseclient = _sseclient.SSEClient(url=self.test_url, session=session)
-        return sseclient
-
+        return _sseclient.SSEClient(url=self.test_url, session=session, retry=1)
 
     def test_init_sseclient(self):
-        sseclient = self.init_sse()
-
+        payload = 'event: put\ndata: {"path":"/","data":"testevent"}\n\n'
+        sseclient = self.init_sse(payload)
         assert sseclient.url == self.test_url
         assert sseclient.session != None
 
-    def test_event(self):
-        sseclient = self.init_sse()
-        msg = next(sseclient)
-        event = json.loads(msg.data)
-        assert event["data"] == "testevent"
-        assert event["path"] == "/"
+    def test_single_event(self):
+        payload = 'event: put\ndata: {"path":"/","data":"testevent"}\n\n'
+        recorder = []
+        sseclient = self.init_sse(payload, recorder)
+        event = next(sseclient)
+        event_payload = json.loads(event.data)
+        assert event_payload["data"] == "testevent"
+        assert event_payload["path"] == "/"
+        assert len(recorder) == 1
+        # The SSEClient should reconnect now, at which point the mock adapter
+        # will echo back the same response.
+        event = next(sseclient)
+        event_payload = json.loads(event.data)
+        assert event_payload["data"] == "testevent"
+        assert event_payload["path"] == "/"
+        assert len(recorder) == 2
+
+    def test_multiple_events(self):
+        payload = 'event: put\ndata: {"path":"/foo","data":"testevent1"}\n\n'
+        payload += 'event: put\ndata: {"path":"/bar","data":"testevent2"}\n\n'
+        recorder = []
+        sseclient = self.init_sse(payload, recorder)
+        event = next(sseclient)
+        event_payload = json.loads(event.data)
+        assert event_payload["data"] == "testevent1"
+        assert event_payload["path"] == "/foo"
+        event = next(sseclient)
+        event_payload = json.loads(event.data)
+        assert event_payload["data"] == "testevent2"
+        assert event_payload["path"] == "/bar"
+        assert len(recorder) == 1
 
 
 class TestEvent(object):
@@ -59,11 +81,19 @@ class TestEvent(object):
     def test_normal(self):
         data = 'event: put\ndata: {"path":"/","data":"testdata"}'
         event = _sseclient.Event.parse(data)
-        assert event.event == "put"
+        assert event.event_type == "put"
         assert event.data == '{"path":"/","data":"testdata"}'
+
+    def test_all_fields(self):
+        data = 'event: put\ndata: {"path":"/","data":"testdata"}\nretry: 5000\nid: abcd'
+        event = _sseclient.Event.parse(data)
+        assert event.event_type == "put"
+        assert event.data == '{"path":"/","data":"testdata"}'
+        assert event.retry == 5000
+        assert event.event_id == 'abcd'
 
     def test_invalid(self):
         data = 'event: invalid_event'
         event = _sseclient.Event.parse(data)
-        assert event.event == "invalid_event"
+        assert event.event_type == "invalid_event"
         assert event.data == ''

--- a/tests/test_sseclient.py
+++ b/tests/test_sseclient.py
@@ -1,3 +1,17 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for firebase_admin._sseclient."""
 import json
 
@@ -9,9 +23,9 @@ from tests.testutils import MockAdapter
 
 
 class MockSSEClientAdapter(MockAdapter):
+
     def __init__(self, payload, recorder):
-        status = 200
-        MockAdapter.__init__(self, payload, status, recorder)
+        super(MockSSEClientAdapter, self).__init__(payload, 200, recorder)
 
     def send(self, request, **kwargs):
         resp = super(MockSSEClientAdapter, self).send(request, **kwargs)


### PR DESCRIPTION
Continuation of #183 

* `KeepAuthSession` now extends from the `AuthorizedSession`. This allows the `listen()` API to properly authorize outgoing requests.
* Added `db.Event` type. The callback gets fired with instances of this class.
* Updated documentation and changelog.
* Cleaned up the code and added more unit tests.