### PR TITLE
Migrated token verification APIs to new exception types

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -216,7 +216,7 @@ class InvalidIdTokenError(exceptions.InvalidArgumentError):
 
     default_message = 'The provided ID token is invalid'
 
-    def __init__(self, message, cause, http_response=None):
+    def __init__(self, message, cause=None, http_response=None):
         exceptions.InvalidArgumentError.__init__(self, message, cause, http_response)
 
 

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -369,6 +369,13 @@ class ExpiredIdTokenError(_auth_utils.InvalidIdTokenError):
         _auth_utils.InvalidIdTokenError.__init__(self, message, cause)
 
 
+class RevokedIdTokenError(_auth_utils.InvalidIdTokenError):
+    """The provided ID token has been revoked."""
+
+    def __init__(self, message):
+        _auth_utils.InvalidIdTokenError.__init__(self, message)
+
+
 class InvalidSessionCookieError(exceptions.InvalidArgumentError):
     """The provided string is not a valid Firebase session cookie."""
 
@@ -381,3 +388,10 @@ class ExpiredSessionCookieError(InvalidSessionCookieError):
 
     def __init__(self, message, cause):
         InvalidSessionCookieError.__init__(self, message, cause)
+
+
+class RevokedSessionCookieError(InvalidSessionCookieError):
+    """The provided session cookie has been revoked."""
+
+    def __init__(self, message):
+        InvalidSessionCookieError.__init__(self, message)

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -35,7 +35,6 @@ _AUTH_ATTRIBUTE = '_auth'
 
 __all__ = [
     'ActionCodeSettings',
-    'AuthError',
     'CertificateFetchError',
     'DELETE_ATTRIBUTE',
     'ErrorInfo',
@@ -529,15 +528,6 @@ def _check_jwt_revoked(verified_claims, exc_type, label, app):
     user = get_user(verified_claims.get('uid'), app=app)
     if verified_claims.get('iat') * 1000 < user.tokens_valid_after_timestamp:
         raise exc_type('The Firebase {0} has been revoked.'.format(label))
-
-
-class AuthError(Exception):
-    """Represents an Exception encountered while invoking the Firebase auth API."""
-
-    def __init__(self, code, message, error=None):
-        Exception.__init__(self, message)
-        self.code = code
-        self.detail = error
 
 
 class _AuthService(object):

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -46,6 +46,8 @@ __all__ = [
     'InvalidIdTokenError',
     'InvalidSessionCookieError',
     'ListUsersPage',
+    'RevokedIdTokenError',
+    'RevokedSessionCookieError',
     'TokenSignError',
     'UidAlreadyExistsError',
     'UnexpectedResponseError',
@@ -88,6 +90,8 @@ InvalidDynamicLinkDomainError = _auth_utils.InvalidDynamicLinkDomainError
 InvalidIdTokenError = _auth_utils.InvalidIdTokenError
 InvalidSessionCookieError = _token_gen.InvalidSessionCookieError
 ListUsersPage = _user_mgt.ListUsersPage
+RevokedIdTokenError = _token_gen.RevokedIdTokenError
+RevokedSessionCookieError = _token_gen.RevokedSessionCookieError
 TokenSignError = _token_gen.TokenSignError
 UidAlreadyExistsError = _auth_utils.UidAlreadyExistsError
 UnexpectedResponseError = _auth_utils.UnexpectedResponseError
@@ -155,9 +159,9 @@ def verify_id_token(id_token, app=None, check_revoked=False):
 
     Raises:
         ValueError: If ``id_token`` is a not a string or is empty.
-        InvalidIdTokenError: If ``id_token`` is not a valid Firebase ID token or if
-            ``check_revoked`` is ``True`` and the ID token has been revoked.
+        InvalidIdTokenError: If ``id_token`` is not a valid Firebase ID token.
         ExpiredIdTokenError: If the specified ID token has expired.
+        RevokedIdTokenError: If ``check_revoked`` is ``True`` and the ID token has been revoked.
         CertificateFetchError: If an error occurs while fetching the public key certificates
             required to verify the ID token.
     """
@@ -168,7 +172,7 @@ def verify_id_token(id_token, app=None, check_revoked=False):
     token_verifier = _get_auth_service(app).token_verifier
     verified_claims = token_verifier.verify_id_token(id_token)
     if check_revoked:
-        _check_jwt_revoked(verified_claims, InvalidIdTokenError, 'ID token', app)
+        _check_jwt_revoked(verified_claims, RevokedIdTokenError, 'ID token', app)
     return verified_claims
 
 
@@ -210,16 +214,16 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None):
 
     Raises:
         ValueError: If ``session_cookie`` is a not a string or is empty.
-        InvalidSessionCookieError: If ``session_cookie`` is not a valid Firebase session cookie or
-            if ``check_revoked`` is ``True`` and the cookie has been revoked.
+        InvalidSessionCookieError: If ``session_cookie`` is not a valid Firebase session cookie.
         ExpiredSessionCookieError: If the specified session cookie has expired.
+        RevokedSessionCookieError: If ``check_revoked`` is ``True`` and the cookie has been revoked.
         CertificateFetchError: If an error occurs while fetching the public key certificates
             required to verify the session cookie.
     """
     token_verifier = _get_auth_service(app).token_verifier
     verified_claims = token_verifier.verify_session_cookie(session_cookie)
     if check_revoked:
-        _check_jwt_revoked(verified_claims, InvalidSessionCookieError, 'session cookie', app)
+        _check_jwt_revoked(verified_claims, RevokedSessionCookieError, 'session cookie', app)
     return verified_claims
 
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -351,7 +351,7 @@ def test_verify_id_token_revoked(new_user, api_key):
     # verify_id_token succeeded because it didn't check revoked.
     assert claims['iat'] * 1000 < user.tokens_valid_after_timestamp
 
-    with pytest.raises(auth.InvalidIdTokenError) as excinfo:
+    with pytest.raises(auth.RevokedIdTokenError) as excinfo:
         claims = auth.verify_id_token(id_token, check_revoked=True)
     assert str(excinfo.value) == 'The Firebase ID token has been revoked.'
 
@@ -372,7 +372,7 @@ def test_verify_session_cookie_revoked(new_user, api_key):
     # verify_session_cookie succeeded because it didn't check revoked.
     assert claims['iat'] * 1000 < user.tokens_valid_after_timestamp
 
-    with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
+    with pytest.raises(auth.RevokedSessionCookieError) as excinfo:
         claims = auth.verify_session_cookie(session_cookie, check_revoked=True)
     assert str(excinfo.value) == 'The Firebase session cookie has been revoked.'
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -351,9 +351,8 @@ def test_verify_id_token_revoked(new_user, api_key):
     # verify_id_token succeeded because it didn't check revoked.
     assert claims['iat'] * 1000 < user.tokens_valid_after_timestamp
 
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.InvalidIdTokenError) as excinfo:
         claims = auth.verify_id_token(id_token, check_revoked=True)
-    assert excinfo.value.code == auth._ID_TOKEN_REVOKED
     assert str(excinfo.value) == 'The Firebase ID token has been revoked.'
 
     # Sign in again, verify works.
@@ -373,9 +372,8 @@ def test_verify_session_cookie_revoked(new_user, api_key):
     # verify_session_cookie succeeded because it didn't check revoked.
     assert claims['iat'] * 1000 < user.tokens_valid_after_timestamp
 
-    with pytest.raises(auth.AuthError) as excinfo:
+    with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
         claims = auth.verify_session_cookie(session_cookie, check_revoked=True)
-    assert excinfo.value.code == auth._SESSION_COOKIE_REVOKED
     assert str(excinfo.value) == 'The Firebase session cookie has been revoked.'
 
     # Sign in again, verify works.

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -46,6 +46,15 @@ MOCK_REQUEST = testutils.MockRequest(200, MOCK_PUBLIC_CERTS)
 
 INVALID_STRINGS = [None, '', 0, 1, True, False, list(), tuple(), dict()]
 INVALID_BOOLS = [None, '', 'foo', 0, 1, list(), tuple(), dict()]
+INVALID_JWT_ARGS = {
+    'NoneToken': None,
+    'EmptyToken': '',
+    'BoolToken': True,
+    'IntToken': 1,
+    'ListToken': [],
+    'EmptyDictToken': {},
+    'NonEmptyDictToken': {'a': 1},
+}
 
 # Fixture for mocking a HTTP server
 httpserver = plugin.httpserver
@@ -363,13 +372,6 @@ class TestVerifyIdToken(object):
             'iat': int(time.time()) - 10000,
             'exp': int(time.time()) - 3600
         }),
-        'NoneToken': None,
-        'EmptyToken': '',
-        'BoolToken': True,
-        'IntToken': 1,
-        'ListToken': [],
-        'EmptyDictToken': {},
-        'NonEmptyDictToken': {'a': 1},
         'BadFormatToken': 'foobar'
     }
 
@@ -392,9 +394,8 @@ class TestVerifyIdToken(object):
     def test_revoked_token_check_revoked(self, user_mgt_app, revoked_tokens, id_token):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, revoked_tokens)
-        with pytest.raises(auth.AuthError) as excinfo:
+        with pytest.raises(auth.InvalidIdTokenError) as excinfo:
             auth.verify_id_token(id_token, app=user_mgt_app, check_revoked=True)
-        assert excinfo.value.code == 'ID_TOKEN_REVOKED'
         assert str(excinfo.value) == 'The Firebase ID token has been revoked.'
 
     @pytest.mark.parametrize('arg', INVALID_BOOLS)
@@ -411,11 +412,30 @@ class TestVerifyIdToken(object):
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
 
+    @pytest.mark.parametrize('id_token', INVALID_JWT_ARGS.values(), ids=list(INVALID_JWT_ARGS))
+    def test_invalid_arg(self, user_mgt_app, id_token):
+        _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
+        with pytest.raises(ValueError) as excinfo:
+            auth.verify_id_token(id_token, app=user_mgt_app)
+        assert 'Illegal ID token provided' in str(excinfo.value)
+
     @pytest.mark.parametrize('id_token', invalid_tokens.values(), ids=list(invalid_tokens))
     def test_invalid_token(self, user_mgt_app, id_token):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
-        with pytest.raises(ValueError):
+        with pytest.raises(auth.InvalidIdTokenError) as excinfo:
             auth.verify_id_token(id_token, app=user_mgt_app)
+        assert isinstance(excinfo.value, exceptions.InvalidArgumentError)
+        assert excinfo.value.http_response is None
+
+    def test_expired_token(self, user_mgt_app):
+        _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
+        id_token = self.invalid_tokens['ExpiredToken']
+        with pytest.raises(auth.ExpiredIdTokenError) as excinfo:
+            auth.verify_id_token(id_token, app=user_mgt_app)
+        assert isinstance(excinfo.value, auth.InvalidIdTokenError)
+        assert 'Token expired' in str(excinfo.value)
+        assert excinfo.value.cause is not None
+        assert excinfo.value.http_response is None
 
     def test_project_id_option(self):
         app = firebase_admin.initialize_app(
@@ -440,13 +460,19 @@ class TestVerifyIdToken(object):
     def test_custom_token(self, auth_app):
         id_token = auth.create_custom_token(MOCK_UID, app=auth_app)
         _overwrite_cert_request(auth_app, MOCK_REQUEST)
-        with pytest.raises(ValueError):
+        with pytest.raises(auth.InvalidIdTokenError) as excinfo:
             auth.verify_id_token(id_token, app=auth_app)
+        message = 'verify_id_token() expects an ID token, but was given a custom token.'
+        assert str(excinfo.value) == message
 
     def test_certificate_request_failure(self, user_mgt_app):
         _overwrite_cert_request(user_mgt_app, testutils.MockRequest(404, 'not found'))
-        with pytest.raises(google.auth.exceptions.TransportError):
+        with pytest.raises(auth.CertificateFetchError) as excinfo:
             auth.verify_id_token(TEST_ID_TOKEN, app=user_mgt_app)
+        assert 'Could not fetch certificates' in str(excinfo.value)
+        assert isinstance(excinfo.value, exceptions.UnknownError)
+        assert excinfo.value.cause is not None
+        assert excinfo.value.http_response is None
 
 
 class TestVerifySessionCookie(object):
@@ -471,13 +497,6 @@ class TestVerifySessionCookie(object):
             'iat': int(time.time()) - 10000,
             'exp': int(time.time()) - 3600
         }),
-        'NoneCookie': None,
-        'EmptyCookie': '',
-        'BoolCookie': True,
-        'IntCookie': 1,
-        'ListCookie': [],
-        'EmptyDictCookie': {},
-        'NonEmptyDictCookie': {'a': 1},
         'BadFormatCookie': 'foobar',
         'IDToken': TEST_ID_TOKEN,
     }
@@ -501,9 +520,8 @@ class TestVerifySessionCookie(object):
     def test_revoked_cookie_check_revoked(self, user_mgt_app, revoked_tokens, cookie):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, revoked_tokens)
-        with pytest.raises(auth.AuthError) as excinfo:
+        with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
             auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=True)
-        assert excinfo.value.code == 'SESSION_COOKIE_REVOKED'
         assert str(excinfo.value) == 'The Firebase session cookie has been revoked.'
 
     @pytest.mark.parametrize('cookie', valid_cookies.values(), ids=list(valid_cookies))
@@ -514,11 +532,30 @@ class TestVerifySessionCookie(object):
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
 
+    @pytest.mark.parametrize('cookie', INVALID_JWT_ARGS.values(), ids=list(INVALID_JWT_ARGS))
+    def test_invalid_args(self, user_mgt_app, cookie):
+        _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
+        with pytest.raises(ValueError) as excinfo:
+            auth.verify_session_cookie(cookie, app=user_mgt_app)
+        assert 'Illegal session cookie provided' in str(excinfo.value)
+
     @pytest.mark.parametrize('cookie', invalid_cookies.values(), ids=list(invalid_cookies))
     def test_invalid_cookie(self, user_mgt_app, cookie):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
-        with pytest.raises(ValueError):
+        with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
             auth.verify_session_cookie(cookie, app=user_mgt_app)
+        assert isinstance(excinfo.value, exceptions.InvalidArgumentError)
+        assert excinfo.value.http_response is None
+
+    def test_expired_cookie(self, user_mgt_app):
+        _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
+        cookie = self.invalid_cookies['ExpiredCookie']
+        with pytest.raises(auth.ExpiredSessionCookieError) as excinfo:
+            auth.verify_session_cookie(cookie, app=user_mgt_app)
+        assert isinstance(excinfo.value, auth.InvalidSessionCookieError)
+        assert 'Token expired' in str(excinfo.value)
+        assert excinfo.value.cause is not None
+        assert excinfo.value.http_response is None
 
     def test_project_id_option(self):
         app = firebase_admin.initialize_app(
@@ -540,13 +577,17 @@ class TestVerifySessionCookie(object):
     def test_custom_token(self, auth_app):
         custom_token = auth.create_custom_token(MOCK_UID, app=auth_app)
         _overwrite_cert_request(auth_app, MOCK_REQUEST)
-        with pytest.raises(ValueError):
+        with pytest.raises(auth.InvalidSessionCookieError):
             auth.verify_session_cookie(custom_token, app=auth_app)
 
     def test_certificate_request_failure(self, user_mgt_app):
         _overwrite_cert_request(user_mgt_app, testutils.MockRequest(404, 'not found'))
-        with pytest.raises(google.auth.exceptions.TransportError):
+        with pytest.raises(auth.CertificateFetchError) as excinfo:
             auth.verify_session_cookie(TEST_SESSION_COOKIE, app=user_mgt_app)
+        assert 'Could not fetch certificates' in str(excinfo.value)
+        assert isinstance(excinfo.value, exceptions.UnknownError)
+        assert excinfo.value.cause is not None
+        assert excinfo.value.http_response is None
 
 
 class TestCertificateCaching(object):

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -394,7 +394,7 @@ class TestVerifyIdToken(object):
     def test_revoked_token_check_revoked(self, user_mgt_app, revoked_tokens, id_token):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, revoked_tokens)
-        with pytest.raises(auth.InvalidIdTokenError) as excinfo:
+        with pytest.raises(auth.RevokedIdTokenError) as excinfo:
             auth.verify_id_token(id_token, app=user_mgt_app, check_revoked=True)
         assert str(excinfo.value) == 'The Firebase ID token has been revoked.'
 
@@ -520,7 +520,7 @@ class TestVerifySessionCookie(object):
     def test_revoked_cookie_check_revoked(self, user_mgt_app, revoked_tokens, cookie):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, revoked_tokens)
-        with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
+        with pytest.raises(auth.RevokedSessionCookieError) as excinfo:
             auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=True)
         assert str(excinfo.value) == 'The Firebase session cookie has been revoked.'
 


### PR DESCRIPTION
Migrates the `verify_id_token()` and `verify_session_cookie()` APIs to new exception types. This completes the error handling migration for the `auth` module.

go/firebase-error-handling-py