### PR TITLE
Skipping Firestore tests on PyPy

### DIFF
--- a/tests/test_firestore.py
+++ b/tests/test_firestore.py
@@ -14,56 +14,68 @@
 
 """Tests for firebase_admin.firestore."""
 
+import platform
+
 import pytest
 
 import firebase_admin
 from firebase_admin import credentials
-from firebase_admin import firestore
+try:
+    from firebase_admin import firestore
+except ImportError:
+    pass
 from tests import testutils
 
 
-def teardown_function():
-    testutils.cleanup_apps()
+@pytest.mark.skipif(
+    platform.python_implementation() == 'PyPy',
+    reason='Firestore is not supported on PyPy')
+class TestFirestore(object):
+    """Test class Firestore APIs."""
 
-def test_no_project_id():
-    def evaluate():
-        firebase_admin.initialize_app(testutils.MockCredential())
-        with pytest.raises(ValueError):
-            firestore.client()
-    testutils.run_without_project_id(evaluate)
+    def teardown_method(self, method):
+        del method
+        testutils.cleanup_apps()
 
-def test_project_id():
-    cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
-    firebase_admin.initialize_app(cred, {'projectId': 'explicit-project-id'})
-    client = firestore.client()
-    assert client is not None
-    assert client.project == 'explicit-project-id'
+    def test_no_project_id(self):
+        def evaluate():
+            firebase_admin.initialize_app(testutils.MockCredential())
+            with pytest.raises(ValueError):
+                firestore.client()
+        testutils.run_without_project_id(evaluate)
 
-def test_project_id_with_explicit_app():
-    cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
-    app = firebase_admin.initialize_app(cred, {'projectId': 'explicit-project-id'})
-    client = firestore.client(app=app)
-    assert client is not None
-    assert client.project == 'explicit-project-id'
+    def test_project_id(self):
+        cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
+        firebase_admin.initialize_app(cred, {'projectId': 'explicit-project-id'})
+        client = firestore.client()
+        assert client is not None
+        assert client.project == 'explicit-project-id'
 
-def test_service_account():
-    cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
-    firebase_admin.initialize_app(cred)
-    client = firestore.client()
-    assert client is not None
-    assert client.project == 'mock-project-id'
+    def test_project_id_with_explicit_app(self):
+        cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
+        app = firebase_admin.initialize_app(cred, {'projectId': 'explicit-project-id'})
+        client = firestore.client(app=app)
+        assert client is not None
+        assert client.project == 'explicit-project-id'
 
-def test_service_account_with_explicit_app():
-    cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
-    app = firebase_admin.initialize_app(cred)
-    client = firestore.client(app=app)
-    assert client is not None
-    assert client.project == 'mock-project-id'
+    def test_service_account(self):
+        cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
+        firebase_admin.initialize_app(cred)
+        client = firestore.client()
+        assert client is not None
+        assert client.project == 'mock-project-id'
 
-def test_geo_point():
-    geo_point = firestore.GeoPoint(10, 20) # pylint: disable=no-member
-    assert geo_point.latitude == 10
-    assert geo_point.longitude == 20
+    def test_service_account_with_explicit_app(self):
+        cred = credentials.Certificate(testutils.resource_filename('service_account.json'))
+        app = firebase_admin.initialize_app(cred)
+        client = firestore.client(app=app)
+        assert client is not None
+        assert client.project == 'mock-project-id'
 
-def test_server_timestamp():
-    assert firestore.SERVER_TIMESTAMP is not None # pylint: disable=no-member
+    def test_geo_point(self):
+        geo_point = firestore.GeoPoint(10, 20) # pylint: disable=no-member
+        assert geo_point.latitude == 10
+        assert geo_point.longitude == 20
+
+    def test_server_timestamp(self):
+        assert firestore.SERVER_TIMESTAMP is not None # pylint: disable=no-member


### PR DESCRIPTION
Firestore/GRPC is not supported on PyPy, and therefore we have to skip the affected tests.

See https://github.com/grpc/grpc/issues/4221