### PR TITLE
New error handling support in create/update/delete user APIs

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -193,6 +193,15 @@ def validate_action_type(action_type):
     return action_type
 
 
+class UidAlreadyExistsError(exceptions.AlreadyExistsError):
+    """The user with the provided uid already exists."""
+
+    default_message = 'The user with the provided uid already exists'
+
+    def __init__(self, message, cause, http_response=None):
+        exceptions.AlreadyExistsError.__init__(self, message, cause, http_response)
+
+
 class InvalidIdTokenError(exceptions.InvalidArgumentError):
     """The provided ID token is not a valid Firebase ID token."""
 
@@ -219,6 +228,7 @@ class UserNotFoundError(exceptions.NotFoundError):
 
 
 _CODE_TO_EXC_TYPE = {
+    'DUPLICATE_LOCAL_ID': UidAlreadyExistsError,
     'INVALID_ID_TOKEN': InvalidIdTokenError,
     'USER_NOT_FOUND': UserNotFoundError,
 }

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -44,6 +44,8 @@ __all__ = [
     'ImportUserRecord',
     'ListUsersPage',
     'TokenSignError',
+    'UidAlreadyExistsError',
+    'UnexpectedResponseError',
     'UserImportHash',
     'UserImportResult',
     'UserInfo',
@@ -80,6 +82,7 @@ UserImportHash = _user_import.UserImportHash
 ImportUserRecord = _user_import.ImportUserRecord
 InvalidIdTokenError = _auth_utils.InvalidIdTokenError
 TokenSignError = _token_gen.TokenSignError
+UidAlreadyExistsError = _auth_utils.UidAlreadyExistsError
 UnexpectedResponseError = _auth_utils.UnexpectedResponseError
 UserImportResult = _user_import.UserImportResult
 UserInfo = _user_mgt.UserInfo
@@ -333,15 +336,12 @@ def create_user(**kwargs):
 
     Raises:
         ValueError: If the specified user properties are invalid.
-        AuthError: If an error occurs while creating the user account.
+        FirebaseError: If an error occurs while creating the user account.
     """
     app = kwargs.pop('app', None)
     user_manager = _get_auth_service(app).user_manager
-    try:
-        uid = user_manager.create_user(**kwargs)
-        return UserRecord(user_manager.get_user(uid=uid))
-    except _user_mgt.ApiCallError as error:
-        raise AuthError(error.code, str(error), error.detail)
+    uid = user_manager.create_user(**kwargs)
+    return UserRecord(user_manager.get_user(uid=uid))
 
 
 def update_user(uid, **kwargs):
@@ -373,15 +373,12 @@ def update_user(uid, **kwargs):
 
     Raises:
         ValueError: If the specified user ID or properties are invalid.
-        AuthError: If an error occurs while updating the user account.
+        FirebaseError: If an error occurs while updating the user account.
     """
     app = kwargs.pop('app', None)
     user_manager = _get_auth_service(app).user_manager
-    try:
-        user_manager.update_user(uid, **kwargs)
-        return UserRecord(user_manager.get_user(uid=uid))
-    except _user_mgt.ApiCallError as error:
-        raise AuthError(error.code, str(error), error.detail)
+    user_manager.update_user(uid, **kwargs)
+    return UserRecord(user_manager.get_user(uid=uid))
 
 
 def set_custom_user_claims(uid, custom_claims, app=None):
@@ -402,13 +399,10 @@ def set_custom_user_claims(uid, custom_claims, app=None):
 
     Raises:
         ValueError: If the specified user ID or the custom claims are invalid.
-        AuthError: If an error occurs while updating the user account.
+        FirebaseError: If an error occurs while updating the user account.
     """
     user_manager = _get_auth_service(app).user_manager
-    try:
-        user_manager.update_user(uid, custom_claims=custom_claims)
-    except _user_mgt.ApiCallError as error:
-        raise AuthError(error.code, str(error), error.detail)
+    user_manager.update_user(uid, custom_claims=custom_claims)
 
 
 def delete_user(uid, app=None):
@@ -420,13 +414,10 @@ def delete_user(uid, app=None):
 
     Raises:
         ValueError: If the user ID is None, empty or malformed.
-        AuthError: If an error occurs while deleting the user account.
+        FirebaseError: If an error occurs while deleting the user account.
     """
     user_manager = _get_auth_service(app).user_manager
-    try:
-        user_manager.delete_user(uid)
-    except _user_mgt.ApiCallError as error:
-        raise AuthError(error.code, str(error), error.detail)
+    user_manager.delete_user(uid)
 
 
 def import_users(users, hash_alg=None, app=None):

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -148,11 +148,11 @@ def test_get_non_existing_user_by_email():
     assert str(excinfo.value) == error_msg
 
 def test_update_non_existing_user():
-    with pytest.raises(auth.UserNotFoundError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError):
         auth.update_user('non.existing')
 
 def test_delete_non_existing_user():
-    with pytest.raises(auth.UserNotFoundError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError):
         auth.delete_user('non.existing')
 
 @pytest.fixture
@@ -256,7 +256,7 @@ def test_create_user(new_user):
     assert user.user_metadata.creation_timestamp > 0
     assert user.user_metadata.last_sign_in_timestamp is None
     assert len(user.provider_data) is 0
-    with pytest.raises(auth.UidAlreadyExistsError) as excinfo:
+    with pytest.raises(auth.UidAlreadyExistsError):
         auth.create_user(uid=new_user.uid)
 
 def test_update_user(new_user):
@@ -326,7 +326,7 @@ def test_disable_user(new_user_with_params):
 def test_delete_user():
     user = auth.create_user()
     auth.delete_user(user.uid)
-    with pytest.raises(auth.UserNotFoundError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError):
         auth.get_user(user.uid)
 
 def test_revoke_refresh_tokens(new_user):

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -148,14 +148,12 @@ def test_get_non_existing_user_by_email():
     assert str(excinfo.value) == error_msg
 
 def test_update_non_existing_user():
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError) as excinfo:
         auth.update_user('non.existing')
-    assert 'USER_UPDATE_ERROR' in str(excinfo.value.code)
 
 def test_delete_non_existing_user():
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError) as excinfo:
         auth.delete_user('non.existing')
-    assert 'USER_DELETE_ERROR' in str(excinfo.value.code)
 
 @pytest.fixture
 def new_user():
@@ -258,9 +256,8 @@ def test_create_user(new_user):
     assert user.user_metadata.creation_timestamp > 0
     assert user.user_metadata.last_sign_in_timestamp is None
     assert len(user.provider_data) is 0
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.UidAlreadyExistsError) as excinfo:
         auth.create_user(uid=new_user.uid)
-    assert excinfo.value.code == 'USER_CREATE_ERROR'
 
 def test_update_user(new_user):
     _, email = _random_id()
@@ -329,9 +326,8 @@ def test_disable_user(new_user_with_params):
 def test_delete_user():
     user = auth.create_user()
     auth.delete_user(user.uid)
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.UserNotFoundError) as excinfo:
         auth.get_user(user.uid)
-    assert excinfo.value.code == 'USER_NOT_FOUND_ERROR'
 
 def test_revoke_refresh_tokens(new_user):
     user = auth.get_user(new_user.uid)

--- a/lint.sh
+++ b/lint.sh
@@ -20,7 +20,7 @@ function lintAllFiles () {
 }
 
 function lintChangedFiles () {
-  files=`git status -s $1 | grep -v "^D" | awk '{print $NF}' | grep .py$`
+  files=`git status -s $1 | (grep -v "^D") | awk '{print $NF}' | (grep .py$ || true)`
   for f in $files
   do
     echo "Running linter on $f"


### PR DESCRIPTION
Migrating the `create_user()`, `update_user()` and `delete_user()` APIs to the new error handling mechanism.