### PR TITLE
Updated the metadata server URL

### DIFF
--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -48,8 +48,8 @@ RESERVED_CLAIMS = set([
     'acr', 'amr', 'at_hash', 'aud', 'auth_time', 'azp', 'cnf', 'c_hash',
     'exp', 'firebase', 'iat', 'iss', 'jti', 'nbf', 'nonce', 'sub'
 ])
-METADATA_SERVICE_URL = ('http://metadata/computeMetadata/v1/instance/service-accounts/'
-                        'default/email')
+METADATA_SERVICE_URL = ('http://metadata.google.internal/computeMetadata/v1/instance/'
+                        'service-accounts/default/email')
 
 # Error codes
 COOKIE_CREATE_ERROR = 'COOKIE_CREATE_ERROR'


### PR DESCRIPTION
Using the full hostname of the metadata server, since the shortname `metadata` is aliased to different hosts in certain environments. This is not a problem for production deployments, but sometimes causes issues when running unit tests.

https://cloud.google.com/compute/docs/storing-retrieving-metadata