### PR TITLE
Add linting and bandit security static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,25 @@ python:
   - "3.6"
   - "pypy3.5"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install:
+  - "pip install -r requirements.txt"
+  - pip install -U tox
 before_script: 
   - export PY_VERSION=`python -c 'import sys; print sys.version_info.major'`
   - if [[ "$PY_VERSION" == '2' ]]; then ./lint.sh all; fi
 # command to run tests
-script: pytest
+matrix:
+  include:
+    - env: TOX_ENV=py2
+      python: 2.7
+    - env: TOX_ENV=py3
+      python: 3.7
+    - env: TOX_ENV=cover
+      python: 2.7
+    - env: TOX_ENV=securitypy2
+      python: 2.7
+    - env: TOX_ENV=securitypy3
+      python: 3.7
+
+script: travis_retry tox -e $TOX_ENV
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py2,py3,pypy,cover
+envlist = py2,py3,pypy,cover,securitypy2,securitypy3
 
 [testenv]
 commands = pytest
@@ -29,3 +29,35 @@ commands =
     coverage report --show-missing
 deps =
     {[coverbase]deps}
+
+[testenv:securitypy2]
+basepython = python2.7
+commands =
+    bandit -r firebase_admin --skip B105
+deps =
+    bandit
+
+[testenv:securitypy3]
+basepython = python3.7
+commands =
+    bandit -r firebase_admin --skip B105
+deps =
+    bandit
+
+[testenv:lintpy3]
+basepython = python3.7
+commands =
+    flake8 firebase_admin
+    #isort --check-only --recursive firebase_admin
+deps =
+    flake8
+    isort
+
+[testenv:lintpy2]
+basepython = python2.7
+commands =
+    flake8 firebase_admin
+    #isort --check-only --recursive firebase_admin
+deps =
+    flake8
+    isort


### PR DESCRIPTION
https://github.com/firebase/firebase-admin-python/issues/299

Added tox and travis options for security static analysis.

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

Tested locally on py2.7 and py3.7

```
ecuritypy2 run-test-pre: PYTHONHASHSEED='1105419126'
securitypy2 run-test: commands[0] | bandit -r firebase_admin --skip B105
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: B105
[main]	INFO	running on Python 2.7.16
Run started:2019-06-23 22:25:20.988791

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 4993
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
	Total issues (by confidence):
		Undefined: 0
		Low: 0
		Medium: 0
		High: 0
Files skipped (0):
securitypy3 inst-nodeps: /home/goose/Development/firebase-admin-python/.tox/.tmp/package/1/firebase_admin-2.17.0.zip
securitypy3 installed: bandit==1.6.1,CacheControl==0.12.5,cachetools==3.1.1,certifi==2019.6.16,chardet==3.0.4,firebase-admin==2.17.0,gitdb2==2.0.5,GitPython==2.1.11,google-api-core==1.12.0,google-api-python-client==1.7.9,google-auth==1.6.3,google-auth-httplib2==0.0.3,google-cloud-core==1.0.2,google-cloud-firestore==1.2.0,google-cloud-storage==1.16.1,google-resumable-media==0.3.2,googleapis-common-protos==1.6.0,grpcio==1.21.1,httplib2==0.13.0,idna==2.8,msgpack==0.6.1,pbr==5.3.1,protobuf==3.8.0,pyasn1==0.4.5,pyasn1-modules==0.2.5,pytz==2019.1,PyYAML==5.1.1,requests==2.22.0,rsa==4.0,six==1.12.0,smmap2==2.0.5,stevedore==1.30.1,uritemplate==3.0.0,urllib3==1.25.3
securitypy3 run-test-pre: PYTHONHASHSEED='1105419126'
securitypy3 run-test: commands[0] | bandit -r firebase_admin --skip B105
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: B105
[main]	INFO	running on Python 3.7.3
Run started:2019-06-23 22:25:22.866109

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 4993
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
	Total issues (by confidence):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
Files skipped (0):
___________________________________________________________ summary ___________________________________________________________
  securitypy2: commands succeeded
  securitypy3: commands succeeded
  congratulations :)

```

### API Changes

None
