### PR TITLE
Add messaging send_all and send_multicast functions

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -54,6 +54,33 @@ class Message(object):
         self.condition = condition
 
 
+class MulticastMessage(object):
+    """A message that can be sent to multiple tokens via Firebase Cloud Messaging.
+
+    Contains payload information as well as recipient information. In particular, the message must
+    contain exactly one of token, topic or condition fields.
+
+    Args:
+        tokens: A list of registration token of the device to which the message should be sent.
+        data: A dictionary of data fields (optional). All keys and values in the dictionary must be
+            strings.
+        notification: An instance of ``messaging.Notification`` (optional).
+        android: An instance of ``messaging.AndroidConfig`` (optional).
+        webpush: An instance of ``messaging.WebpushConfig`` (optional).
+        apns: An instance of ``messaging.ApnsConfig`` (optional).
+    """
+    def __init__(self, tokens, data=None, notification=None, android=None, webpush=None, apns=None):
+        _Validators.check_string_list('MulticastMessage.tokens', tokens)
+        if len(tokens) > 100:
+            raise ValueError('MulticastMessage.tokens must contain less than 100 tokens.')
+        self.tokens = tokens
+        self.data = data
+        self.notification = notification
+        self.android = android
+        self.webpush = webpush
+        self.apns = apns
+
+
 class Notification(object):
     """A notification that can be included in a message.
 
@@ -150,7 +177,7 @@ class WebpushConfig(object):
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings. When specified, overrides any data fields set via ``Message.data``.
         notification: A ``messaging.WebpushNotification`` to be included in the message (optional).
-        fcm_options: A ``messaging.WebpushFcmOptions`` instance to be included in the messsage
+        fcm_options: A ``messaging.WebpushFcmOptions`` instance to be included in the message
             (optional).
 
     .. _Webpush Specification: https://tools.ietf.org/html/rfc8030#section-5

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -72,7 +72,7 @@ class MulticastMessage(object):
     def __init__(self, tokens, data=None, notification=None, android=None, webpush=None, apns=None):
         _Validators.check_string_list('MulticastMessage.tokens', tokens)
         if len(tokens) > 100:
-            raise ValueError('MulticastMessage.tokens must contain less than 100 tokens.')
+            raise ValueError('MulticastMessage.tokens must not contain more than 100 tokens.')
         self.tokens = tokens
         self.data = data
         self.notification = notification

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -100,7 +100,7 @@ def send(message, dry_run=False, app=None):
     return _get_messaging_service(app).send(message, dry_run)
 
 def send_all(messages, dry_run=False, app=None):
-    """Batch sends the given messages via Firebase Cloud Messaging (FCM).
+    """Sends the given list of messages via Firebase Cloud Messaging as a single batch.
 
     If the ``dry_run`` mode is enabled, the message will not be actually delivered to the
     recipients. Instead FCM performs all the usual validations, and emulates the send operation.
@@ -258,10 +258,7 @@ class BatchResponse(object):
 
     def __init__(self, responses):
         self._responses = responses
-        self._success_count = 0
-        for response in responses:
-            if response.success:
-                self._success_count += 1
+        self._success_count = len([resp for resp in responses if resp.success])
 
     @property
     def responses(self):
@@ -455,7 +452,7 @@ class _MessagingService(object):
 
     def _postproc(self, resp, body):
         if resp.status == 200:
-            return json.loads(body)
+            return json.loads(body.decode())
         else:
             raise Exception('unexpected response')
 
@@ -498,7 +495,7 @@ class _MessagingService(object):
 
         data = {}
         try:
-            parsed_body = json.loads(error.content)
+            parsed_body = json.loads(error.content.decode())
             if isinstance(parsed_body, dict):
                 data = parsed_body
         except ValueError:

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -379,6 +379,8 @@ class _MessagingService(object):
         """Sends the given messages to FCM via the batch API."""
         if not isinstance(messages, list):
             raise ValueError('Messages must be an list of messaging.Message instances.')
+        if len(messages) > 100:
+            raise ValueError('send_all messages must not contain more than 100 messages.')
 
         responses = []
 

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -454,16 +454,7 @@ class _MessagingService(object):
 
     def _postproc(self, resp, body):
         """Handle response from batch API request."""
-        if resp.status is not 200:
-            data = {}
-            try:
-                parsed_body = json.loads(body.decode())
-                if isinstance(parsed_body, dict):
-                    data = parsed_body
-            except ValueError:
-                pass
-            code, msg = _MessagingService._parse_fcm_error(data, body, resp.status)
-            raise ApiCallError(code, msg)
+        # This only gets called for 2xx responses.
         return json.loads(body.decode())
 
     def _handle_fcm_error(self, error):

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -453,6 +453,7 @@ class _MessagingService(object):
         return data
 
     def _postproc(self, resp, body):
+        """Handle response from batch API request."""
         if resp.status is not 200:
             data = {}
             try:

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -452,7 +452,7 @@ class _MessagingService(object):
             data['validate_only'] = True
         return data
 
-    def _postproc(self, resp, body):
+    def _postproc(self, _, body):
         """Handle response from batch API request."""
         # This only gets called for 2xx responses.
         return json.loads(body.decode())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tox >= 3.6.0
 
 cachecontrol >= 0.12.4
 google-api-core[grpc] >= 1.7.0, < 2.0.0dev; platform.python_implementation != 'PyPy'
+google-api-python-client >= 1.7.8
 google-cloud-firestore >= 0.31.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.13.0
 six >= 1.6.1

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ long_description = ('The Firebase Admin Python SDK enables server-side (backend)
 install_requires = [
     'cachecontrol>=0.12.4',
     'google-api-core[grpc] >= 1.7.0, < 2.0.0dev; platform.python_implementation != "PyPy"',
+    'google-api-python-client >= 1.7.8',
     'google-cloud-firestore>=0.31.0; platform.python_implementation != "PyPy"',
     'google-cloud-storage>=1.13.0',
     'six>=1.6.1'

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -55,13 +55,13 @@ class TestMulticastMessage(object):
 
     def test_tokens_over_one_hundred(self):
         with pytest.raises(ValueError) as excinfo:
-            messaging.MulticastMessage(tokens=['token' for i in xrange(0, 101)])
+            messaging.MulticastMessage(tokens=['token' for _ in range(0, 101)])
         expected = 'MulticastMessage.tokens must not contain more than 100 tokens.'
         assert str(excinfo.value) == expected
 
     def test_tokens_type(self):
         messaging.MulticastMessage(tokens=['token'])
-        messaging.MulticastMessage(tokens=['token' for i in xrange(0, 100)])
+        messaging.MulticastMessage(tokens=['token' for _ in range(0, 100)])
 
 
 class TestMessageEncoder(object):
@@ -1401,7 +1401,7 @@ class TestSendAll(TestBatch):
     def test_invalid_over_one_hundred(self):
         msg = messaging.Message(topic='foo')
         with pytest.raises(ValueError) as excinfo:
-            messaging.send_all([msg for i in xrange(0, 101)])
+            messaging.send_all([msg for _ in range(0, 101)])
         expected = 'send_all messages must not contain more than 100 messages.'
         assert str(excinfo.value) == expected
 
@@ -1441,7 +1441,7 @@ class TestSendAll(TestBatch):
             payload=self._batch_payload([(200, success_payload), (202, error_payload)]))
         msg = messaging.Message(topic='foo')
         with pytest.raises(messaging.ApiCallError) as excinfo:
-            batch_response = messaging.send_all([msg, msg], dry_run=True)
+            messaging.send_all([msg, msg], dry_run=True)
         assert str(excinfo.value) == 'test error'
         assert str(excinfo.value.code) == 'invalid-argument'
 
@@ -1458,7 +1458,6 @@ class TestSendAll(TestBatch):
         msg = messaging.Message(topic='foo')
         with pytest.raises(messaging.ApiCallError) as excinfo:
             messaging.send_all([msg, msg], dry_run=True)
-        expected = 'send_all messages must not contain more than 100 messages.'
         assert str(excinfo.value) == 'test error'
         assert str(excinfo.value.code) == 'registration-token-not-registered'
 
@@ -1689,7 +1688,7 @@ class TestSendMulticast(TestBatch):
             payload=self._batch_payload([(200, success_payload), (202, error_payload)]))
         msg = messaging.MulticastMessage(tokens=['foo', 'foo'])
         with pytest.raises(messaging.ApiCallError) as excinfo:
-            batch_response = messaging.send_multicast(msg, dry_run=True)
+            messaging.send_multicast(msg, dry_run=True)
         assert str(excinfo.value) == 'test error'
         assert str(excinfo.value.code) == 'invalid-argument'
 
@@ -1788,7 +1787,7 @@ class TestSendMulticast(TestBatch):
         assert str(exception.code) == 'registration-token-not-registered'
 
     @pytest.mark.parametrize('status', HTTP_ERRORS)
-    def test_send_multicast_canonical_error_code(self, status):
+    def test_send_multicast_fcm_error_code(self, status):
         success_payload = json.dumps({'name': 'message-id'})
         error_payload = json.dumps({
             'error': {

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -20,7 +20,6 @@ import numbers
 import pytest
 import six
 
-import googleapiclient
 from googleapiclient.http import HttpMockSequence
 
 import firebase_admin
@@ -1338,7 +1337,9 @@ class TestSend(object):
 
 class TestSendAll(object):
 
-    _PAYLOAD_FORMAT = """--boundary\r\nContent-Type: application/http\r\nContent-ID: <uuid + 1>\r\n\r\nHTTP/1.1 {} Success\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{}\r\n\r\n--boundary--"""
+    _PAYLOAD_FORMAT = """--boundary\r\nContent-Type: application/http\r\n\
+Content-ID: <uuid + 1>\r\n\r\nHTTP/1.1 {} Success\r\n\
+Content-Type: application/json; charset=UTF-8\r\n\r\n{}\r\n\r\n--boundary--"""
     _CLIENT_VERSION = 'fire-admin-python/{0}'.format(firebase_admin.__version__)
 
     @classmethod
@@ -1386,7 +1387,8 @@ class TestSendAll(object):
 
     def test_send_all(self):
         payload = json.dumps({'name': 'message-id'})
-        _ = self._instrument_batch_messaging_service(payload=self._PAYLOAD_FORMAT.format('200', payload))
+        _ = self._instrument_batch_messaging_service(
+            payload=self._PAYLOAD_FORMAT.format('200', payload))
         msg = messaging.Message(topic='foo')
         batch_response = messaging.send_all([msg], dry_run=True)
         assert batch_response.success_count is 1
@@ -1488,7 +1490,7 @@ class TestSendAll(object):
         assert str(excinfo.value.code) == 'invalid-argument'
 
     @pytest.mark.parametrize('status', HTTP_ERRORS)
-    def test_send_all_canonical_error_code(self, status):
+    def test_send_all_batch_canonical_error_code(self, status):
         payload = json.dumps({
             'error': {
                 'status': 'NOT_FOUND',
@@ -1503,7 +1505,7 @@ class TestSendAll(object):
         assert str(excinfo.value.code) == 'registration-token-not-registered'
 
     @pytest.mark.parametrize('status', HTTP_ERRORS)
-    def test_send_all_fcm_error_code(self, status):
+    def test_send_all_batch_fcm_error_code(self, status):
         payload = json.dumps({
             'error': {
                 'status': 'INVALID_ARGUMENT',
@@ -1526,7 +1528,9 @@ class TestSendAll(object):
 
 class TestSendMulticast(object):
 
-    _PAYLOAD_FORMAT = """--boundary\r\nContent-Type: application/http\r\nContent-ID: <uuid + 1>\r\n\r\nHTTP/1.1 {} Success\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{}\r\n\r\n--boundary--"""
+    _PAYLOAD_FORMAT = """--boundary\r\nContent-Type: application/http\r\n\
+Content-ID: <uuid + 1>\r\n\r\nHTTP/1.1 {} Success\r\n\
+Content-Type: application/json; charset=UTF-8\r\n\r\n{}\r\n\r\n--boundary--"""
     _CLIENT_VERSION = 'fire-admin-python/{0}'.format(firebase_admin.__version__)
 
     @classmethod
@@ -1570,7 +1574,8 @@ class TestSendMulticast(object):
 
     def test_send_multicast(self):
         payload = json.dumps({'name': 'message-id'})
-        _ = self._instrument_batch_messaging_service(payload=self._PAYLOAD_FORMAT.format('200', payload))
+        _ = self._instrument_batch_messaging_service(
+            payload=self._PAYLOAD_FORMAT.format('200', payload))
         msg = messaging.MulticastMessage(tokens=['foo'])
         batch_response = messaging.send_multicast(msg, dry_run=True)
         assert batch_response.success_count is 1
@@ -1672,7 +1677,7 @@ class TestSendMulticast(object):
         assert str(excinfo.value.code) == 'invalid-argument'
 
     @pytest.mark.parametrize('status', HTTP_ERRORS)
-    def test_send_multicast_canonical_error_code(self, status):
+    def test_send_multicast_batch_canonical_error_code(self, status):
         payload = json.dumps({
             'error': {
                 'status': 'NOT_FOUND',
@@ -1687,7 +1692,7 @@ class TestSendMulticast(object):
         assert str(excinfo.value.code) == 'registration-token-not-registered'
 
     @pytest.mark.parametrize('status', HTTP_ERRORS)
-    def test_send_multicast_fcm_error_code(self, status):
+    def test_send_multicast_batch_fcm_error_code(self, status):
         payload = json.dumps({
             'error': {
                 'status': 'INVALID_ARGUMENT',


### PR DESCRIPTION
Hey y'all - I'm working on adding the `sendAll` and `sendMulticast` features for #196 based on https://github.com/firebase/firebase-admin-node/pull/453 - I was hoping I could get some assistance with how to represent returns from these functions, since the current `send` endpoint will raise if the response from FCM contains an error, and this doesn't seem like a great solution when sending several requests.

Also, if I could get suggestions on a non-regex way to wrangle batch response content, that would be appreciated. My first thought was seeing if we could dump each individual response content in to a requests Response object, but that doesn't appear to be a thing with Response objects.