### PR TITLE
feat(fcm): Added support for arbitrary key-value pairs in `messaging.ApsAlert`

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -394,10 +394,13 @@ class ApsAlert(object):
         action_loc_key: Key of the text in the app's string resources to use to localize the
             action button text (optional).
         launch_image: Image for the notification action (optional).
+        custom_data: A dict of custom key-value pairs to be included in the ApsAlert dictionary
+            (optional)
     """
 
     def __init__(self, title=None, subtitle=None, body=None, loc_key=None, loc_args=None,
-                 title_loc_key=None, title_loc_args=None, action_loc_key=None, launch_image=None):
+                 title_loc_key=None, title_loc_args=None, action_loc_key=None, launch_image=None,
+                 custom_data=None):
         self.title = title
         self.subtitle = subtitle
         self.body = body
@@ -407,6 +410,7 @@ class ApsAlert(object):
         self.title_loc_args = title_loc_args
         self.action_loc_key = action_loc_key
         self.launch_image = launch_image
+        self.custom_data = custom_data
 
 
 class APNSFcmOptions(object):
@@ -835,6 +839,14 @@ class MessageEncoder(json.JSONEncoder):
         if result.get('title-loc-args') and not result.get('title-loc-key'):
             raise ValueError(
                 'ApsAlert.title_loc_key is required when specifying title_loc_args.')
+        if alert.custom_data is not None:
+            if not isinstance(alert.custom_data, dict):
+                raise ValueError('ApsAlert.custom_data must be a dict.')
+            for key, val in alert.custom_data.items():
+                _Validators.check_string('ApsAlert.custom_data key', key)
+                # allow specifying key override because Apple could update API so that key
+                # could have unexpected value type
+                result[key] = val
         return cls.remove_null_values(result)
 
     @classmethod

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1209,6 +1209,72 @@ class TestApsAlertEncoder(object):
         }
         check_encoding(msg, expected)
 
+    def test_aps_alert_custom_data_merge(self):
+        msg = messaging.Message(
+            topic='topic',
+            apns=messaging.APNSConfig(
+                payload=messaging.APNSPayload(
+                    aps=messaging.Aps(
+                        alert=messaging.ApsAlert(
+                            title='t',
+                            subtitle='st',
+                            custom_data={'k1': 'v1', 'k2': 'v2'}
+                        )
+                    ),
+                )
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'apns': {
+                'payload': {
+                    'aps': {
+                        'alert': {
+                            'title': 't',
+                            'subtitle': 'st',
+                            'k1': 'v1',
+                            'k2': 'v2'
+                        },
+                    },
+                }
+            },
+        }
+        check_encoding(msg, expected)
+
+    def test_aps_alert_custom_data_override(self):
+        msg = messaging.Message(
+            topic='topic',
+            apns=messaging.APNSConfig(
+                payload=messaging.APNSPayload(
+                    aps=messaging.Aps(
+                        alert=messaging.ApsAlert(
+                            title='t',
+                            subtitle='st',
+                            launch_image='li',
+                            custom_data={'launch-image': ['li1', 'li2']}
+                        )
+                    ),
+                )
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'apns': {
+                'payload': {
+                    'aps': {
+                        'alert': {
+                            'title': 't',
+                            'subtitle': 'st',
+                            'launch-image': [
+                                'li1',
+                                'li2'
+                            ]
+                        },
+                    },
+                }
+            },
+        }
+        check_encoding(msg, expected)
 
 class TestTimeout(object):
 


### PR DESCRIPTION
NB: If arbitrary key-value dictionary contains key matching already supported key, it overrides the value. The motivation behind this is that if Apple will start accepting other value type than API provides API consumer will still be able to specify that (case covered w/ unit test)

It does affect the public API, but in a backwards compatible way, so I believe it's good to go?
Closes #245