### PR TITLE
Bumped minimum pytest requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pylint == 1.6.4
-pytest >= 3.0.6
+pytest >= 3.6.0
 pytest-cov >= 2.4.0
 pytest-localserver >= 0.4.1
 tox >= 3.6.0


### PR DESCRIPTION
Recent versions of the `pytest-cov` plugin requires `pytest` 3.6.0 or higher. This is causing some of our builds to fail on Travis, where instances seem to come pre-installed with an old version of pytest. This PR forces the CI environment to install a more recent version of pytest