### PR TITLE
Implementing HTTP retries for the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [added] Implemented HTTP retries. The SDK now retries HTTP calls on
+  low-level connection and socket read errors, as well as HTTP 500 and
+  503 errors.
 - [changed] Taking a direct dependency on `google-api-core[grpc]` in order to
   resolve some long standing Firestore installation problems.
 - `messaging.WebpushConfig` class now supports configuring additional

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -42,7 +42,7 @@ def testdata():
         return json.load(dino_file)
 
 @pytest.fixture(scope='module')
-def testref(update_rules):
+def testref(update_rules, testdata):
     """Adds the necessary DB indices, and sets the initial values.
 
     This fixture is attached to the module scope, and therefore is guaranteed to run only once
@@ -53,7 +53,7 @@ def testref(update_rules):
     """
     del update_rules
     ref = db.reference('_adminsdk/python/dinodb')
-    ref.set(testdata())
+    ref.set(testdata)
     return ref
 
 


### PR DESCRIPTION
Implementing HTTP retries for the SDK. This will:

1. Retry once for all low-level errors
2. Retry up to 4 times for HTTP 500 and 503 errors (with exponential backoff)
3. Respect the HTTP Retry-After header when available

Resolves #237 