### PR TITLE
Extending HTTP retries to all methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
--
+- [fixed] Extending HTTP retries to more HTTP methods like POST and PATCH.
 
 # v2.15.1
 

--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -22,11 +22,13 @@ import requests
 from requests.packages.urllib3.util import retry # pylint: disable=import-error
 
 
+_ANY_METHOD = None
+
 # Default retry configuration: Retries once on low-level connection and socket read errors.
 # Retries up to 4 times on HTTP 500 and 503 errors, with exponential backoff. Returns the
 # last response upon exhausting all retries.
 DEFAULT_RETRY_CONFIG = retry.Retry(
-    connect=1, read=1, status=4, status_forcelist=[500, 503],
+    connect=1, read=1, status=4, status_forcelist=[500, 503], method_whitelist=_ANY_METHOD,
     raise_on_status=False, backoff_factor=0.5)
 
 


### PR DESCRIPTION
By default `urllib3` only retries certain HTTP methods: https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST

Lot of our APIs use the POST method and some even use PATCH. Therefore I'm enabling retry support for all HTTP methods.

Related to #248


