### PR TITLE
Adding a few overlooked error types

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -202,6 +202,15 @@ class UidAlreadyExistsError(exceptions.AlreadyExistsError):
         exceptions.AlreadyExistsError.__init__(self, message, cause, http_response)
 
 
+class EmailAlreadyExistsError(exceptions.AlreadyExistsError):
+    """The user with the provided email already exists."""
+
+    default_message = 'The user with the provided email already exists'
+
+    def __init__(self, message, cause, http_response):
+        exceptions.AlreadyExistsError.__init__(self, message, cause, http_response)
+
+
 class InvalidDynamicLinkDomainError(exceptions.InvalidArgumentError):
     """Dynamic link domain in ActionCodeSettings is not authorized."""
 
@@ -218,6 +227,15 @@ class InvalidIdTokenError(exceptions.InvalidArgumentError):
 
     def __init__(self, message, cause=None, http_response=None):
         exceptions.InvalidArgumentError.__init__(self, message, cause, http_response)
+
+
+class PhoneNumberAlreadyExistsError(exceptions.AlreadyExistsError):
+    """The user with the provided phone number already exists."""
+
+    default_message = 'The user with the provided phone number already exists'
+
+    def __init__(self, message, cause, http_response):
+        exceptions.AlreadyExistsError.__init__(self, message, cause, http_response)
 
 
 class UnexpectedResponseError(exceptions.UnknownError):
@@ -237,9 +255,11 @@ class UserNotFoundError(exceptions.NotFoundError):
 
 
 _CODE_TO_EXC_TYPE = {
+    'DUPLICATE_EMAIL': EmailAlreadyExistsError,
     'DUPLICATE_LOCAL_ID': UidAlreadyExistsError,
     'INVALID_DYNAMIC_LINK_DOMAIN': InvalidDynamicLinkDomainError,
     'INVALID_ID_TOKEN': InvalidIdTokenError,
+    'PHONE_NUMBER_EXISTS': PhoneNumberAlreadyExistsError,
     'USER_NOT_FOUND': UserNotFoundError,
 }
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -37,6 +37,7 @@ __all__ = [
     'ActionCodeSettings',
     'CertificateFetchError',
     'DELETE_ATTRIBUTE',
+    'EmailAlreadyExistsError',
     'ErrorInfo',
     'ExpiredIdTokenError',
     'ExpiredSessionCookieError',
@@ -46,6 +47,7 @@ __all__ = [
     'InvalidIdTokenError',
     'InvalidSessionCookieError',
     'ListUsersPage',
+    'PhoneNumberAlreadyExistsError',
     'RevokedIdTokenError',
     'RevokedSessionCookieError',
     'TokenSignError',
@@ -81,6 +83,7 @@ __all__ = [
 ActionCodeSettings = _user_mgt.ActionCodeSettings
 CertificateFetchError = _token_gen.CertificateFetchError
 DELETE_ATTRIBUTE = _user_mgt.DELETE_ATTRIBUTE
+EmailAlreadyExistsError = _auth_utils.EmailAlreadyExistsError
 ErrorInfo = _user_import.ErrorInfo
 ExpiredIdTokenError = _token_gen.ExpiredIdTokenError
 ExpiredSessionCookieError = _token_gen.ExpiredSessionCookieError
@@ -90,6 +93,7 @@ InvalidDynamicLinkDomainError = _auth_utils.InvalidDynamicLinkDomainError
 InvalidIdTokenError = _auth_utils.InvalidIdTokenError
 InvalidSessionCookieError = _token_gen.InvalidSessionCookieError
 ListUsersPage = _user_mgt.ListUsersPage
+PhoneNumberAlreadyExistsError = _auth_utils.PhoneNumberAlreadyExistsError
 RevokedIdTokenError = _token_gen.RevokedIdTokenError
 RevokedSessionCookieError = _token_gen.RevokedSessionCookieError
 TokenSignError = _token_gen.TokenSignError

--- a/firebase_admin/exceptions.py
+++ b/firebase_admin/exceptions.py
@@ -38,7 +38,18 @@ DEADLINE_EXCEEDED = 'DEADLINE_EXCEEDED'
 
 
 class FirebaseError(Exception):
-    """Base class for all errors raised by the Admin SDK."""
+    """Base class for all errors raised by the Admin SDK.
+
+    Args:
+        code: A string error code that represents the type of the exception. Possible error
+            codes are defined in https://cloud.google.com/apis/design/errors#handling_errors.
+        message: A human-readable error message string.
+        cause: The exception that caused this error (optional).
+        http_response: If this error was caused by an HTTP error response, this property is
+            set to the ``requests.Response`` object that represents the HTTP response (optional).
+            See https://2.python-requests.org/en/master/api/#requests.Response for details of
+            this object.
+    """
 
     def __init__(self, code, message, cause=None, http_response=None):
         Exception.__init__(self, message)


### PR DESCRIPTION
Added the following error types in `auth`:

1. EmailAlreadyExistsError
2. PhoneNumberAlreadyExistsError

Updated documentation and tests.