### PR TITLE
Migrating FCM Send APIs to the New Exceptions

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -22,6 +22,8 @@ import re
 
 import six
 
+from firebase_admin import exceptions
+
 
 class Message(object):
     """A message that can be sent via Firebase Cloud Messaging.
@@ -797,3 +799,33 @@ class MessageEncoder(json.JSONEncoder):
         if target_count != 1:
             raise ValueError('Exactly one of token, topic or condition must be specified.')
         return result
+
+
+class ThirdPartyAuthError(exceptions.UnauthenticatedError):
+    """APNs certificate or web push auth key was invalid or missing."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.UnauthenticatedError.__init__(self, message, cause, http_response)
+
+
+class QuotaExceededError(exceptions.ResourceExhaustedError):
+    """Sending limit exceeded for the message target."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.ResourceExhaustedError.__init__(self, message, cause, http_response)
+
+
+class SenderIdMismatchError(exceptions.PermissionDeniedError):
+    """The authenticated sender ID is different from the sender ID for the registration token."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.PermissionDeniedError.__init__(self, message, cause, http_response)
+
+
+class UnregisteredError(exceptions.NotFoundError):
+    """App instance was unregistered from FCM.
+
+    This usually means that the token used is no longer valid and a new one must be used."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.NotFoundError.__init__(self, message, cause, http_response)

--- a/firebase_admin/_utils.py
+++ b/firebase_admin/_utils.py
@@ -29,6 +29,22 @@ _STATUS_TO_EXCEPTION_TYPE = {
     429: exceptions.ResourceExhaustedError,
     500: exceptions.InternalError,
     503: exceptions.UnavailableError,
+
+    exceptions.INVALID_ARGUMENT: exceptions.InvalidArgumentError,
+    exceptions.FAILED_PRECONDITION: exceptions.FailedPreconditionError,
+    exceptions.OUT_OF_RANGE: exceptions.OutOfRangeError,
+    exceptions.UNAUTHENTICATED: exceptions.UnauthenticatedError,
+    exceptions.PERMISSION_DENIED: exceptions.PermissionDeniedError,
+    exceptions.NOT_FOUND: exceptions.NotFoundError,
+    exceptions.ABORTED: exceptions.AbortedError,
+    exceptions.ALREADY_EXISTS: exceptions.AlreadyExistsError,
+    exceptions.RESOURCE_EXHAUSTED: exceptions.ResourceExhaustedError,
+    exceptions.CANCELLED: exceptions.CancelledError,
+    exceptions.DATA_LOSS: exceptions.DataLossError,
+    exceptions.UNKNOWN: exceptions.UnknownError,
+    exceptions.INTERNAL: exceptions.InternalError,
+    exceptions.UNAVAILABLE: exceptions.UnavailableError,
+    exceptions.DEADLINE_EXCEEDED: exceptions.DeadlineExceededError,
 }
 
 
@@ -56,8 +72,9 @@ def handle_requests_error(error, message=None, status=None):
         error: An error raised by the reqests module while making an HTTP call.
         message: A message to be included in the resulting ``FirebaseError`` (optional). If not
             specified the string representation of the ``error`` argument is used as the message.
-        status: An HTTP status code that will be used to determine the resulting error type
-            (optional). If not specified the HTTP status code on the error response is used.
+        status: An HTTP status code or GCP error code that will be used to determine the resulting
+            error type (optional). If not specified the HTTP status code on the error response is
+            used.
 
     Returns:
         FirebaseError: A ``FirebaseError`` that can be raised to the user code.
@@ -79,5 +96,8 @@ def handle_requests_error(error, message=None, status=None):
         status = error.response.status_code
     if not message:
         message = str(error)
-    err_type = _STATUS_TO_EXCEPTION_TYPE.get(status, exceptions.UnknownError)
+    err_type = lookup_error_type(status)
     return err_type(message=message, cause=error, http_response=error.response)
+
+def lookup_error_type(status):
+    return _STATUS_TO_EXCEPTION_TYPE.get(status, exceptions.UnknownError)

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -451,16 +451,16 @@ class _MessagingService(object):
 
     def _handle_fcm_error(self, error):
         """Handles errors received from the FCM API."""
-        code, msg = None, None
+        code, message = None, None
         if error.response is not None:
-            code, msg = _utils.parse_platform_error(
-                content=error.response.content.decode(), status_code=error.response.status_code,
+            code, message = _utils.parse_requests_platform_error(
+                response=error.response,
                 parse_func=_MessagingService._parse_fcm_error)
             exc_type = _MessagingService.FCM_ERROR_TYPES.get(code)
             if exc_type:
-                raise exc_type(msg, cause=error, http_response=error.response)
+                raise exc_type(message, cause=error, http_response=error.response)
 
-        raise _utils.handle_requests_error(error, message=msg, status=code)
+        raise _utils.handle_requests_error(error, message=message, code=code)
 
     def _handle_iid_error(self, error):
         """Handles errors received from the Instance ID API."""
@@ -487,16 +487,13 @@ class _MessagingService(object):
         resp.status_code = error.resp.status
 
         code, msg = _utils.parse_platform_error(
-            content=error.content.decode(), status_code=error.resp.status,
+            content=error.content.decode(),
+            status_code=error.resp.status,
             parse_func=_MessagingService._parse_fcm_error)
         exc_type = _MessagingService.FCM_ERROR_TYPES.get(code)
         if exc_type:
             return exc_type(message=msg, cause=error, http_response=resp)
 
-        if not code:
-            code = error.resp.status
-        if not msg:
-            msg = str(error)
         err_type = _utils.lookup_error_type(code)
         return err_type(message=msg, cause=error, http_response=resp)
 

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -499,4 +499,5 @@ class _MessagingService(object):
         for detail in error_dict.get('details', []):
             if detail.get('@type') == 'type.googleapis.com/google.firebase.fcm.v1.FcmError':
                 fcm_code = detail.get('errorCode')
+                break
         return _MessagingService.FCM_ERROR_TYPES.get(fcm_code)

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -99,7 +99,7 @@ def send(message, dry_run=False, app=None):
         string: A message ID string that uniquely identifies the sent the message.
 
     Raises:
-        ApiCallError: If an error occurs while sending the message to the FCM service.
+        FirebaseError: If an error occurs while sending the message to the FCM service.
         ValueError: If the input arguments are invalid.
     """
     return _get_messaging_service(app).send(message, dry_run)
@@ -119,7 +119,7 @@ def send_all(messages, dry_run=False, app=None):
         BatchResponse: A ``messaging.BatchResponse`` instance.
 
     Raises:
-        ApiCallError: If an error occurs while sending the message to the FCM service.
+        FirebaseError: If an error occurs while sending the message to the FCM service.
         ValueError: If the input arguments are invalid.
     """
     return _get_messaging_service(app).send_all(messages, dry_run)
@@ -139,7 +139,7 @@ def send_multicast(multicast_message, dry_run=False, app=None):
         BatchResponse: A ``messaging.BatchResponse`` instance.
 
     Raises:
-        ApiCallError: If an error occurs while sending the message to the FCM service.
+        FirebaseError: If an error occurs while sending the message to the FCM service.
         ValueError: If the input arguments are invalid.
     """
     if not isinstance(multicast_message, MulticastMessage):

--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -16,6 +16,9 @@
 
 import re
 
+import pytest
+
+from firebase_admin import exceptions
 from firebase_admin import messaging
 
 
@@ -47,6 +50,22 @@ def test_send():
     msg_id = messaging.send(msg, dry_run=True)
     assert re.match('^projects/.*/messages/.*$', msg_id)
 
+def test_send_invalid_token():
+    msg = messaging.Message(
+        token=_REGISTRATION_TOKEN,
+        notification=messaging.Notification('test-title', 'test-body')
+    )
+    with pytest.raises(messaging.SenderIdMismatchError):
+        messaging.send(msg, dry_run=True)
+
+def test_send_malformed_token():
+    msg = messaging.Message(
+        token='not-a-token',
+        notification=messaging.Notification('test-title', 'test-body')
+    )
+    with pytest.raises(exceptions.InvalidArgumentError):
+        messaging.send(msg, dry_run=True)
+
 def test_send_all():
     messages = [
         messaging.Message(
@@ -75,7 +94,7 @@ def test_send_all():
 
     response = batch_response.responses[2]
     assert response.success is False
-    assert response.exception is not None
+    assert isinstance(response.exception, exceptions.InvalidArgumentError)
     assert response.message_id is None
 
 def test_send_one_hundred():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -32,11 +32,6 @@ _NOT_FOUND_ERROR_DICT = {
 }
 
 
-_UNAVAILABLE_ERROR_DICT = {
-    'status': exceptions.UNAVAILABLE,
-}
-
-
 _NOT_FOUND_PAYLOAD = json.dumps({
     'error': _NOT_FOUND_ERROR_DICT,
 })
@@ -94,7 +89,7 @@ class TestRequests(object):
 
     def test_http_response_with_code(self):
         resp, error = self._create_response()
-        firebase_error = _utils.handle_requests_error(error, error_dict=_UNAVAILABLE_ERROR_DICT)
+        firebase_error = _utils.handle_requests_error(error, code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Test error'
         assert firebase_error.cause is error
@@ -103,7 +98,7 @@ class TestRequests(object):
     def test_http_response_with_message_and_code(self):
         resp, error = self._create_response()
         firebase_error = _utils.handle_requests_error(
-            error, message='Explicit error message', error_dict=_UNAVAILABLE_ERROR_DICT)
+            error, message='Explicit error message', code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Explicit error message'
         assert firebase_error.cause is error
@@ -245,7 +240,7 @@ class TestGoogleApiClient(object):
     def test_http_response_with_code(self):
         error = self._create_http_error()
         firebase_error = _utils.handle_googleapiclient_error(
-            error, error_dict=_UNAVAILABLE_ERROR_DICT)
+            error, code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == str(error)
         assert firebase_error.cause is error
@@ -255,7 +250,7 @@ class TestGoogleApiClient(object):
     def test_http_response_with_message_and_code(self):
         error = self._create_http_error()
         firebase_error = _utils.handle_googleapiclient_error(
-            error, message='Explicit error message', error_dict=_UNAVAILABLE_ERROR_DICT)
+            error, message='Explicit error message', code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Explicit error message'
         assert firebase_error.cause is error

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -78,7 +78,7 @@ def test_http_response_with_status():
     resp = models.Response()
     resp.status_code = 500
     error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(error, status=503)
+    firebase_error = _utils.handle_requests_error(error, code=503)
     assert isinstance(firebase_error, exceptions.UnavailableError)
     assert str(firebase_error) == 'Test error'
     assert firebase_error.cause is error
@@ -89,7 +89,7 @@ def test_http_response_with_message_and_status():
     resp.status_code = 500
     error = requests.exceptions.RequestException('Test error', response=resp)
     firebase_error = _utils.handle_requests_error(
-        error, message='Explicit error message', status=503)
+        error, message='Explicit error message', code=503)
     assert isinstance(firebase_error, exceptions.UnavailableError)
     assert str(firebase_error) == 'Explicit error message'
     assert firebase_error.cause is error

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,18 +76,18 @@ class TestRequests(object):
         assert firebase_error.cause is error
         assert firebase_error.http_response is resp
 
-    def test_http_response_with_status(self):
+    def test_http_response_with_code(self):
         resp, error = self._create_response()
-        firebase_error = _utils.handle_requests_error(error, code=503)
+        firebase_error = _utils.handle_requests_error(error, code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Test error'
         assert firebase_error.cause is error
         assert firebase_error.http_response is resp
 
-    def test_http_response_with_message_and_status(self):
+    def test_http_response_with_message_and_code(self):
         resp, error = self._create_response()
         firebase_error = _utils.handle_requests_error(
-            error, message='Explicit error message', code=503)
+            error, message='Explicit error message', code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Explicit error message'
         assert firebase_error.cause is error
@@ -252,19 +252,19 @@ class TestGoogleApiClient(object):
         assert firebase_error.http_response.status_code == 500
         assert firebase_error.http_response.content.decode() == 'Body'
 
-    def test_http_response_with_status(self):
+    def test_http_response_with_code(self):
         error = self._create_http_error()
-        firebase_error = _utils.handle_googleapiclient_error(error, code=503)
+        firebase_error = _utils.handle_googleapiclient_error(error, code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == str(error)
         assert firebase_error.cause is error
         assert firebase_error.http_response.status_code == 500
         assert firebase_error.http_response.content.decode() == 'Body'
 
-    def test_http_response_with_message_and_status(self):
+    def test_http_response_with_message_and_code(self):
         error = self._create_http_error()
         firebase_error = _utils.handle_googleapiclient_error(
-            error, message='Explicit error message', code=503)
+            error, message='Explicit error message', code=exceptions.UNAVAILABLE)
         assert isinstance(firebase_error, exceptions.UnavailableError)
         assert str(firebase_error) == 'Explicit error message'
         assert firebase_error.cause is error

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,85 +12,367 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import socket
 
+import httplib2
+import pytest
 import requests
 from requests import models
+import six
 
+from googleapiclient import errors
 from firebase_admin import exceptions
 from firebase_admin import _utils
 
 
-def test_timeout_error():
-    error = requests.exceptions.Timeout('Test error')
-    firebase_error = _utils.handle_requests_error(error)
-    assert isinstance(firebase_error, exceptions.DeadlineExceededError)
-    assert str(firebase_error) == 'Timed out while making an API call: Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is None
+class TestRequests(object):
 
-def test_connection_error():
-    error = requests.exceptions.ConnectionError('Test error')
-    firebase_error = _utils.handle_requests_error(error)
-    assert isinstance(firebase_error, exceptions.UnavailableError)
-    assert str(firebase_error) == 'Failed to establish a connection: Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is None
+    def test_timeout_error(self):
+        error = requests.exceptions.Timeout('Test error')
+        firebase_error = _utils.handle_requests_error(error)
+        assert isinstance(firebase_error, exceptions.DeadlineExceededError)
+        assert str(firebase_error) == 'Timed out while making an API call: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
 
-def test_unknown_transport_error():
-    error = requests.exceptions.RequestException('Test error')
-    firebase_error = _utils.handle_requests_error(error)
-    assert isinstance(firebase_error, exceptions.UnknownError)
-    assert str(firebase_error) == 'Unknown error while making a remote service call: Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is None
+    def test_requests_connection_error(self):
+        error = requests.exceptions.ConnectionError('Test error')
+        firebase_error = _utils.handle_requests_error(error)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == 'Failed to establish a connection: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
 
-def test_http_response():
-    resp = models.Response()
-    resp.status_code = 500
-    error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(error)
-    assert isinstance(firebase_error, exceptions.InternalError)
-    assert str(firebase_error) == 'Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is resp
+    def test_unknown_transport_error(self):
+        error = requests.exceptions.RequestException('Test error')
+        firebase_error = _utils.handle_requests_error(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == 'Unknown error while making a remote service call: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
 
-def test_http_response_with_unknown_status():
-    resp = models.Response()
-    resp.status_code = 501
-    error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(error)
-    assert isinstance(firebase_error, exceptions.UnknownError)
-    assert str(firebase_error) == 'Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is resp
+    def test_http_response(self):
+        resp, error = self._create_response()
+        firebase_error = _utils.handle_requests_error(error)
+        assert isinstance(firebase_error, exceptions.InternalError)
+        assert str(firebase_error) == 'Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
 
-def test_http_response_with_message():
-    resp = models.Response()
-    resp.status_code = 500
-    error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(error, message='Explicit error message')
-    assert isinstance(firebase_error, exceptions.InternalError)
-    assert str(firebase_error) == 'Explicit error message'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is resp
+    def test_http_response_with_unknown_status(self):
+        resp, error = self._create_response(status=501)
+        firebase_error = _utils.handle_requests_error(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == 'Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
 
-def test_http_response_with_status():
-    resp = models.Response()
-    resp.status_code = 500
-    error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(error, code=503)
-    assert isinstance(firebase_error, exceptions.UnavailableError)
-    assert str(firebase_error) == 'Test error'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is resp
+    def test_http_response_with_message(self):
+        resp, error = self._create_response()
+        firebase_error = _utils.handle_requests_error(error, message='Explicit error message')
+        assert isinstance(firebase_error, exceptions.InternalError)
+        assert str(firebase_error) == 'Explicit error message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
 
-def test_http_response_with_message_and_status():
-    resp = models.Response()
-    resp.status_code = 500
-    error = requests.exceptions.RequestException('Test error', response=resp)
-    firebase_error = _utils.handle_requests_error(
-        error, message='Explicit error message', code=503)
-    assert isinstance(firebase_error, exceptions.UnavailableError)
-    assert str(firebase_error) == 'Explicit error message'
-    assert firebase_error.cause is error
-    assert firebase_error.http_response is resp
+    def test_http_response_with_status(self):
+        resp, error = self._create_response()
+        firebase_error = _utils.handle_requests_error(error, code=503)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == 'Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+
+    def test_http_response_with_message_and_status(self):
+        resp, error = self._create_response()
+        firebase_error = _utils.handle_requests_error(
+            error, message='Explicit error message', code=503)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == 'Explicit error message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+
+    def test_handle_platform_error(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp, error = self._create_response(payload=payload)
+        firebase_error = _utils.handle_platform_error_from_requests(error)
+        assert isinstance(firebase_error, exceptions.NotFoundError)
+        assert str(firebase_error) == 'test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+
+    def test_handle_platform_error_with_no_response(self):
+        error = requests.exceptions.RequestException('Test error')
+        firebase_error = _utils.handle_platform_error_from_requests(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == 'Unknown error while making a remote service call: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
+
+    def test_handle_platform_error_with_no_error_code(self):
+        resp, error = self._create_response(payload='no error code')
+        firebase_error = _utils.handle_platform_error_from_requests(error)
+        assert isinstance(firebase_error, exceptions.InternalError)
+        message = 'Unexpected HTTP response with status: 500; body: no error code'
+        assert str(firebase_error) == message
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+
+    def test_handle_platform_error_with_custom_handler(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp, error = self._create_response(payload=payload)
+        invocations = []
+
+        def _custom_handler(error_dict, message, cause, http_response):
+            invocations.append((error_dict, message, cause, http_response))
+            return exceptions.InvalidArgumentError('Custom message', cause, http_response)
+
+        firebase_error = _utils.handle_platform_error_from_requests(error, _custom_handler)
+
+        assert isinstance(firebase_error, exceptions.InvalidArgumentError)
+        assert str(firebase_error) == 'Custom message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+        assert len(invocations) == 1
+        args = invocations[0]
+        assert len(args) == 4
+        assert args[0] == {
+            'status': 'NOT_FOUND',
+            'message': 'test error'
+        }
+        assert args[1] == 'test error'
+        assert args[2] is error
+        assert args[3] is resp
+
+    def test_handle_platform_error_with_custom_handler_ignore(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp, error = self._create_response(payload=payload)
+        invocations = []
+
+        def _custom_handler(error_dict, message, cause, http_response):
+            invocations.append((error_dict, message, cause, http_response))
+            return None
+
+        firebase_error = _utils.handle_platform_error_from_requests(error, _custom_handler)
+
+        assert isinstance(firebase_error, exceptions.NotFoundError)
+        assert str(firebase_error) == 'test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is resp
+        assert len(invocations) == 1
+        args = invocations[0]
+        assert len(args) == 4
+        assert args[0] == {
+            'status': 'NOT_FOUND',
+            'message': 'test error'
+        }
+        assert args[1] == 'test error'
+        assert args[2] is error
+        assert args[3] is resp
+
+    def _create_response(self, status=500, payload=None):
+        resp = models.Response()
+        resp.status_code = status
+        if payload:
+            resp.raw = six.BytesIO(payload.encode())
+        exc = requests.exceptions.RequestException('Test error', response=resp)
+        return resp, exc
+
+
+class TestGoogleApiClient(object):
+
+    @pytest.mark.parametrize('error', [
+        socket.timeout('Test error'),
+        socket.error('Read timed out')
+    ])
+    def test_googleapicleint_timeout_error(self, error):
+        firebase_error = _utils.handle_googleapiclient_error(error)
+        assert isinstance(firebase_error, exceptions.DeadlineExceededError)
+        assert str(firebase_error) == 'Timed out while making an API call: {0}'.format(error)
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
+
+    def test_googleapiclient_connection_error(self):
+        error = httplib2.ServerNotFoundError('Test error')
+        firebase_error = _utils.handle_googleapiclient_error(error)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == 'Failed to establish a connection: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
+
+    def test_unknown_transport_error(self):
+        error = socket.error('Test error')
+        firebase_error = _utils.handle_googleapiclient_error(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == 'Unknown error while making a remote service call: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
+
+    def test_http_response(self):
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, 'Body')
+        firebase_error = _utils.handle_googleapiclient_error(error)
+        assert isinstance(firebase_error, exceptions.InternalError)
+        assert str(firebase_error) == str(error)
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == 'Body'
+
+    def test_http_response_with_unknown_status(self):
+        resp = httplib2.Response({'status': 501})
+        error = errors.HttpError(resp, 'Body')
+        firebase_error = _utils.handle_googleapiclient_error(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == str(error)
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 501
+        assert firebase_error.http_response.content.decode() == 'Body'
+
+    def test_http_response_with_message(self):
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, 'Body')
+        firebase_error = _utils.handle_googleapiclient_error(
+            error, message='Explicit error message')
+        assert isinstance(firebase_error, exceptions.InternalError)
+        assert str(firebase_error) == 'Explicit error message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == 'Body'
+
+    def test_http_response_with_status(self):
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, 'Body')
+        firebase_error = _utils.handle_googleapiclient_error(error, code=503)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == str(error)
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == 'Body'
+
+    def test_http_response_with_message_and_status(self):
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, 'Body')
+        firebase_error = _utils.handle_googleapiclient_error(
+            error, message='Explicit error message', code=503)
+        assert isinstance(firebase_error, exceptions.UnavailableError)
+        assert str(firebase_error) == 'Explicit error message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == 'Body'
+
+    def test_handle_platform_error(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, payload)
+        firebase_error = _utils.handle_platform_error_from_googleapiclient(error)
+        assert isinstance(firebase_error, exceptions.NotFoundError)
+        assert str(firebase_error) == 'test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == payload
+
+    def test_handle_platform_error_with_no_response(self):
+        error = socket.error('Test error')
+        firebase_error = _utils.handle_platform_error_from_googleapiclient(error)
+        assert isinstance(firebase_error, exceptions.UnknownError)
+        assert str(firebase_error) == 'Unknown error while making a remote service call: Test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response is None
+
+    def test_handle_platform_error_with_no_error_code(self):
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, 'no error code')
+        firebase_error = _utils.handle_platform_error_from_googleapiclient(error)
+        assert isinstance(firebase_error, exceptions.InternalError)
+        message = 'Unexpected HTTP response with status: 500; body: no error code'
+        assert str(firebase_error) == message
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == 'no error code'
+
+    def test_handle_platform_error_with_custom_handler(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, payload)
+        invocations = []
+
+        def _custom_handler(error_dict, message, cause, http_response):
+            invocations.append((error_dict, message, cause, http_response))
+            return exceptions.InvalidArgumentError('Custom message', cause, http_response)
+
+        firebase_error = _utils.handle_platform_error_from_googleapiclient(error, _custom_handler)
+
+        assert isinstance(firebase_error, exceptions.InvalidArgumentError)
+        assert str(firebase_error) == 'Custom message'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == payload
+        assert len(invocations) == 1
+        args = invocations[0]
+        assert len(args) == 4
+        assert args[0] == {
+            'status': 'NOT_FOUND',
+            'message': 'test error'
+        }
+        assert args[1] == 'test error'
+        assert args[2] is error
+        assert args[3] is not None
+
+    def test_handle_platform_error_with_custom_handler_ignore(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'NOT_FOUND',
+                'message': 'test error'
+            }
+        })
+        resp = httplib2.Response({'status': 500})
+        error = errors.HttpError(resp, payload)
+        invocations = []
+
+        def _custom_handler(error_dict, message, cause, http_response):
+            invocations.append((error_dict, message, cause, http_response))
+            return None
+
+        firebase_error = _utils.handle_platform_error_from_googleapiclient(error, _custom_handler)
+
+        assert isinstance(firebase_error, exceptions.NotFoundError)
+        assert str(firebase_error) == 'test error'
+        assert firebase_error.cause is error
+        assert firebase_error.http_response.status_code == 500
+        assert firebase_error.http_response.content.decode() == payload
+        assert len(invocations) == 1
+        args = invocations[0]
+        assert len(args) == 4
+        assert args[0] == {
+            'status': 'NOT_FOUND',
+            'message': 'test error'
+        }
+        assert args[1] == 'test error'
+        assert args[2] is error
+        assert args[3] is not None


### PR DESCRIPTION
* Introduced new FCM-specific error types in the `messaging` module.
* Updated the shared error handling code in `_utils` to handle  platform errors.
* Implemented logic for handling errors raised by `requests` and `googleapiclient` packages (latter used by FCM batch operations).
* Updated FCM send APIs to raise new exception types.
* Updated affected tests and docs.