### PR TITLE
Error handling updated for remaining user_mgt APIs

### DIFF
--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -24,9 +24,6 @@ from firebase_admin import _auth_utils
 from firebase_admin import _user_import
 
 
-USER_IMPORT_ERROR = 'USER_IMPORT_ERROR'
-USER_DOWNLOAD_ERROR = 'LIST_USERS_ERROR'
-
 MAX_LIST_USERS_RESULTS = 1000
 MAX_IMPORT_USERS_SIZE = 1000
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -308,14 +308,11 @@ def list_users(page_token=None, max_results=_user_mgt.MAX_LIST_USERS_RESULTS, ap
 
     Raises:
         ValueError: If max_results or page_token are invalid.
-        AuthError: If an error occurs while retrieving the user accounts.
+        FirebaseError: If an error occurs while retrieving the user accounts.
     """
     user_manager = _get_auth_service(app).user_manager
     def download(page_token, max_results):
-        try:
-            return user_manager.list_users(page_token, max_results)
-        except _user_mgt.ApiCallError as error:
-            raise AuthError(error.code, str(error), error.detail)
+        return user_manager.list_users(page_token, max_results)
     return ListUsersPage(download, page_token, max_results)
 
 
@@ -443,14 +440,11 @@ def import_users(users, hash_alg=None, app=None):
 
     Raises:
         ValueError: If the provided arguments are invalid.
-        AuthError: If an error occurs while importing users.
+        FirebaseError: If an error occurs while importing users.
     """
     user_manager = _get_auth_service(app).user_manager
-    try:
-        result = user_manager.import_users(users, hash_alg)
-        return UserImportResult(result, len(users))
-    except _user_mgt.ApiCallError as error:
-        raise AuthError(error.code, str(error), error.detail)
+    result = user_manager.import_users(users, hash_alg)
+    return UserImportResult(result, len(users))
 
 
 def generate_password_reset_link(email, action_code_settings=None, app=None):


### PR DESCRIPTION
Updated `import_users()` and `list_users()` APIs to use the new exception types.

This completes the error handling migration for the user management APIs.