### PR TITLE
Migrating Auth API to the new Identity Toolkit endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [added] Migrated the `FirebaseAuth` user management API to the
+- [added] Migrated the `auth` user management API to the
   new Identity Toolkit endpoint.
 - [fixed] Extending HTTP retries to more HTTP methods like POST and PATCH.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [added] Migrated the `FirebaseAuth` user management API to the
+  new Identity Toolkit endpoint.
 - [fixed] Extending HTTP retries to more HTTP methods like POST and PATCH.
 
 # v2.15.1

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -206,7 +206,7 @@ class TokenGenerator(object):
             'validDuration': expires_in,
         }
         try:
-            response = self.client.body('post', 'createSessionCookie', json=payload)
+            response = self.client.body('post', ':createSessionCookie', json=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(COOKIE_CREATE_ERROR, 'Failed to create session cookie', error)
         else:

--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -421,7 +421,7 @@ class UserManager(object):
         if page_token:
             payload['nextPageToken'] = page_token
         try:
-            return self._client.body('get', '/accounts:batchGet', json=payload)
+            return self._client.body('get', '/accounts:batchGet', params=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(USER_DOWNLOAD_ERROR, 'Failed to download user accounts.', error)
 

--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -394,7 +394,7 @@ class UserManager(object):
             raise TypeError('Unsupported keyword arguments: {0}.'.format(kwargs))
 
         try:
-            response = self._client.body('post', 'getAccountInfo', json=payload)
+            response = self._client.body('post', '/accounts:lookup', json=payload)
         except requests.exceptions.RequestException as error:
             msg = 'Failed to get user by {0}: {1}.'.format(key_type, key)
             self._handle_http_error(INTERNAL_ERROR, msg, error)
@@ -421,7 +421,7 @@ class UserManager(object):
         if page_token:
             payload['nextPageToken'] = page_token
         try:
-            return self._client.body('post', 'downloadAccount', json=payload)
+            return self._client.body('get', '/accounts:batchGet', json=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(USER_DOWNLOAD_ERROR, 'Failed to download user accounts.', error)
 
@@ -440,7 +440,7 @@ class UserManager(object):
         }
         payload = {k: v for k, v in payload.items() if v is not None}
         try:
-            response = self._client.body('post', 'signupNewUser', json=payload)
+            response = self._client.body('post', '/accounts', json=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(USER_CREATE_ERROR, 'Failed to create new user.', error)
         else:
@@ -490,7 +490,7 @@ class UserManager(object):
 
         payload = {k: v for k, v in payload.items() if v is not None}
         try:
-            response = self._client.body('post', 'setAccountInfo', json=payload)
+            response = self._client.body('post', '/accounts:update', json=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(
                 USER_UPDATE_ERROR, 'Failed to update user: {0}.'.format(uid), error)
@@ -503,7 +503,7 @@ class UserManager(object):
         """Deletes the user identified by the specified user ID."""
         _auth_utils.validate_uid(uid, required=True)
         try:
-            response = self._client.body('post', 'deleteAccount', json={'localId' : uid})
+            response = self._client.body('post', '/accounts:delete', json={'localId' : uid})
         except requests.exceptions.RequestException as error:
             self._handle_http_error(
                 USER_DELETE_ERROR, 'Failed to delete user: {0}.'.format(uid), error)
@@ -529,7 +529,7 @@ class UserManager(object):
                 raise ValueError('A UserImportHash is required to import users with passwords.')
             payload.update(hash_alg.to_dict())
         try:
-            response = self._client.body('post', 'uploadAccount', json=payload)
+            response = self._client.body('post', '/accounts:batchCreate', json=payload)
         except requests.exceptions.RequestException as error:
             self._handle_http_error(USER_IMPORT_ERROR, 'Failed to import users.', error)
         else:

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -466,13 +466,19 @@ class AuthError(Exception):
 class _AuthService(object):
     """Firebase Authentication service."""
 
-    ID_TOOLKIT_URL = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/'
+    ID_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1/projects/'
 
     def __init__(self, app):
         credential = app.credential.get_credential()
         version_header = 'Python/Admin/{0}'.format(firebase_admin.__version__)
+
+        if not app.project_id:
+            raise ValueError("Project ID is required to access the auth service. Use a service account credential or "
+            + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
+            + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.")
+
         client = _http_client.JsonHttpClient(
-            credential=credential, base_url=self.ID_TOOLKIT_URL,
+            credential=credential, base_url=self.ID_TOOLKIT_URL + app.project_id,
             headers={'X-Client-Version': version_header})
         self._token_generator = _token_gen.TokenGenerator(app, client)
         self._token_verifier = _token_gen.TokenVerifier(app)

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -473,9 +473,10 @@ class _AuthService(object):
         version_header = 'Python/Admin/{0}'.format(firebase_admin.__version__)
 
         if not app.project_id:
-            raise ValueError("Project ID is required to access the auth service. Use a service account credential or "
-            + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
-            + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.")
+            raise ValueError("""Project ID is required to access the auth service.
+            1. Use a service account credential, or
+            2. set the project ID explicitly via FirebaseOptions, or
+            3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
         client = _http_client.JsonHttpClient(
             credential=credential, base_url=self.ID_TOOLKIT_URL + app.project_id,

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -475,7 +475,7 @@ class _AuthService(object):
         if not app.project_id:
             raise ValueError("""Project ID is required to access the auth service.
             1. Use a service account credential, or
-            2. set the project ID explicitly via FirebaseOptions, or
+            2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
         client = _http_client.JsonHttpClient(

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -65,6 +65,7 @@ def test_custom_token_without_service_account(api_key):
     cred = CredentialWrapper.from_existing_credential(google_cred)
     custom_app = firebase_admin.initialize_app(cred, {
         'serviceAccountId': google_cred.service_account_email,
+        'projectId': firebase_admin.get_app().project_id
     }, 'temp-app')
     try:
         custom_token = auth.create_custom_token('user1', app=custom_app)

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -25,6 +25,8 @@ from firebase_admin import _auth_utils
 from firebase_admin import _user_import
 from firebase_admin import _user_mgt
 from tests import testutils
+from urllib3.util import parse_url
+from requests.compat import urlencode
 
 
 INVALID_STRINGS = [None, '', 0, 1, True, False, list(), tuple(), dict()]
@@ -628,8 +630,8 @@ class TestListUsers(object):
         if expected is None:
             expected = {'maxResults' : 1000}
         assert len(recorder) == 1
-        request = json.loads(recorder[0].body.decode())
-        assert request == expected
+        request = parse_url(recorder[0].url).query
+        assert request == urlencode(query=expected)
 
 
 class TestUserProvider(object):

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -26,10 +26,7 @@ from firebase_admin import _user_import
 from firebase_admin import _user_mgt
 from tests import testutils
 
-try:
-    from urllib.parse import urlsplit, parse_qsl
-except ImportError:
-    from urlparse import urlsplit, parse_qsl
+from six.moves import urllib
 
 
 INVALID_STRINGS = [None, '', 0, 1, True, False, list(), tuple(), dict()]
@@ -633,7 +630,7 @@ class TestListUsers(object):
         if expected is None:
             expected = {'maxResults' : '1000'}
         assert len(recorder) == 1
-        request = dict(parse_qsl(urlsplit(recorder[0].url).query))
+        request = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(recorder[0].url).query))
         assert request == expected
 
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -87,6 +87,14 @@ def _check_user_record(user, expected_uid='testuser'):
     assert provider.provider_id == 'phone'
 
 
+class TestAuthServiceInitialization(object):
+
+    def test_fail_on_no_project_id(self):
+        app = firebase_admin.initialize_app(testutils.MockCredential(), name='userMgt2')
+        with pytest.raises(ValueError):
+            auth._get_auth_service(app)
+        firebase_admin.delete_app(app)
+
 class TestUserRecord(object):
 
     # Input dict must be non-empty, and must not contain unsupported keys.


### PR DESCRIPTION
Using the new Identity Toolkit REST endpoint for user management features. This is as per corresponding change in java (firebase/firebase-admin-java#220) and node SDKs.