### PR TITLE
Handling non-existing validSince case on UserRecord

### DIFF
--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -215,7 +215,7 @@ class UserRecord(UserInfo):
         valid_since = self._data.get('validSince')
         if valid_since is not None:
             return 1000 * int(valid_since)
-        return None
+        return 0
 
     @property
     def user_metadata(self):

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -151,6 +151,14 @@ class TestUserRecord(object):
         with pytest.raises(ValueError):
             _user_mgt.ProviderUserInfo(data)
 
+    def test_tokens_valid_after_time(self):
+        user = auth.UserRecord({'localId' : 'user', 'validSince' : 100})
+        assert user.tokens_valid_after_timestamp == 100000
+
+    def test_no_tokens_valid_after_time(self):
+        user = auth.UserRecord({'localId' : 'user'})
+        assert user.tokens_valid_after_timestamp is 0
+
 
 class TestGetUser(object):
 


### PR DESCRIPTION
When the `validSince` parameter is not present on the `UserRecord` we should return 0. Returning `None` here can break other APIs. See #199.