### PR TITLE
Fixing a performance issue in SSE client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   type.googleapis.com/google.firebase.fcm.v1.FcmError to set error code.
 - [fixed] Ensuring that `UserRecord.tokens_valid_after_time` always
   returns an integer, and never returns `None`.
+- [fixed] Fixing a performance issue in the `db.listen()` API
+  where it was taking a long time to process large RTDB nodes.
 
 # v2.13.0
 

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -50,8 +50,7 @@ class _EventBuffer(object):
     def append(self, char):
         self._buffer.append(char)
         self._tail += char
-        if len(self._tail) > 4:
-            self._tail = self._tail[1:]
+        self._tail = self._tail[-4:]
 
     def truncate(self):
         head, sep, _ = self.buffer_string.rpartition('\n')

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -177,7 +177,7 @@ class Event(object):
           raw: the raw data to parse.
 
         Returns:
-          Event: newly intialized ``Event`` object with the parameters initialized.
+          Event: A new ``Event`` with the parameters initialized.
         """
         event = cls()
         for line in raw.split('\n'):

--- a/firebase_admin/_sseclient.py
+++ b/firebase_admin/_sseclient.py
@@ -17,7 +17,6 @@
 Based on a similar implementation from Pyrebase.
 """
 
-import collections
 import re
 import time
 import warnings
@@ -46,25 +45,24 @@ class _EventBuffer(object):
 
     def __init__(self):
         self._buffer = []
-        self._tail = collections.deque([])
+        self._tail = ''
 
     def append(self, char):
         self._buffer.append(char)
-        self._tail.append(char)
+        self._tail += char
         if len(self._tail) > 4:
-            self._tail.popleft()
+            self._tail = self._tail[1:]
 
     def truncate(self):
         head, sep, _ = self.buffer_string.rpartition('\n')
         rem = head + sep
         self._buffer = list(rem)
-        self._tail = collections.deque(self._buffer[-4:])
+        self._tail = rem[-4:]
 
     @property
     def is_end_of_field(self):
-        tail_str = ''.join(self._tail)
-        last_two_chars = tail_str[-2:]
-        return tail_str == '\r\n\r\n' or last_two_chars == '\n\n' or last_two_chars == '\r\r'
+        last_two_chars = self._tail[-2:]
+        return last_two_chars == '\n\n' or last_two_chars == '\r\r' or self._tail == '\r\n\r\n'
 
     @property
     def buffer_string(self):

--- a/tests/test_sseclient.py
+++ b/tests/test_sseclient.py
@@ -73,6 +73,17 @@ class TestSSEClient(object):
         assert event_payload["path"] == "/"
         assert len(recorder) == 2
 
+    def test_large_event(self):
+        data = 'a' * int(0.1 * 1024 * 1024)
+        payload = 'event: put\ndata: {"path":"/","data":"' + data + '"}\n\n'
+        recorder = []
+        sseclient = self.init_sse(payload, recorder)
+        event = next(sseclient)
+        event_payload = json.loads(event.data)
+        assert event_payload["data"] == data
+        assert event_payload["path"] == "/"
+        assert len(recorder) == 1
+
     def test_multiple_events(self):
         payload = 'event: put\ndata: {"path":"/foo","data":"testevent1"}\n\n'
         payload += 'event: put\ndata: {"path":"/bar","data":"testevent2"}\n\n'


### PR DESCRIPTION
Improves the streaming RTDB API performance by checking for end of field more efficiently. Specifically, instead of matching a regex on each iteration, we keep track of the last 4 characters seen, and perform a simple string comparison.

Here are some preliminary test results to get an idea of the improvement.

| Node Size  | Time to process (Before) | Time to process (After) |
| ------------- | ------------- | ------------- |
| 100K  | 40.83s  | 1.73s |
| 1M  | - | 11.36s |

Fixes #198