### PR TITLE
Support RTDB Emulator via FIREBASE_DATABASE_EMULATOR_HOST.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,20 @@ Now you can invoke the integration test suite as follows:
 pytest integration/ --cert scripts/cert.json --apikey scripts/apikey.txt
 ```
 
+### Emulator-based Integration Testing
+
+Some integration tests can run against emulators. This allows local testing
+without using real projects or credentials. For now, only the RTDB Emulator
+is supported.
+
+First, run the RTDB emulator in the background and note the host and port.
+And now you can run the RTDB integration tests as follows, replacing the
+host and port as needed:
+
+```
+FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000 pytest integration/test_db.py --project fake
+```
+
 ### Test Coverage
 
 To review the test coverage, run `pytest` with the `--cov` flag. To view a detailed line by line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,12 +201,10 @@ Some integration tests can run against emulators. This allows local testing
 without using real projects or credentials. For now, only the RTDB Emulator
 is supported.
 
-First, run the RTDB emulator in the background and note the host and port.
-And now you can run the RTDB integration tests as follows, replacing the
-host and port as needed:
+First, install the Firebase CLI, then run:
 
 ```
-FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000 pytest integration/test_db.py --project fake
+firebase emulators:exec --only database --project fake-project-id 'pytest integration/test_db.py'
 ```
 
 ### Test Coverage

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -239,6 +239,12 @@ class App(object):
 
     @property
     def project_id(self):
+        if not self._project_id_initialized:
+            self._project_id = self._lookup_project_id()
+            self._project_id_initialized = True
+        return self._project_id
+
+    def _lookup_project_id(self):
         """Looks up the Firebase project ID associated with an App.
 
         If a ``projectId`` is specified in app options, it is returned. Then tries to
@@ -249,12 +255,6 @@ class App(object):
         Returns:
             str: A project ID string or None.
         """
-        if not self._project_id_initialized:
-            self._project_id = self._lookup_project_id()
-            self._project_id_initialized = True
-        return self._project_id
-
-    def _lookup_project_id(self):
         project_id = self._options.get('projectId')
         if not project_id:
             try:

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -264,10 +264,8 @@ class App(object):
         if not project_id:
             project_id = os.environ.get('GOOGLE_CLOUD_PROJECT',
                                         os.environ.get('GCLOUD_PROJECT'))
-        if project_id:
-            return project_id
-        else:
-            return None
+        App._validate_project_id(self._options.get('projectId'))
+        return project_id
 
     def _get_service(self, name, initializer):
         """Returns the service instance identified by the given name.

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -215,7 +215,7 @@ class App(object):
         self._options = _AppOptions(options)
         self._lock = threading.RLock()
         self._services = {}
-        self._project_id = App._lookup_project_id(self._credential, self._options)
+        self._project_id = None  # Will be lazily-loaded when self.project_id is used.
 
     @classmethod
     def _lookup_project_id(cls, credential, options):
@@ -263,6 +263,8 @@ class App(object):
 
     @property
     def project_id(self):
+        if self._project_id is None:
+            self._project_id = App._lookup_project_id(self._credential, self._options)
         return self._project_id
 
     def _get_service(self, name, initializer):

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -254,7 +254,8 @@ class App(object):
             except AttributeError:
                 project_id = None
             if not project_id:
-                project_id = os.environ.get('GOOGLE_CLOUD_PROJECT', os.environ.get('GCLOUD_PROJECT'))
+                project_id = os.environ.get('GOOGLE_CLOUD_PROJECT',
+                                            os.environ.get('GCLOUD_PROJECT'))
             if project_id:
                 self._project_id = project_id
         return self._project_id

--- a/firebase_admin/credentials.py
+++ b/firebase_admin/credentials.py
@@ -199,3 +199,19 @@ class RefreshToken(Base):
         Returns:
           google.auth.credentials.Credentials: A Google Auth credential instance."""
         return self._g_credential
+
+
+class FakeCredential(Base):
+    """Provides fake credentials, which is only accepted in local emulators."""
+
+    def get_credential(self):
+        return _EmulatorAdminCredentials()
+
+
+class _EmulatorAdminCredentials(google.auth.credentials.Credentials):
+    def __init__(self):
+        google.auth.credentials.Credentials.__init__(self)
+        self.token = 'owner'
+
+    def refresh(self, request):
+        pass

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -812,7 +812,7 @@ class _DatabaseService(object):
             if use_fake_creds:
                 credential = _EmulatorAdminCredentials()
             else:
-                self._credential.get_credential()
+                credential = self._credential.get_credential()
             client = _Client(credential, base_url, self._timeout, params)
             self._clients[client_cache_key] = client
         return self._clients[client_cache_key]

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -869,7 +869,7 @@ class _DatabaseService(object):
     def _parse_emulator_url(cls, parsed_url):
         # Handle emulator URL like http://localhost:8080/?ns=foo-bar
         query_ns = urllib.parse.parse_qs(parsed_url.query).get('ns')
-        if parsed_url.scheme in ['http', 'https']:
+        if parsed_url.scheme == 'http':
             if query_ns and len(query_ns) == 1 and query_ns[0]:
                 base_url = '{0}://{1}'.format(parsed_url.scheme, parsed_url.netloc)
                 return base_url, query_ns[0]

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -846,11 +846,11 @@ class _DatabaseService(object):
 
     @classmethod
     def _parse_production_url(cls, parsed_url, emulator_host):
-        # Handle production URL like https://foo-bar.firebaseio.com/
+        """Parses production URL like https://foo-bar.firebaseio.com/"""
         if parsed_url.scheme != 'https':
             raise ValueError(
                 'Invalid database URL scheme: "{0}". Database URL must be an HTTPS URL.'.format(
-                parsed_url.scheme))
+                    parsed_url.scheme))
         namespace = parsed_url.netloc.split('.')[0]
         if not namespace:
             raise ValueError(
@@ -865,7 +865,7 @@ class _DatabaseService(object):
 
     @classmethod
     def _parse_emulator_url(cls, parsed_url):
-        # Handle emulator URL like http://localhost:8080/?ns=foo-bar
+        """Parses emulator URL like http://localhost:8080/?ns=foo-bar"""
         query_ns = urllib.parse.parse_qs(parsed_url.query).get('ns')
         if parsed_url.scheme != 'http' or (not query_ns or len(query_ns) != 1 or not query_ns[0]):
             raise ValueError(

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -838,11 +838,9 @@ class _DatabaseService(object):
                 'URL string.'.format(url))
         parsed_url = urllib.parse.urlparse(url)
         if parsed_url.netloc.endswith('.firebaseio.com'):
-            base_url, namespace = cls._parse_production_url(parsed_url, emulator_host)
+            return cls._parse_production_url(parsed_url, emulator_host)
         else:
-            base_url, namespace = cls._parse_emulator_url(parsed_url)
-
-        return base_url, namespace
+            return cls._parse_emulator_url(parsed_url)
 
     @classmethod
     def _parse_production_url(cls, parsed_url, emulator_host):

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -787,6 +787,7 @@ class _DatabaseService(object):
         self._clients = {}
 
     def get_client(self, db_url=None):
+        """Creates a client based on the db_url. Clients may be cached."""
         if db_url is None:
             db_url = self._db_url
 
@@ -795,7 +796,7 @@ class _DatabaseService(object):
             if '//' in emulator_host:
                 raise ValueError(
                     'Invalid {0}: "{1}". It must follow format "host:port".'.format(
-                    _EMULATOR_HOST_ENV_VAR, emulator_host))
+                        _EMULATOR_HOST_ENV_VAR, emulator_host))
             use_fake_creds = True
             host_override = emulator_host
         else:
@@ -830,6 +831,7 @@ class _DatabaseService(object):
             raise ValueError(
                 'Invalid database URL: "{0}". Database URL must be a non-empty '
                 'URL string.'.format(url))
+        # pylint: disable=invalid-name
         ns = None
         parsed = urllib.parse.urlparse(url)
         query_ns = urllib.parse.parse_qs(parsed.query).get('ns')

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -26,6 +26,8 @@ def pytest_addoption(parser):
         '--cert', action='store', help='Service account certificate file for integration tests.')
     parser.addoption(
         '--apikey', action='store', help='API key file for integration tests.')
+    parser.addoption(
+        '--project', action='store', help='Fake Project ID for emulator-based integration tests.')
 
 def _get_cert_path(request):
     cert = request.config.getoption('--cert')
@@ -35,6 +37,9 @@ def _get_cert_path(request):
                      '"--cert" command-line option.')
 
 def integration_conf(request):
+    project_id = request.config.getoption('--project')
+    if project_id:
+        return credentials.FakeCredential(), project_id
     cert_path = _get_cert_path(request)
     with open(cert_path) as cert:
         project_id = json.load(cert).get('project_id')

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -26,8 +26,6 @@ def pytest_addoption(parser):
         '--cert', action='store', help='Service account certificate file for integration tests.')
     parser.addoption(
         '--apikey', action='store', help='API key file for integration tests.')
-    parser.addoption(
-        '--project', action='store', help='Fake Project ID for emulator-based integration tests.')
 
 def _get_cert_path(request):
     cert = request.config.getoption('--cert')
@@ -37,9 +35,6 @@ def _get_cert_path(request):
                      '"--cert" command-line option.')
 
 def integration_conf(request):
-    project_id = request.config.getoption('--project')
-    if project_id:
-        return credentials.FakeCredential(), project_id
     cert_path = _get_cert_path(request)
     with open(cert_path) as cert:
         project_id = json.load(cert).get('project_id')

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -75,4 +75,3 @@ def api_key(request):
                          'command-line option.')
     with open(path) as keyfile:
         return keyfile.read().strip()
- 

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -44,7 +44,7 @@ def app(request):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def default_app(request):
+def default_app():
     # Overwrites the default_app fixture in conftest.py.
     # This test suite should not use the default app. Use the app fixture instead.
     pass

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -318,7 +318,7 @@ class TestFirebaseApp(object):
     def test_non_string_project_id(self):
         options = {'projectId': {'key': 'not a string'}}
         with pytest.raises(ValueError):
-            firebase_admin.initialize_app(CREDENTIAL, options=options)
+            app = firebase_admin.initialize_app(CREDENTIAL, options=options)
 
     def test_app_get(self, init_app):
         assert init_app is firebase_admin.get_app(init_app.name)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -318,7 +318,7 @@ class TestFirebaseApp(object):
     def test_non_string_project_id(self):
         options = {'projectId': {'key': 'not a string'}}
         with pytest.raises(ValueError):
-            app = firebase_admin.initialize_app(CREDENTIAL, options=options)
+            firebase_admin.initialize_app(CREDENTIAL, options=options)
 
     def test_app_get(self, init_app):
         assert init_app is firebase_admin.get_app(init_app.name)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -115,8 +115,11 @@ class TestApplicationDefault(object):
                              indirect=True)
     def test_nonexisting_path(self, app_default):
         del app_default
+        # This does not yet throw because the credentials are lazily loaded.
+        creds = credentials.ApplicationDefault()
+
         with pytest.raises(exceptions.DefaultCredentialsError):
-            credentials.ApplicationDefault()
+            creds.get_credential()  # This now throws.
 
 
 class TestRefreshToken(object):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -632,8 +632,10 @@ class TestDatabaseInitialization(object):
         # With host override: extracts ns from URL but uses override_host for base URL.
         ('https://test.firebaseio.com', 'localhost:9000', 'http://localhost:9000', {'ns': 'test'}),
         ('https://test.firebaseio.com/', 'localhost:9000', 'http://localhost:9000', {'ns': 'test'}),
-        ('https://s-usc1c-nss-200.firebaseio.com/?ns=test', 'localhost:9000', 'http://localhost:9000', {'ns': 'test'}),
-        ('http://localhost:8000/?ns=test', 'localhost:9000', 'http://localhost:9000', {'ns': 'test'}),
+        ('https://s-usc1c-nss-200.firebaseio.com/?ns=test', 'localhost:9000',
+         'http://localhost:9000', {'ns': 'test'}),
+        ('http://localhost:8000/?ns=test', 'localhost:9000',
+         'http://localhost:9000', {'ns': 'test'}),
     ])
     def test_parse_db_url(self, url, host_override, expected_base_url, expected_params):
         base_url, params = db._DatabaseService._parse_db_url(url, host_override)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -624,31 +624,26 @@ class TestDatabaseInitialization(object):
             db.reference()
 
     @pytest.mark.parametrize(
-        'url,emulator_host,expected_base_url,expected_params,expected_use_fake_creds',
+        'url,emulator_host,expected_base_url,expected_namespace',
         [
             # Production URLs with no override:
-            ('https://test.firebaseio.com', None, 'https://test.firebaseio.com', {}, False),
-            ('https://test.firebaseio.com/', None, 'https://test.firebaseio.com', {}, False),
+            ('https://test.firebaseio.com', None, 'https://test.firebaseio.com', 'test'),
+            ('https://test.firebaseio.com/', None, 'https://test.firebaseio.com', 'test'),
 
             # Production URLs with emulator_host override:
-            ('https://test.firebaseio.com', 'localhost:9000',
-             'http://localhost:9000', {'ns': 'test'}, True),
-            ('https://test.firebaseio.com/', 'localhost:9000',
-             'http://localhost:9000', {'ns': 'test'}, True),
+            ('https://test.firebaseio.com', 'localhost:9000', 'http://localhost:9000', 'test'),
+            ('https://test.firebaseio.com/', 'localhost:9000', 'http://localhost:9000', 'test'),
 
             # Emulator URLs with no override.
-            ('http://localhost:8000/?ns=test', None, 'http://localhost:8000', {'ns': 'test'}, True),
+            ('http://localhost:8000/?ns=test', None, 'http://localhost:8000', 'test'),
             # emulator_host is ignored when the original URL is already emulator.
-            ('http://localhost:8000/?ns=test', 'localhost:9999',
-             'http://localhost:8000', {'ns': 'test'}, True),
+            ('http://localhost:8000/?ns=test', 'localhost:9999', 'http://localhost:8000', 'test'),
         ]
     )
-    def test_parse_db_url(self, url, emulator_host, expected_base_url,
-                          expected_params, expected_use_fake_creds):
-        base_url, params, use_fake_creds = db._DatabaseService._parse_db_url(url, emulator_host)
+    def test_parse_db_url(self, url, emulator_host, expected_base_url, expected_namespace):
+        base_url, namespace = db._DatabaseService._parse_db_url(url, emulator_host)
         assert base_url == expected_base_url
-        assert params == expected_params
-        assert use_fake_creds == expected_use_fake_creds
+        assert namespace == expected_namespace
 
     @pytest.mark.parametrize('url,emulator_host', [
         ('', None),

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py2,py3,pypy,cover
 
 [testenv]
-commands = pytest
+commands = pytest {posargs}
 deps =
     pytest
     pytest-localserver
@@ -29,3 +29,11 @@ commands =
     coverage report --show-missing
 deps =
     {[coverbase]deps}
+
+[testenv:integration_db]
+passenv =
+    FIREBASE_DATABASE_EMULATOR_HOST
+basepython = python3
+commands = pytest integration/test_db.py --project fake {posargs}
+deps =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -29,11 +29,3 @@ commands =
     coverage report --show-missing
 deps =
     {[coverbase]deps}
-
-[testenv:integration_db]
-passenv =
-    FIREBASE_DATABASE_EMULATOR_HOST
-basepython = python3
-commands = pytest integration/test_db.py --project fake {posargs}
-deps =
-    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@
 envlist = py2,py3,pypy,cover
 
 [testenv]
+passenv =
+    FIREBASE_DATABASE_EMULATOR_HOST
 commands = pytest {posargs}
 deps =
     pytest


### PR DESCRIPTION
### Discussion

(Discussed internally.)

### Testing

I've manually ran the integration tests with and without the emulator and verified that they pass.
We may consider running the emulator-based integration test on Travis in a follow up PR.

### API Changes

No public API change except FakeCredential and the FIREBASE_DATABASE_EMULATOR_HOST env var.