### PR TITLE
Firebase auth Email Action Links API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [added] Added `generate_password_reset_link()`, 
+  `generate_email_verification_link()` and `generate_email_sign_in_link()`
+  methods to the `auth` API.
 - [added] Migrated the `auth` user management API to the
   new Identity Toolkit endpoint.
 - [fixed] Extending HTTP retries to more HTTP methods like POST and PATCH.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - [added] Added `generate_password_reset_link()`, 
-  `generate_email_verification_link()` and `generate_email_sign_in_link()`
+  `generate_email_verification_link()` and `generate_sign_in_with_email_link()`
   methods to the `auth` API.
 - [added] Migrated the `auth` user management API to the
   new Identity Toolkit endpoint.

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -26,7 +26,7 @@ RESERVED_CLAIMS = set([
     'acr', 'amr', 'at_hash', 'aud', 'auth_time', 'azp', 'cnf', 'c_hash', 'exp', 'iat',
     'iss', 'jti', 'nbf', 'nonce', 'sub', 'firebase',
 ])
-VALID_ACTION_TYPE = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'])
+VALID_EMAIL_ACTION_TYPES = set(['VERIFY_EMAIL', 'EMAIL_SIGNIN', 'PASSWORD_RESET'])
 
 
 def validate_uid(uid, required=False):
@@ -184,7 +184,7 @@ def validate_custom_claims(custom_claims, required=False):
     return claims_str
 
 def validate_action_type(action_type):
-    if action_type not in VALID_ACTION_TYPE:
+    if action_type not in VALID_EMAIL_ACTION_TYPES:
         raise ValueError('Invalid action type provided action_type: {0}. \
-            Valid values are {1}'.format(action_type, VALID_ACTION_TYPE))
+            Valid values are {1}'.format(action_type, ', '.join(VALID_EMAIL_ACTION_TYPES)))
     return action_type

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -183,73 +183,8 @@ def validate_custom_claims(custom_claims, required=False):
             'Claim "{0}" is reserved, and must not be set.'.format(invalid_claims.pop()))
     return claims_str
 
-def validate_action_code_settings(settings):
-    """ Validates the provided action code settings for email link generation and
-    populates the REST api parameters.
-
-    settings - dict provided to build the ActionCodeSettings object
-    returns  - dict of parameters to be passed for link gereration.
-    """
-    if not isinstance(settings, dict):
-        raise ValueError('Invalid data argument: {0}. Must be a dictionary.'.format(settings))
-
-    parameters = {}
-    # Validate url
-    url = settings.get('url', None)
-    if url:
-        try:
-            parsed = urllib.parse.urlparse(url)
-            if not parsed.netloc:
-                raise ValueError('Malformed photo URL: "{0}".'.format(url))
-            parameters['continueUrl'] = url
-        except Exception:
-            raise ValueError('Malformed photo URL: "{0}".'.format(url))
-
-    # Validate boolean types
-    for field in ['handle_code_in_app', 'android_install_app']:
-        if not isinstance(settings.get(field, False), bool):
-            raise ValueError('Invalid value provided for {0}: {1}'.format(
-                field, settings.get(field, False)))
-
-    # Validate string types
-    for field in ['dynamic_link_domain', 'ios_bundle_id',
-                  'android_package_name', 'android_minimum_version']:
-        if not isinstance(settings.get(field, ''), six.string_types):
-            raise ValueError('Invalid value provided for {0}: {1}'.format(
-                field, settings.get(field, False)))
-
-    # handle_code_in_app
-    handle_code_in_app = settings.get('handle_code_in_app', False)
-    if handle_code_in_app:
-        parameters['canHandleCodeInApp'] = handle_code_in_app
-
-    # dynamic_link_domain
-    dynamic_link_domain = settings.get('dynamic_link_domain', None)
-    if dynamic_link_domain:
-        parameters['dynamicLinkDomain'] = dynamic_link_domain
-
-    # ios_bundle_id
-    ios_bundle_id = settings.get('ios_bundle_id', None)
-    if ios_bundle_id:
-        parameters['iosBundleId'] = ios_bundle_id
-
-    # android_* attributes
-    android_package_name = settings.get('android_package_name', None)
-    android_minimum_version = settings.get('android_minimum_version', None)
-    android_install_app = settings.get('android_install_app', False)
-    if (android_minimum_version or android_install_app) and not android_package_name:
-        raise ValueError("Android package name is required when specifying other Android settings")
-
-    if android_package_name:
-        parameters['androidPackageName'] = android_package_name
-    if android_minimum_version:
-        parameters['androidMinimumVersion'] = android_minimum_version
-    if android_install_app:
-        parameters['androidInstallApp'] = android_install_app
-    return parameters
-
 def validate_action_type(action_type):
-    if not action_type in VALID_ACTION_TYPE:
+    if action_type not in VALID_ACTION_TYPE:
         raise ValueError('Invalid action type provided action_type: {0}. \
             Valid values are {1}'.format(action_type, VALID_ACTION_TYPE))
     return action_type

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -54,7 +54,7 @@ __all__ = [
     'delete_user',
     'generate_password_reset_link',
     'generate_email_verification_link',
-    'generate_email_sign_in_link',
+    'generate_sign_in_with_email_link',
     'get_user',
     'get_user_by_email',
     'get_user_by_phone_number',
@@ -453,13 +453,13 @@ def import_users(users, hash_alg=None, app=None):
     except _user_mgt.ApiCallError as error:
         raise AuthError(error.code, str(error), error.detail)
 
-def generate_password_reset_link(email, settings=None, app=None):
+def generate_password_reset_link(email, action_code_settings=None, app=None):
     """Generates the out-of-band email action link for password reset flows for the specified email
     address.
 
     Args:
         email: The email of the user whose password is to be reset.
-        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+        action_code_settings: ``ActionCodeSettings`` instance (optional). Defines whether
             the link is to be handled by a mobile app and the additional state information to be
             passed in the deep link, etc.
         app: An App instance (optional).
@@ -472,17 +472,18 @@ def generate_password_reset_link(email, settings=None, app=None):
     """
     user_manager = _get_auth_service(app).user_manager
     try:
-        return user_manager.generate_email_action_link('PASSWORD_RESET', email, settings)
+        return user_manager.generate_email_action_link('PASSWORD_RESET', email,
+                                                       action_code_settings=action_code_settings)
     except _user_mgt.ApiCallError as error:
         raise AuthError(error.code, str(error), error.detail)
 
-def generate_email_verification_link(email, settings=None, app=None):
+def generate_email_verification_link(email, action_code_settings=None, app=None):
     """Generates the out-of-band email action link for email verification flows for the specified
     email address.
 
     Args:
         email: The email of the user to be verified.
-        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+        action_code_settings: ``ActionCodeSettings`` instance (optional). Defines whether
             the link is to be handled by a mobile app and the additional state information to be
             passed in the deep link, etc.
         app: An App instance (optional).
@@ -495,17 +496,18 @@ def generate_email_verification_link(email, settings=None, app=None):
     """
     user_manager = _get_auth_service(app).user_manager
     try:
-        return user_manager.generate_email_action_link('VERIFY_EMAIL', email, settings)
+        return user_manager.generate_email_action_link('VERIFY_EMAIL', email,
+                                                       action_code_settings=action_code_settings)
     except _user_mgt.ApiCallError as error:
         raise AuthError(error.code, str(error), error.detail)
 
-def generate_email_sign_in_link(email, settings=None, app=None):
+def generate_sign_in_with_email_link(email, action_code_settings, app=None):
     """Generates the out-of-band email action link for email link sign-in flows, using the action
     code settings provided.
 
     Args:
         email: The email of the user signing in.
-        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+        action_code_settings: ``ActionCodeSettings`` instance. Defines whether
             the link is to be handled by a mobile app and the additional state information to be
             passed in the deep link, etc.
         app: An App instance (optional).
@@ -518,7 +520,8 @@ def generate_email_sign_in_link(email, settings=None, app=None):
     """
     user_manager = _get_auth_service(app).user_manager
     try:
-        return user_manager.generate_email_action_link('EMAIL_SIGNIN', email, settings)
+        return user_manager.generate_email_action_link('EMAIL_SIGNIN', email,
+                                                       action_code_settings=action_code_settings)
     except _user_mgt.ApiCallError as error:
         raise AuthError(error.code, str(error), error.detail)
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -461,7 +461,7 @@ def generate_password_reset_link(email, action_code_settings=None, app=None):
         email: The email of the user whose password is to be reset.
         action_code_settings: ``ActionCodeSettings`` instance (optional). Defines whether
             the link is to be handled by a mobile app and the additional state information to be
-            passed in the deep link, etc.
+            passed in the deep link.
         app: An App instance (optional).
     Returns:
         link: The password reset link created by API
@@ -485,7 +485,7 @@ def generate_email_verification_link(email, action_code_settings=None, app=None)
         email: The email of the user to be verified.
         action_code_settings: ``ActionCodeSettings`` instance (optional). Defines whether
             the link is to be handled by a mobile app and the additional state information to be
-            passed in the deep link, etc.
+            passed in the deep link.
         app: An App instance (optional).
     Returns:
         link: The email verification link created by API
@@ -509,7 +509,7 @@ def generate_sign_in_with_email_link(email, action_code_settings, app=None):
         email: The email of the user signing in.
         action_code_settings: ``ActionCodeSettings`` instance. Defines whether
             the link is to be handled by a mobile app and the additional state information to be
-            passed in the deep link, etc.
+            passed in the deep link.
         app: An App instance (optional).
     Returns:
         link: The email sign in link created by API

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -35,6 +35,7 @@ _SESSION_COOKIE_REVOKED = 'SESSION_COOKIE_REVOKED'
 
 
 __all__ = [
+    'ActionCodeSettings',
     'AuthError',
     'ErrorInfo',
     'ExportedUserRecord',
@@ -51,6 +52,9 @@ __all__ = [
     'create_session_cookie',
     'create_user',
     'delete_user',
+    'generate_password_reset_link',
+    'generate_email_verification_link',
+    'generate_email_sign_in_link',
     'get_user',
     'get_user_by_email',
     'get_user_by_phone_number',
@@ -63,6 +67,7 @@ __all__ = [
     'verify_session_cookie',
 ]
 
+ActionCodeSettings = _user_mgt.ActionCodeSettings
 ErrorInfo = _user_import.ErrorInfo
 ExportedUserRecord = _user_mgt.ExportedUserRecord
 ListUsersPage = _user_mgt.ListUsersPage
@@ -445,6 +450,75 @@ def import_users(users, hash_alg=None, app=None):
     try:
         result = user_manager.import_users(users, hash_alg)
         return UserImportResult(result, len(users))
+    except _user_mgt.ApiCallError as error:
+        raise AuthError(error.code, str(error), error.detail)
+
+def generate_password_reset_link(email, settings=None, app=None):
+    """Generates the out-of-band email action link for password reset flows for the specified email
+    address.
+
+    Args:
+        email: The email of the user whose password is to be reset.
+        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+            the link is to be handled by a mobile app and the additional state information to be
+            passed in the deep link, etc.
+        app: An App instance (optional).
+    Returns:
+        link: The password reset link created by API
+
+    Raises:
+        ValueError: If the provided arguments are invalid
+        AuthError: If an error occurs while generating the link
+    """
+    user_manager = _get_auth_service(app).user_manager
+    try:
+        return user_manager.generate_email_action_link('PASSWORD_RESET', email, settings)
+    except _user_mgt.ApiCallError as error:
+        raise AuthError(error.code, str(error), error.detail)
+
+def generate_email_verification_link(email, settings=None, app=None):
+    """Generates the out-of-band email action link for email verification flows for the specified
+    email address.
+
+    Args:
+        email: The email of the user to be verified.
+        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+            the link is to be handled by a mobile app and the additional state information to be
+            passed in the deep link, etc.
+        app: An App instance (optional).
+    Returns:
+        link: The email verification link created by API
+
+    Raises:
+        ValueError: If the provided arguments are invalid
+        AuthError: If an error occurs while generating the link
+    """
+    user_manager = _get_auth_service(app).user_manager
+    try:
+        return user_manager.generate_email_action_link('VERIFY_EMAIL', email, settings)
+    except _user_mgt.ApiCallError as error:
+        raise AuthError(error.code, str(error), error.detail)
+
+def generate_email_sign_in_link(email, settings=None, app=None):
+    """Generates the out-of-band email action link for email link sign-in flows, using the action
+    code settings provided.
+
+    Args:
+        email: The email of the user signing in.
+        settings: dict or ``ActionCodeSettings`` instance (optional). Defines whether
+            the link is to be handled by a mobile app and the additional state information to be
+            passed in the deep link, etc.
+        app: An App instance (optional).
+    Returns:
+        link: The email sign in link created by API
+
+    Raises:
+        ValueError: If the provided arguments are invalid
+        AuthError: If an error occurs while generating the link
+    """
+    user_manager = _get_auth_service(app).user_manager
+    try:
+        return user_manager.generate_email_action_link('EMAIL_SIGNIN', email, settings)
     except _user_mgt.ApiCallError as error:
         raise AuthError(error.code, str(error), error.detail)
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -18,6 +18,7 @@ import datetime
 import random
 import time
 import uuid
+import six
 
 import pytest
 import requests
@@ -371,6 +372,44 @@ def test_import_users_with_password(api_key):
         assert len(id_token) > 0
     finally:
         auth.delete_user(uid)
+
+@pytest.fixture
+def action_code_settings():
+    data = {
+        'url': 'http://localhost',
+    }
+    return auth.ActionCodeSettings(data)
+
+def _validate_link_url(link):
+    assert isinstance(link, six.string_types)
+    six.moves.urllib.parse.urlparse(link)
+
+def test_password_reset(new_user_with_params):
+    link = auth.generate_password_reset_link(new_user_with_params.email)
+    _validate_link_url(link)
+
+def test_email_verification(new_user_with_params):
+    link = auth.generate_email_verification_link(new_user_with_params.email)
+    _validate_link_url(link)
+
+def test_email_sign_in(new_user_with_params):
+    link = auth.generate_email_sign_in_link(new_user_with_params.email)
+    _validate_link_url(link)
+
+def test_password_reset_with_settings(new_user_with_params, action_code_settings):
+    link = auth.generate_password_reset_link(new_user_with_params.email,
+                                             settings=action_code_settings)
+    _validate_link_url(link)
+
+def test_email_verification_with_settings(new_user_with_params, action_code_settings):
+    link = auth.generate_email_verification_link(new_user_with_params.email,
+                                                 settings=action_code_settings)
+    _validate_link_url(link)
+
+def test_email_sign_in_with_settings(new_user_with_params, action_code_settings):
+    link = auth.generate_email_sign_in_link(new_user_with_params.email,
+                                            settings=action_code_settings)
+    _validate_link_url(link)
 
 
 class CredentialWrapper(credentials.Base):

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -419,7 +419,7 @@ def test_password_reset(new_user_email_unverified, api_key):
     link = auth.generate_password_reset_link(new_user_email_unverified.email)
     assert isinstance(link, six.string_types)
     query_dict = _extract_link_params(link)
-    user_email = _reset_password(query_dict['oobCode'], "newPassword", api_key)
+    user_email = _reset_password(query_dict['oobCode'], 'newPassword', api_key)
     assert new_user_email_unverified.email == user_email
     # password reset also set email_verified to True
     assert auth.get_user(new_user_email_unverified.uid).email_verified
@@ -439,7 +439,7 @@ def test_password_reset_with_settings(new_user_email_unverified, api_key):
     assert isinstance(link, six.string_types)
     query_dict = _extract_link_params(link)
     assert query_dict['continueUrl'] == ACTION_LINK_CONTINUE_URL
-    user_email = _reset_password(query_dict['oobCode'], "newPassword", api_key)
+    user_email = _reset_password(query_dict['oobCode'], 'newPassword', api_key)
     assert new_user_email_unverified.email == user_email
     # password reset also set email_verified to True
     assert auth.get_user(new_user_email_unverified.uid).email_verified
@@ -464,7 +464,7 @@ def test_email_sign_in_with_settings(new_user_email_unverified, api_key):
     assert query_dict['continueUrl'] == ACTION_LINK_CONTINUE_URL
     oob_code = query_dict['oobCode']
     id_token = _sign_in_with_email_link(new_user_email_unverified.email, oob_code, api_key)
-    assert id_token
+    assert id_token is not None and len(id_token) > 0
     assert auth.get_user(new_user_email_unverified.uid).email_verified
 
 class CredentialWrapper(credentials.Base):

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -375,10 +375,7 @@ def test_import_users_with_password(api_key):
 
 @pytest.fixture
 def action_code_settings():
-    data = {
-        'url': 'http://localhost',
-    }
-    return auth.ActionCodeSettings(data)
+    return auth.ActionCodeSettings('http://localhost')
 
 def _validate_link_url(link):
     assert isinstance(link, six.string_types)
@@ -392,23 +389,19 @@ def test_email_verification(new_user_with_params):
     link = auth.generate_email_verification_link(new_user_with_params.email)
     _validate_link_url(link)
 
-def test_email_sign_in(new_user_with_params):
-    link = auth.generate_email_sign_in_link(new_user_with_params.email)
-    _validate_link_url(link)
-
 def test_password_reset_with_settings(new_user_with_params, action_code_settings):
     link = auth.generate_password_reset_link(new_user_with_params.email,
-                                             settings=action_code_settings)
+                                             action_code_settings=action_code_settings)
     _validate_link_url(link)
 
 def test_email_verification_with_settings(new_user_with_params, action_code_settings):
     link = auth.generate_email_verification_link(new_user_with_params.email,
-                                                 settings=action_code_settings)
+                                                 action_code_settings=action_code_settings)
     _validate_link_url(link)
 
 def test_email_sign_in_with_settings(new_user_with_params, action_code_settings):
-    link = auth.generate_email_sign_in_link(new_user_with_params.email,
-                                            settings=action_code_settings)
+    link = auth.generate_sign_in_with_email_link(new_user_with_params.email,
+                                                 action_code_settings=action_code_settings)
     _validate_link_url(link)
 
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -26,6 +26,7 @@ from firebase_admin import _user_import
 from firebase_admin import _user_mgt
 from tests import testutils
 
+import six
 from six.moves import urllib
 
 
@@ -972,3 +973,203 @@ class TestRevokeRefreshTokkens(object):
         assert request['localId'] == 'testuser'
         assert int(request['validSince']) >= int(before_time)
         assert int(request['validSince']) <= int(after_time)
+
+class TestActionCodeSetting(object):
+
+    # Input dict must be non-empty, and must not contain unsupported keys.
+    @pytest.mark.parametrize('data', ['foo', 12, True, {'foo':'bar'}])
+    def test_invalid_settings(self, data):
+        with pytest.raises(ValueError):
+            auth.ActionCodeSettings(data)
+
+    def test_valid_data(self):
+        data = {
+            'url': 'http://localhost',
+            'handle_code_in_app': True,
+            'dynamic_link_domain': 'http://testly',
+            'ios_bundle_id': 'test.bundle',
+            'android_package_name': 'test.bundle',
+            'android_minimum_version': '7',
+            'android_install_app': True,
+        }
+        settings = auth.ActionCodeSettings(data)
+        parameters = settings.to_parameters_dict()
+        assert parameters['continueUrl'] == data['url']
+        assert parameters['canHandleCodeInApp'] == data['handle_code_in_app']
+        assert parameters['dynamicLinkDomain'] == data['dynamic_link_domain']
+        assert parameters['iosBundleId'] == data['ios_bundle_id']
+        assert parameters['androidPackageName'] == data['android_package_name']
+        assert parameters['androidMinimumVersion'] == data['android_minimum_version']
+        assert parameters['androidInstallApp'] == data['android_install_app']
+
+    def test_empty_dict(self):
+        data = {}
+        settings = auth.ActionCodeSettings(data)
+        parameters = settings.to_parameters_dict()
+        assert parameters == {}
+
+    def test_no_parameters(self):
+        settings = auth.ActionCodeSettings()
+        parameters = settings.to_parameters_dict()
+        assert parameters == {}
+
+    def test_setters(self):
+        data = {
+            'url': 'http://localhost',
+            'handle_code_in_app': True,
+            'dynamic_link_domain': 'http://testly',
+            'ios_bundle_id': 'test.bundle',
+            'android_package_name': 'test.bundle',
+            'android_minimum_version': '7',
+            'android_install_app': True,
+        }
+        settings = auth.ActionCodeSettings()
+        for key in six.iterkeys(data):
+            setattr(settings, key, data[key])
+        parameters = settings.to_parameters_dict()
+        assert parameters['continueUrl'] == data['url']
+        assert parameters['canHandleCodeInApp'] == data['handle_code_in_app']
+        assert parameters['dynamicLinkDomain'] == data['dynamic_link_domain']
+        assert parameters['iosBundleId'] == data['ios_bundle_id']
+        assert parameters['androidPackageName'] == data['android_package_name']
+        assert parameters['androidMinimumVersion'] == data['android_minimum_version']
+        assert parameters['androidInstallApp'] == data['android_install_app']
+
+    def test_empty_url(self):
+        settings = auth.ActionCodeSettings()
+        settings.url = ''
+        parameters = settings.to_parameters_dict()
+        assert parameters == {}
+
+    @pytest.mark.parametrize('data', [{'url':'badurl'},
+                                      {'handle_code_in_app':'nonboolean'},
+                                      {'android_install_app':'nonboolean'},
+                                      {'dynamic_link_domain': False},
+                                      {'ios_bundle_id':11},
+                                      {'android_package_name':dict()},
+                                      {'android_minimum_version':tuple()},
+                                      {'android_minimum_version':'7'},
+                                      {'android_install_app': True}])
+    def test_bad_data(self, data):
+        settings = auth.ActionCodeSettings(data)
+        with pytest.raises(ValueError):
+            settings.to_parameters_dict()
+
+
+@pytest.fixture(scope='module')
+def action_code_settings():
+    data = {
+        'url': 'http://localhost',
+        'handle_code_in_app': True,
+        'dynamic_link_domain': 'http://testly',
+        'ios_bundle_id': 'test.bundle',
+        'android_package_name': 'test.bundle',
+        'android_minimum_version': '7',
+        'android_install_app': True,
+    }
+    return auth.ActionCodeSettings(data)
+
+class TestGenerateEmailActionLink(object):
+
+    def _validate_request(self, request, settings=None):
+        assert request['email'] == "test@test.com"
+        assert request['returnOobLink']
+        if settings:
+            assert request['continueUrl'] == settings.url
+            assert request['canHandleCodeInApp'] == settings.handle_code_in_app
+            assert request['dynamicLinkDomain'] == settings.dynamic_link_domain
+            assert request['iosBundleId'] == settings.ios_bundle_id
+            assert request['androidPackageName'] == settings.android_package_name
+            assert request['androidMinimumVersion'] == settings.android_minimum_version
+            assert request['androidInstallApp'] == settings.android_install_app
+
+    def test_email_signin_no_settings(self, user_mgt_app):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_email_sign_in_link("test@test.com", app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "EMAIL_SIGNIN"
+        self._validate_request(request)
+
+
+    def test_email_verification_no_settings(self, user_mgt_app):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_email_verification_link("test@test.com", app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "VERIFY_EMAIL"
+        self._validate_request(request)
+
+    def test_password_reset_no_settings(self, user_mgt_app):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_password_reset_link("test@test.com", app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "PASSWORD_RESET"
+        self._validate_request(request)
+
+    def test_email_signin_with_settings(self, user_mgt_app, action_code_settings):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_email_sign_in_link("test@test.com",
+                                                settings=action_code_settings,
+                                                app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "EMAIL_SIGNIN"
+        self._validate_request(request, action_code_settings)
+
+    def test_email_verification_with_settings(self, user_mgt_app, action_code_settings):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_email_verification_link("test@test.com",
+                                                     settings=action_code_settings,
+                                                     app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "VERIFY_EMAIL"
+        self._validate_request(request, action_code_settings)
+
+    def test_password_reset_with_settings(self, user_mgt_app, action_code_settings):
+        _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        link = auth.generate_password_reset_link("test@test.com",
+                                                 settings=action_code_settings,
+                                                 app=user_mgt_app)
+        request = json.loads(recorder[0].body.decode())
+
+        assert link == "https://testlink"
+        assert request['requestType'] == "PASSWORD_RESET"
+        self._validate_request(request, action_code_settings)
+
+    @pytest.mark.parametrize('func', [
+        auth.generate_email_sign_in_link,
+        auth.generate_email_verification_link,
+        auth.generate_password_reset_link,
+    ])
+    def test_api_call_failure(self, user_mgt_app, func):
+        _instrument_user_manager(user_mgt_app, 500, '{"error":"dummy error"}')
+        with pytest.raises(auth.AuthError):
+            func("test@test.com", app=user_mgt_app)
+
+    @pytest.mark.parametrize('func', [
+        auth.generate_email_sign_in_link,
+        auth.generate_email_verification_link,
+        auth.generate_password_reset_link,
+    ])
+    def test_api_call_no_link(self, user_mgt_app, func):
+        _instrument_user_manager(user_mgt_app, 200, '{}')
+        with pytest.raises(auth.AuthError):
+            func("test@test.com", app=user_mgt_app)
+
+    @pytest.mark.parametrize('func', [
+        auth.generate_email_sign_in_link,
+        auth.generate_email_verification_link,
+        auth.generate_password_reset_link,
+    ])
+    def test_bad_settings_data(self, user_mgt_app, func):
+        _instrument_user_manager(user_mgt_app, 200, '{"oobLink":"https://testlink"}')
+        with pytest.raises(ValueError):
+            func("test@test.com", app=user_mgt_app, settings=1234)


### PR DESCRIPTION
Added `generate_password_reset_link()`, 
  `generate_email_verification_link()` and `generate_email_sign_in_link()`
  methods to the `auth` API.
