### PR TITLE
fix(fcm): Renamed FcmOptions types to FCMOptions

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -36,7 +36,7 @@ class Message(object):
         android: An instance of ``messaging.AndroidConfig`` (optional).
         webpush: An instance of ``messaging.WebpushConfig`` (optional).
         apns: An instance of ``messaging.ApnsConfig`` (optional).
-        fcm_options: An instance of ``messaging.FcmOptions`` (optional).
+        fcm_options: An instance of ``messaging.FCMOptions`` (optional).
         token: The registration token of the device to which the message should be sent (optional).
         topic: Name of the FCM topic to which the message should be sent (optional). Topic name
             may contain the ``/topics/`` prefix.
@@ -67,7 +67,7 @@ class MulticastMessage(object):
         android: An instance of ``messaging.AndroidConfig`` (optional).
         webpush: An instance of ``messaging.WebpushConfig`` (optional).
         apns: An instance of ``messaging.ApnsConfig`` (optional).
-        fcm_options: An instance of ``messaging.FcmOptions`` (optional).
+        fcm_options: An instance of ``messaging.FCMOptions`` (optional).
     """
     def __init__(self, tokens, data=None, notification=None, android=None, webpush=None, apns=None,
                  fcm_options=None):
@@ -112,7 +112,7 @@ class AndroidConfig(object):
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings. When specified, overrides any data fields set via ``Message.data``.
         notification: A ``messaging.AndroidNotification`` to be included in the message (optional).
-        fcm_options: A ``messaging.AndroidFcmOptions`` to be included in the message (optional).
+        fcm_options: A ``messaging.AndroidFCMOptions`` to be included in the message (optional).
     """
 
     def __init__(self, collapse_key=None, priority=None, ttl=None, restricted_package_name=None,
@@ -172,7 +172,7 @@ class AndroidNotification(object):
         self.channel_id = channel_id
 
 
-class AndroidFcmOptions(object):
+class AndroidFCMOptions(object):
     """Options for features provided by the FCM SDK for Android.
 
     Args:
@@ -193,7 +193,7 @@ class WebpushConfig(object):
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings. When specified, overrides any data fields set via ``Message.data``.
         notification: A ``messaging.WebpushNotification`` to be included in the message (optional).
-        fcm_options: A ``messaging.WebpushFcmOptions`` instance to be included in the message
+        fcm_options: A ``messaging.WebpushFCMOptions`` instance to be included in the message
             (optional).
 
     .. _Webpush Specification: https://tools.ietf.org/html/rfc8030#section-5
@@ -278,7 +278,7 @@ class WebpushNotification(object):
         self.custom_data = custom_data
 
 
-class WebpushFcmOptions(object):
+class WebpushFCMOptions(object):
     """Options for features provided by the FCM SDK for Web.
 
     Args:
@@ -298,7 +298,7 @@ class APNSConfig(object):
     Args:
         headers: A dictionary of headers (optional).
         payload: A ``messaging.APNSPayload`` to be included in the message (optional).
-        fcm_options: A ``messaging.APNSFcmOptions`` instance to be included in the message
+        fcm_options: A ``messaging.APNSFCMOptions`` instance to be included in the message
             (optional).
 
     .. _APNS Documentation: https://developer.apple.com/library/content/documentation\
@@ -413,7 +413,7 @@ class ApsAlert(object):
         self.custom_data = custom_data
 
 
-class APNSFcmOptions(object):
+class APNSFCMOptions(object):
     """Options for features provided by the FCM SDK for iOS.
 
     Args:
@@ -425,7 +425,7 @@ class APNSFcmOptions(object):
         self.analytics_label = analytics_label
 
 
-class FcmOptions(object):
+class FCMOptions(object):
     """Options for features provided by SDK.
 
     Args:
@@ -535,15 +535,15 @@ class MessageEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_android_fcm_options(cls, fcm_options):
-        """Encodes a AndroidFcmOptions instance into a json."""
+        """Encodes an AndroidFCMOptions instance into a json."""
         if fcm_options is None:
             return None
-        if not isinstance(fcm_options, AndroidFcmOptions):
+        if not isinstance(fcm_options, AndroidFCMOptions):
             raise ValueError('AndroidConfig.fcm_options must be an instance of '
-                             'AndroidFcmOptions class.')
+                             'AndroidFCMOptions class.')
         result = {
             'analytics_label': _Validators.check_analytics_label(
-                'AndroidFcmOptions.analytics_label', fcm_options.analytics_label),
+                'AndroidFCMOptions.analytics_label', fcm_options.analytics_label),
         }
         result = cls.remove_null_values(result)
         return result
@@ -703,7 +703,7 @@ class MessageEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_webpush_fcm_options(cls, options):
-        """Encodes a WebpushFcmOptions instance into JSON."""
+        """Encodes a WebpushFCMOptions instance into JSON."""
         if options is None:
             return None
         result = {
@@ -712,7 +712,7 @@ class MessageEncoder(json.JSONEncoder):
         result = cls.remove_null_values(result)
         link = result.get('link')
         if link is not None and not link.startswith('https://'):
-            raise ValueError('WebpushFcmOptions.link must be a HTTPS URL.')
+            raise ValueError('WebpushFCMOptions.link must be a HTTPS URL.')
         return result
 
     @classmethod
@@ -746,14 +746,14 @@ class MessageEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_apns_fcm_options(cls, fcm_options):
-        """Encodes an APNSFcmOptions instance into JSON."""
+        """Encodes an APNSFCMOptions instance into JSON."""
         if fcm_options is None:
             return None
-        if not isinstance(fcm_options, APNSFcmOptions):
-            raise ValueError('APNSConfig.fcm_options must be an instance of APNSFcmOptions class.')
+        if not isinstance(fcm_options, APNSFCMOptions):
+            raise ValueError('APNSConfig.fcm_options must be an instance of APNSFCMOptions class.')
         result = {
             'analytics_label': _Validators.check_analytics_label(
-                'APNSFcmOptions.analytics_label', fcm_options.analytics_label),
+                'APNSFCMOptions.analytics_label', fcm_options.analytics_label),
         }
         result = cls.remove_null_values(result)
         return result
@@ -897,14 +897,14 @@ class MessageEncoder(json.JSONEncoder):
 
     @classmethod
     def encode_fcm_options(cls, fcm_options):
-        """Encodes an FcmOptions instance into JSON."""
+        """Encodes an FCMOptions instance into JSON."""
         if fcm_options is None:
             return None
-        if not isinstance(fcm_options, FcmOptions):
-            raise ValueError('Message.fcm_options must be an instance of FcmOptions class.')
+        if not isinstance(fcm_options, FCMOptions):
+            raise ValueError('Message.fcm_options must be an instance of FCMOptions class.')
         result = {
             'analytics_label': _Validators.check_analytics_label(
-                'FcmOptions.analytics_label', fcm_options.analytics_label),
+                'FCMOptions.analytics_label', fcm_options.analytics_label),
         }
         result = cls.remove_null_values(result)
         return result

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -33,10 +33,10 @@ _MESSAGING_ATTRIBUTE = '_messaging'
 
 __all__ = [
     'AndroidConfig',
-    'AndroidFcmOptions',
+    'AndroidFCMOptions',
     'AndroidNotification',
     'APNSConfig',
-    'APNSFcmOptions',
+    'APNSFCMOptions',
     'APNSPayload',
     'ApiCallError',
     'Aps',
@@ -44,14 +44,14 @@ __all__ = [
     'BatchResponse',
     'CriticalSound',
     'ErrorInfo',
-    'FcmOptions',
+    'FCMOptions',
     'Message',
     'MulticastMessage',
     'Notification',
     'SendResponse',
     'TopicManagementResponse',
     'WebpushConfig',
-    'WebpushFcmOptions',
+    'WebpushFCMOptions',
     'WebpushNotification',
     'WebpushNotificationAction',
 
@@ -64,20 +64,21 @@ __all__ = [
 
 
 AndroidConfig = _messaging_utils.AndroidConfig
-AndroidFcmOptions = _messaging_utils.AndroidFcmOptions
+AndroidFCMOptions = _messaging_utils.AndroidFCMOptions
 AndroidNotification = _messaging_utils.AndroidNotification
 APNSConfig = _messaging_utils.APNSConfig
-APNSFcmOptions = _messaging_utils.APNSFcmOptions
+APNSFCMOptions = _messaging_utils.APNSFCMOptions
 APNSPayload = _messaging_utils.APNSPayload
 Aps = _messaging_utils.Aps
 ApsAlert = _messaging_utils.ApsAlert
 CriticalSound = _messaging_utils.CriticalSound
-FcmOptions = _messaging_utils.FcmOptions
+FCMOptions = _messaging_utils.FCMOptions
 Message = _messaging_utils.Message
 MulticastMessage = _messaging_utils.MulticastMessage
 Notification = _messaging_utils.Notification
 WebpushConfig = _messaging_utils.WebpushConfig
-WebpushFcmOptions = _messaging_utils.WebpushFcmOptions
+WebpushFCMOptions = _messaging_utils.WebpushFCMOptions
+WebpushFcmOptions = _messaging_utils.WebpushFCMOptions
 WebpushNotification = _messaging_utils.WebpushNotification
 WebpushNotificationAction = _messaging_utils.WebpushNotificationAction
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -123,10 +123,10 @@ class TestMessageEncoder(object):
     def test_fcm_options(self):
         check_encoding(
             messaging.Message(
-                topic='topic', fcm_options=messaging.FcmOptions('analytics_label_v1')),
+                topic='topic', fcm_options=messaging.FCMOptions('analytics_label_v1')),
             {'topic': 'topic', 'fcm_options': {'analytics_label': 'analytics_label_v1'}})
         check_encoding(
-            messaging.Message(topic='topic', fcm_options=messaging.FcmOptions()),
+            messaging.Message(topic='topic', fcm_options=messaging.FCMOptions()),
             {'topic': 'topic'})
 
 
@@ -177,27 +177,27 @@ class TestFcmOptionEncoder(object):
         with pytest.raises(ValueError) as excinfo:
             check_encoding(messaging.Message(
                 topic='topic',
-                fcm_options=messaging.FcmOptions(label)
+                fcm_options=messaging.FCMOptions(label)
             ))
-        expected = 'Malformed FcmOptions.analytics_label.'
+        expected = 'Malformed FCMOptions.analytics_label.'
         assert str(excinfo.value) == expected
 
     def test_fcm_options(self):
         check_encoding(
             messaging.Message(
                 topic='topic',
-                fcm_options=messaging.FcmOptions(),
-                android=messaging.AndroidConfig(fcm_options=messaging.AndroidFcmOptions()),
-                apns=messaging.APNSConfig(fcm_options=messaging.APNSFcmOptions())
+                fcm_options=messaging.FCMOptions(),
+                android=messaging.AndroidConfig(fcm_options=messaging.AndroidFCMOptions()),
+                apns=messaging.APNSConfig(fcm_options=messaging.APNSFCMOptions())
             ),
             {'topic': 'topic'})
         check_encoding(
             messaging.Message(
                 topic='topic',
-                fcm_options=messaging.FcmOptions('message-label'),
+                fcm_options=messaging.FCMOptions('message-label'),
                 android=messaging.AndroidConfig(
-                    fcm_options=messaging.AndroidFcmOptions('android-label')),
-                apns=messaging.APNSConfig(fcm_options=messaging.APNSFcmOptions('apns-label'))
+                    fcm_options=messaging.AndroidFCMOptions('android-label')),
+                apns=messaging.APNSConfig(fcm_options=messaging.APNSFCMOptions('apns-label'))
             ),
             {
                 'topic': 'topic',
@@ -267,7 +267,7 @@ class TestAndroidConfigEncoder(object):
                 priority='high',
                 ttl=123,
                 data={'k1': 'v1', 'k2': 'v2'},
-                fcm_options=messaging.AndroidFcmOptions('analytics_label_v1')
+                fcm_options=messaging.AndroidFCMOptions('analytics_label_v1')
             )
         )
         expected = {
@@ -500,7 +500,7 @@ class TestWebpushConfigEncoder(object):
         check_encoding(msg, expected)
 
 
-class TestWebpushFcmOptionsEncoder(object):
+class TestWebpushFCMOptionsEncoder(object):
 
     @pytest.mark.parametrize('data', NON_OBJECT_ARGS)
     def test_invalid_webpush_fcm_options(self, data):
@@ -510,7 +510,7 @@ class TestWebpushFcmOptionsEncoder(object):
 
     @pytest.mark.parametrize('data', NON_STRING_ARGS)
     def test_invalid_link_type(self, data):
-        options = messaging.WebpushFcmOptions(link=data)
+        options = messaging.WebpushFCMOptions(link=data)
         with pytest.raises(ValueError) as excinfo:
             check_encoding(messaging.Message(
                 topic='topic', webpush=messaging.WebpushConfig(fcm_options=options)))
@@ -519,14 +519,33 @@ class TestWebpushFcmOptionsEncoder(object):
 
     @pytest.mark.parametrize('data', ['', 'foo', 'http://example'])
     def test_invalid_link_format(self, data):
-        options = messaging.WebpushFcmOptions(link=data)
+        options = messaging.WebpushFCMOptions(link=data)
         with pytest.raises(ValueError) as excinfo:
             check_encoding(messaging.Message(
                 topic='topic', webpush=messaging.WebpushConfig(fcm_options=options)))
-        expected = 'WebpushFcmOptions.link must be a HTTPS URL.'
+        expected = 'WebpushFCMOptions.link must be a HTTPS URL.'
         assert str(excinfo.value) == expected
 
-    def test_webpush_notification(self):
+    def test_webpush_options(self):
+        msg = messaging.Message(
+            topic='topic',
+            webpush=messaging.WebpushConfig(
+                fcm_options=messaging.WebpushFCMOptions(
+                    link='https://example',
+                ),
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'webpush': {
+                'fcm_options': {
+                    'link': 'https://example',
+                },
+            },
+        }
+        check_encoding(msg, expected)
+
+    def test_deprecated_fcm_options(self):
         msg = messaging.Message(
             topic='topic',
             webpush=messaging.WebpushConfig(
@@ -770,7 +789,7 @@ class TestAPNSConfigEncoder(object):
             topic='topic',
             apns=messaging.APNSConfig(
                 headers={'h1': 'v1', 'h2': 'v2'},
-                fcm_options=messaging.APNSFcmOptions('analytics_label_v1')
+                fcm_options=messaging.APNSFCMOptions('analytics_label_v1')
             ),
         )
         expected = {


### PR DESCRIPTION
Renamed the new types `AndroidFcmOptions`, `APNSFcmOptions` and `FcmOptions` to be PEP8 compliant.

RELEASE NOTE: The `WebpushFcmOptions` type is now deprecated. Developers should use the PEP8 compliant type name `WebpushFCMOptions` instead.