### PR TITLE
Fixing some integration test failures

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -150,7 +150,8 @@ class WebpushConfig(object):
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings. When specified, overrides any data fields set via ``Message.data``.
         notification: A ``messaging.WebpushNotification`` to be included in the message (optional).
-        fcm_options: A ``messaging.WebpushFcmOptions`` to be included in the messsage (optional).
+        fcm_options: A ``messaging.WebpushFcmOptions`` instance to be included in the messsage
+            (optional).
 
     .. _Webpush Specification: https://tools.ietf.org/html/rfc8030#section-5
     """

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -42,7 +42,7 @@ def testdata():
         return json.load(dino_file)
 
 @pytest.fixture(scope='module')
-def testref(update_rules):
+def testref(update_rules, testdata):
     """Adds the necessary DB indices, and sets the initial values.
 
     This fixture is attached to the module scope, and therefore is guaranteed to run only once
@@ -53,7 +53,7 @@ def testref(update_rules):
     """
     del update_rules
     ref = db.reference('_adminsdk/python/dinodb')
-    ref.set(testdata())
+    ref.set(testdata)
     return ref
 
 

--- a/integration/test_firestore.py
+++ b/integration/test_firestore.py
@@ -14,9 +14,6 @@
 
 """Integration tests for firebase_admin.firestore module."""
 import datetime
-import pytest
-
-from google.cloud import exceptions # pylint: disable=import-error,no-name-in-module
 
 from firebase_admin import firestore
 

--- a/integration/test_firestore.py
+++ b/integration/test_firestore.py
@@ -36,8 +36,7 @@ def test_firestore():
     assert data == expected
 
     doc.delete()
-    with pytest.raises(exceptions.NotFound):
-        doc.get()
+    assert doc.get().exists is False
 
 def test_server_timestamp():
     client = firestore.client()


### PR DESCRIPTION
* Latest `pytest` does not allow calling fixtures as functions. Therefore we must inject them into the target functions as arguments.
* Firestore has changed behavior wrt how non-existing docs are handled. We need to update the affected integration test case.