### PR TITLE
Dropping Python 3.3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
   - "pypy3.5"
 # command to install dependencies
 install: "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
+  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "pypy3.5"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 before_script: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
--
+- [changed] Dropped support for Python 3.3.
 
 # v2.14.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ tox >= 2.6.0
 
 cachecontrol >= 0.12.4
 google-auth >= 1.3.0
-google-cloud-firestore >= 0.27.0
+google-cloud-firestore >= 0.27.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.2.0
 requests >= 2.13.0
 six >= 1.6.1
-enum34 >= 1.0.4; python_version < '3.4'

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -93,10 +93,10 @@ fi
 # Ensure the checked out branch is master
 CHECKED_OUT_BRANCH="$(git branch | grep "*" | awk -F ' ' '{print $2}')"
 if [[ $CHECKED_OUT_BRANCH != "master" ]]; then
-    read -p "[WARN] You are on the '${CHECKED_OUT_BRANCH}' branch, not 'master'. Continue? (Y/n) " CONTINUE
+    read -p "[WARN] You are on the '${CHECKED_OUT_BRANCH}' branch, not 'master'. Continue? (y/N) " CONTINUE
     echo
 
-    if ! [[ $CONTINUE == "Y" ]]; then
+    if ! [[ $CONTINUE == "y" || $CONTINUE == "Y" ]]; then
         echo "[INFO] You chose not to continue."
         exit 1
     fi
@@ -104,10 +104,10 @@ fi
 
 # Ensure the branch does not have local changes
 if [[ $(git status --porcelain) ]]; then
-    read -p "[WARN] Local changes exist in the repo. Continue? (Y/n) " CONTINUE
+    read -p "[WARN] Local changes exist in the repo. Continue? (y/N) " CONTINUE
     echo
 
-    if ! [[ $CONTINUE == "Y" ]]; then
+    if ! [[ $CONTINUE == "y" || $CONTINUE == "Y" ]]; then
         echo "[INFO] You chose not to continue."
         exit 1
     fi

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-if sys.version_info < (2, 7):
-    print('firebase_admin requires python2 version >= 2.7 or python3.', file=sys.stderr)
+(major, minor) = (sys.version_info.major, sys.version_info.minor)
+if (major == 2 and minor < 7) or (major == 3 and minor < 4):
+    print('firebase_admin requires python2 >= 2.7 or python3 >= 3.4', file=sys.stderr)
     sys.exit(1)
 
-# Read in the package meta data per recommendations from:
+# Read in the package metadata per recommendations from:
 # https://packaging.python.org/guides/single-sourcing-package-version/
 about_path = path.join(path.dirname(path.abspath(__file__)), 'firebase_admin', '__about__.py')
 about = {}
@@ -45,10 +46,6 @@ install_requires = [
     'six>=1.6.1'
 ]
 
-extras_require = {
-    ':python_version<"3.4"': ('enum34>=1.0.4',),
-}
-
 setup(
     name=about['__title__'],
     version=about['__version__'],
@@ -58,9 +55,9 @@ setup(
     author=about['__author__'],
     license=about['__license__'],
     keywords='firebase cloud development',
-    extras_require=extras_require,
     install_requires=install_requires,
     packages=find_packages(exclude=['tests']),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -68,8 +65,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: Apache Software License',
     ],
 )


### PR DESCRIPTION
Python 3.3 is pretty old (released in 2012) and not officially supported by some GCP libraries (e.g. google-auth, Firestore/GRPC). Therefore to reduce the maintenance burden, I'm dropping support for 3.3 in Admin SDK as well.

Also:
* Adding pypy to the CI matrix
* Preventing Firestore installation on PyPy during CI