### PR TITLE
Some types renamed to be PEP8 compliant

### DIFF
--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -81,7 +81,6 @@ MulticastMessage = _messaging_utils.MulticastMessage
 Notification = _messaging_utils.Notification
 WebpushConfig = _messaging_utils.WebpushConfig
 WebpushFCMOptions = _messaging_utils.WebpushFCMOptions
-WebpushFcmOptions = _messaging_utils.WebpushFCMOptions
 WebpushNotification = _messaging_utils.WebpushNotification
 WebpushNotificationAction = _messaging_utils.WebpushNotificationAction
 

--- a/firebase_admin/project_management.py
+++ b/firebase_admin/project_management.py
@@ -58,9 +58,9 @@ def ios_app(app_id, app=None):
         app: An App instance (optional).
 
     Returns:
-        IosApp: An ``IosApp`` instance.
+        IOSApp: An ``IOSApp`` instance.
     """
-    return IosApp(app_id=app_id, service=_get_project_management_service(app))
+    return IOSApp(app_id=app_id, service=_get_project_management_service(app))
 
 
 def list_android_apps(app=None):
@@ -83,7 +83,7 @@ def list_ios_apps(app=None):
         app: An App instance (optional).
 
     Returns:
-        list: a list of ``IosApp`` instances referring to each iOS app in the Firebase project.
+        list: a list of ``IOSApp`` instances referring to each iOS app in the Firebase project.
     """
     return _get_project_management_service(app).list_ios_apps()
 
@@ -111,7 +111,7 @@ def create_ios_app(bundle_id, display_name=None, app=None):
         app: An App instance (optional).
 
     Returns:
-        IosApp: An ``IosApp`` instance that is a reference to the newly created app.
+        IOSApp: An ``IOSApp`` instance that is a reference to the newly created app.
     """
     return _get_project_management_service(app).create_ios_app(bundle_id, display_name)
 
@@ -199,7 +199,7 @@ class AndroidApp(object):
         """Retrieves the entire list of SHA certificates associated with this Android app.
 
         Returns:
-            list: A list of ``ShaCertificate`` instances.
+            list: A list of ``SHACertificate`` instances.
 
         Raises:
             FirebaseError: If an error occurs while communicating with the Firebase Project
@@ -238,7 +238,7 @@ class AndroidApp(object):
         return self._service.delete_sha_certificate(certificate_to_delete)
 
 
-class IosApp(object):
+class IOSApp(object):
     """A reference to an iOS app within a Firebase project.
 
     Note: Unless otherwise specified, all methods defined in this class make an RPC.
@@ -266,7 +266,7 @@ class IosApp(object):
         """Retrieves detailed information about this iOS app.
 
         Returns:
-            IosAppMetadata: An ``IosAppMetadata`` instance.
+            IOSAppMetadata: An ``IOSAppMetadata`` instance.
 
         Raises:
             FirebaseError: If an error occurs while communicating with the Firebase Project
@@ -359,12 +359,12 @@ class AndroidAppMetadata(_AppMetadata):
             (self._name, self.app_id, self.display_name, self.project_id, self.package_name))
 
 
-class IosAppMetadata(_AppMetadata):
+class IOSAppMetadata(_AppMetadata):
     """iOS-specific information about an iOS Firebase app."""
 
     def __init__(self, bundle_id, name, app_id, display_name, project_id):
         """Clients should not instantiate this class directly."""
-        super(IosAppMetadata, self).__init__(name, app_id, display_name, project_id)
+        super(IOSAppMetadata, self).__init__(name, app_id, display_name, project_id)
         self._bundle_id = _check_is_nonempty_string(bundle_id, 'bundle_id')
 
     @property
@@ -373,7 +373,7 @@ class IosAppMetadata(_AppMetadata):
         return self._bundle_id
 
     def __eq__(self, other):
-        return super(IosAppMetadata, self).__eq__(other) and self.bundle_id == other.bundle_id
+        return super(IOSAppMetadata, self).__eq__(other) and self.bundle_id == other.bundle_id
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -382,7 +382,7 @@ class IosAppMetadata(_AppMetadata):
         return hash((self._name, self.app_id, self.display_name, self.project_id, self.bundle_id))
 
 
-class ShaCertificate(object):
+class SHACertificate(object):
     """Represents a SHA-1 or SHA-256 certificate associated with an Android app."""
 
     SHA_1 = 'SHA_1'
@@ -392,7 +392,7 @@ class ShaCertificate(object):
     _SHA_256_RE = re.compile('^[0-9A-Fa-f]{64}$')
 
     def __init__(self, sha_hash, name=None):
-        """Creates a new ShaCertificate instance.
+        """Creates a new SHACertificate instance.
 
         Args:
             sha_hash: A string; the certificate hash for the Android app.
@@ -407,10 +407,10 @@ class ShaCertificate(object):
         _check_is_nonempty_string_or_none(name, 'name')
         self._name = name
         self._sha_hash = sha_hash.lower()
-        if ShaCertificate._SHA_1_RE.match(sha_hash):
-            self._cert_type = ShaCertificate.SHA_1
-        elif ShaCertificate._SHA_256_RE.match(sha_hash):
-            self._cert_type = ShaCertificate.SHA_256
+        if SHACertificate._SHA_1_RE.match(sha_hash):
+            self._cert_type = SHACertificate.SHA_1
+        elif SHACertificate._SHA_256_RE.match(sha_hash):
+            self._cert_type = SHACertificate.SHA_256
         else:
             raise ValueError(
                 'The supplied certificate hash is neither a valid SHA-1 nor SHA_256 hash.')
@@ -444,7 +444,7 @@ class ShaCertificate(object):
         return self._cert_type
 
     def __eq__(self, other):
-        if not isinstance(other, ShaCertificate):
+        if not isinstance(other, SHACertificate):
             return False
         return (self.name == other.name and self.sha_hash == other.sha_hash and
                 self.cert_type == other.cert_type)
@@ -496,7 +496,7 @@ class _ProjectManagementService(object):
         return self._get_app_metadata(
             platform_resource_name=_ProjectManagementService.IOS_APPS_RESOURCE_NAME,
             identifier_name=_ProjectManagementService.IOS_APP_IDENTIFIER_NAME,
-            metadata_class=IosAppMetadata,
+            metadata_class=IOSAppMetadata,
             app_id=app_id)
 
     def _get_app_metadata(self, platform_resource_name, identifier_name, metadata_class, app_id):
@@ -538,7 +538,7 @@ class _ProjectManagementService(object):
     def list_ios_apps(self):
         return self._list_apps(
             platform_resource_name=_ProjectManagementService.IOS_APPS_RESOURCE_NAME,
-            app_class=IosApp)
+            app_class=IOSApp)
 
     def _list_apps(self, platform_resource_name, app_class):
         """Lists all the Android or iOS apps within the Firebase project."""
@@ -579,7 +579,7 @@ class _ProjectManagementService(object):
             identifier_name=_ProjectManagementService.IOS_APP_IDENTIFIER_NAME,
             identifier=bundle_id,
             display_name=display_name,
-            app_class=IosApp)
+            app_class=IOSApp)
 
     def _create_app(
             self,
@@ -639,7 +639,7 @@ class _ProjectManagementService(object):
         path = '/v1beta1/projects/-/androidApps/{0}/sha'.format(app_id)
         response = self._make_request('get', path)
         cert_list = response.get('certificates') or []
-        return [ShaCertificate(sha_hash=cert['shaHash'], name=cert['name']) for cert in cert_list]
+        return [SHACertificate(sha_hash=cert['shaHash'], name=cert['name']) for cert in cert_list]
 
     def add_sha_certificate(self, app_id, certificate_to_add):
         path = '/v1beta1/projects/-/androidApps/{0}/sha'.format(app_id)

--- a/integration/test_project_management.py
+++ b/integration/test_project_management.py
@@ -32,8 +32,8 @@ SHA_1_HASH_1 = '123456789a123456789a123456789a123456789a'
 SHA_1_HASH_2 = 'aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb'
 SHA_256_HASH_1 = '123456789a123456789a123456789a123456789a123456789a123456789a1234'
 SHA_256_HASH_2 = 'cafef00dba5eba11b01dfaceacc01adeda7aba5eca55e77e0b57ac1e5ca1ab1e'
-SHA_1 = project_management.ShaCertificate.SHA_1
-SHA_256 = project_management.ShaCertificate.SHA_256
+SHA_1 = project_management.SHACertificate.SHA_1
+SHA_256 = project_management.SHACertificate.SHA_256
 
 
 def _starts_with(display_name, prefix):
@@ -120,10 +120,10 @@ def test_android_sha_certificates(android_app):
         android_app.delete_sha_certificate(cert)
 
     # Add four different certs and assert that they have all been added successfully.
-    android_app.add_sha_certificate(project_management.ShaCertificate(SHA_1_HASH_1))
-    android_app.add_sha_certificate(project_management.ShaCertificate(SHA_1_HASH_2))
-    android_app.add_sha_certificate(project_management.ShaCertificate(SHA_256_HASH_1))
-    android_app.add_sha_certificate(project_management.ShaCertificate(SHA_256_HASH_2))
+    android_app.add_sha_certificate(project_management.SHACertificate(SHA_1_HASH_1))
+    android_app.add_sha_certificate(project_management.SHACertificate(SHA_1_HASH_2))
+    android_app.add_sha_certificate(project_management.SHACertificate(SHA_256_HASH_1))
+    android_app.add_sha_certificate(project_management.SHACertificate(SHA_256_HASH_2))
 
     cert_list = android_app.get_sha_certificates()
 
@@ -136,7 +136,7 @@ def test_android_sha_certificates(android_app):
 
     # Adding the same cert twice should cause an already-exists error.
     with pytest.raises(exceptions.AlreadyExistsError) as excinfo:
-        android_app.add_sha_certificate(project_management.ShaCertificate(SHA_256_HASH_2))
+        android_app.add_sha_certificate(project_management.SHACertificate(SHA_256_HASH_2))
     assert 'Requested entity already exists' in str(excinfo.value)
     assert excinfo.value.cause is not None
     assert excinfo.value.http_response is not None

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -566,25 +566,6 @@ class TestWebpushFCMOptionsEncoder(object):
         }
         check_encoding(msg, expected)
 
-    def test_deprecated_fcm_options(self):
-        msg = messaging.Message(
-            topic='topic',
-            webpush=messaging.WebpushConfig(
-                fcm_options=messaging.WebpushFcmOptions(
-                    link='https://example',
-                ),
-            )
-        )
-        expected = {
-            'topic': 'topic',
-            'webpush': {
-                'fcm_options': {
-                    'link': 'https://example',
-                },
-            },
-        }
-        check_encoding(msg, expected)
-
 
 class TestWebpushNotificationEncoder(object):
 

--- a/tests/test_project_management.py
+++ b/tests/test_project_management.py
@@ -173,10 +173,10 @@ TEST_APP_CONFIG_RESPONSE = json.dumps({
     'configFileContents': TEST_APP_ENCODED_CONFIG,
 })
 
-SHA_1_CERTIFICATE = project_management.ShaCertificate(
+SHA_1_CERTIFICATE = project_management.SHACertificate(
     '123456789a123456789a123456789a123456789a',
     'projects/-/androidApps/1:12345678:android:deadbeef/sha/name1')
-SHA_256_CERTIFICATE = project_management.ShaCertificate(
+SHA_256_CERTIFICATE = project_management.SHACertificate(
     '123456789a123456789a123456789a123456789a123456789a123456789a1234',
     'projects/-/androidApps/1:12345678:android:deadbeef/sha/name256')
 GET_SHA_CERTIFICATES_RESPONSE = json.dumps({'certificates': [
@@ -190,7 +190,7 @@ ANDROID_APP_METADATA = project_management.AndroidAppMetadata(
     app_id='1:12345678:android:deadbeef',
     display_name='My Android App',
     project_id='test-project-id')
-IOS_APP_METADATA = project_management.IosAppMetadata(
+IOS_APP_METADATA = project_management.IOSAppMetadata(
     bundle_id='com.hello.world.ios',
     name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
     app_id='1:12345678:android:deadbeef',
@@ -315,12 +315,12 @@ class TestAndroidAppMetadata(object):
         assert ANDROID_APP_METADATA.project_id == 'test-project-id'
 
 
-class TestIosAppMetadata(object):
+class TestIOSAppMetadata(object):
 
     def test_create_ios_app_metadata_errors(self):
         # bundle_id must be a non-empty string.
         with pytest.raises(ValueError):
-            project_management.IosAppMetadata(
+            project_management.IOSAppMetadata(
                 bundle_id='',
                 name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
                 app_id='1:12345678:android:deadbeef',
@@ -328,7 +328,7 @@ class TestIosAppMetadata(object):
                 project_id='test-project-id')
         # name must be a non-empty string.
         with pytest.raises(ValueError):
-            project_management.IosAppMetadata(
+            project_management.IOSAppMetadata(
                 bundle_id='com.hello.world.ios',
                 name='',
                 app_id='1:12345678:android:deadbeef',
@@ -336,7 +336,7 @@ class TestIosAppMetadata(object):
                 project_id='test-project-id')
         # app_id must be a non-empty string.
         with pytest.raises(ValueError):
-            project_management.IosAppMetadata(
+            project_management.IOSAppMetadata(
                 bundle_id='com.hello.world.ios',
                 name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
                 app_id='',
@@ -344,7 +344,7 @@ class TestIosAppMetadata(object):
                 project_id='test-project-id')
         # display_name must be a string or None.
         with pytest.raises(ValueError):
-            project_management.IosAppMetadata(
+            project_management.IOSAppMetadata(
                 bundle_id='com.hello.world.ios',
                 name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
                 app_id='1:12345678:android:deadbeef',
@@ -352,7 +352,7 @@ class TestIosAppMetadata(object):
                 project_id='test-project-id')
         # project_id must be a nonempty string.
         with pytest.raises(ValueError):
-            project_management.IosAppMetadata(
+            project_management.IOSAppMetadata(
                 bundle_id='com.hello.world.ios',
                 name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
                 app_id='1:12345678:android:deadbeef',
@@ -361,37 +361,37 @@ class TestIosAppMetadata(object):
 
     def test_ios_app_metadata_eq_and_hash(self):
         metadata_1 = IOS_APP_METADATA
-        metadata_2 = project_management.IosAppMetadata(
+        metadata_2 = project_management.IOSAppMetadata(
             bundle_id='different',
             name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
             app_id='1:12345678:android:deadbeef',
             display_name='My iOS App',
             project_id='test-project-id')
-        metadata_3 = project_management.IosAppMetadata(
+        metadata_3 = project_management.IOSAppMetadata(
             bundle_id='com.hello.world.ios',
             name='different',
             app_id='1:12345678:android:deadbeef',
             display_name='My iOS App',
             project_id='test-project-id')
-        metadata_4 = project_management.IosAppMetadata(
+        metadata_4 = project_management.IOSAppMetadata(
             bundle_id='com.hello.world.ios',
             name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
             app_id='different',
             display_name='My iOS App',
             project_id='test-project-id')
-        metadata_5 = project_management.IosAppMetadata(
+        metadata_5 = project_management.IOSAppMetadata(
             bundle_id='com.hello.world.ios',
             name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
             app_id='1:12345678:android:deadbeef',
             display_name='different',
             project_id='test-project-id')
-        metadata_6 = project_management.IosAppMetadata(
+        metadata_6 = project_management.IOSAppMetadata(
             bundle_id='com.hello.world.ios',
             name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
             app_id='1:12345678:android:deadbeef',
             display_name='My iOS App',
             project_id='different')
-        metadata_7 = project_management.IosAppMetadata(
+        metadata_7 = project_management.IOSAppMetadata(
             bundle_id='com.hello.world.ios',
             name='projects/test-project-id/iosApps/1:12345678:ios:ca5cade5',
             app_id='1:12345678:android:deadbeef',
@@ -427,40 +427,40 @@ class TestIosAppMetadata(object):
         assert IOS_APP_METADATA.project_id == 'test-project-id'
 
 
-class TestShaCertificate(object):
+class TestSHACertificate(object):
     def test_create_sha_certificate_errors(self):
         # sha_hash cannot be None.
         with pytest.raises(ValueError):
-            project_management.ShaCertificate(sha_hash=None)
+            project_management.SHACertificate(sha_hash=None)
         # sha_hash must be a string.
         with pytest.raises(ValueError):
-            project_management.ShaCertificate(sha_hash=0x123456789a123456789a123456789a123456789a)
+            project_management.SHACertificate(sha_hash=0x123456789a123456789a123456789a123456789a)
         # sha_hash must be a valid SHA-1 or SHA-256 hash.
         with pytest.raises(ValueError):
-            project_management.ShaCertificate(sha_hash='123456789a123456789')
+            project_management.SHACertificate(sha_hash='123456789a123456789')
         with pytest.raises(ValueError):
-            project_management.ShaCertificate(sha_hash='123456789a123456789a123456789a123456oops')
+            project_management.SHACertificate(sha_hash='123456789a123456789a123456789a123456oops')
 
     def test_sha_certificate_eq(self):
-        sha_cert_1 = project_management.ShaCertificate(
+        sha_cert_1 = project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a',
             'projects/-/androidApps/1:12345678:android:deadbeef/sha/name1')
         # sha_hash is different from sha_cert_1, but name is the same.
-        sha_cert_2 = project_management.ShaCertificate(
+        sha_cert_2 = project_management.SHACertificate(
             '0000000000000000000000000000000000000000',
             'projects/-/androidApps/1:12345678:android:deadbeef/sha/name1')
         # name is different from sha_cert_1, but sha_hash is the same.
-        sha_cert_3 = project_management.ShaCertificate(
+        sha_cert_3 = project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a', None)
         # name is different from sha_cert_1, but sha_hash is the same.
-        sha_cert_4 = project_management.ShaCertificate(
+        sha_cert_4 = project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a', 'projects/-/androidApps/{0}/sha/notname1')
         # sha_hash and cert_type are different from sha_cert_1, but name is the same.
-        sha_cert_5 = project_management.ShaCertificate(
+        sha_cert_5 = project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a123456789a123456789a1234',
             'projects/-/androidApps/{0}/sha/name1')
         # Exactly the same as sha_cert_1.
-        sha_cert_6 = project_management.ShaCertificate(
+        sha_cert_6 = project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a',
             'projects/-/androidApps/1:12345678:android:deadbeef/sha/name1')
         not_a_sha_cert = {
@@ -653,7 +653,7 @@ class TestCreateAndroidApp(BaseProjectManagementTest):
         assert len(recorder) == 3
 
 
-class TestCreateIosApp(BaseProjectManagementTest):
+class TestCreateIOSApp(BaseProjectManagementTest):
     _CREATION_URL = 'https://firebase.googleapis.com/v1beta1/projects/test-project-id/iosApps'
 
     def test_create_ios_app_without_display_name(self):
@@ -671,7 +671,7 @@ class TestCreateIosApp(BaseProjectManagementTest):
         assert ios_app.app_id == '1:12345678:ios:ca5cade5'
         assert len(recorder) == 3
         body = {'bundleId': 'com.hello.world.ios'}
-        self._assert_request_is_correct(recorder[0], 'POST', TestCreateIosApp._CREATION_URL, body)
+        self._assert_request_is_correct(recorder[0], 'POST', TestCreateIOSApp._CREATION_URL, body)
         self._assert_request_is_correct(
             recorder[1], 'GET', 'https://firebase.googleapis.com/v1/operations/abcdefg')
         self._assert_request_is_correct(
@@ -696,7 +696,7 @@ class TestCreateIosApp(BaseProjectManagementTest):
             'bundleId': 'com.hello.world.ios',
             'displayName': 'My iOS App',
         }
-        self._assert_request_is_correct(recorder[0], 'POST', TestCreateIosApp._CREATION_URL, body)
+        self._assert_request_is_correct(recorder[0], 'POST', TestCreateIOSApp._CREATION_URL, body)
         self._assert_request_is_correct(
             recorder[1], 'GET', 'https://firebase.googleapis.com/v1/operations/abcdefg')
         self._assert_request_is_correct(
@@ -836,7 +836,7 @@ class TestListAndroidApps(BaseProjectManagementTest):
         assert len(recorder) == 2
 
 
-class TestListIosApps(BaseProjectManagementTest):
+class TestListIOSApps(BaseProjectManagementTest):
     _LISTING_URL = ('https://firebase.googleapis.com/v1beta1/projects/test-project-id/'
                     'iosApps?pageSize=100')
     _LISTING_PAGE_2_URL = ('https://firebase.googleapis.com/v1beta1/projects/test-project-id/'
@@ -850,7 +850,7 @@ class TestListIosApps(BaseProjectManagementTest):
         expected_app_ids = set(['1:12345678:ios:ca5cade5', '1:12345678:ios:ca5cade5cafe'])
         assert set(app.app_id for app in ios_apps) == expected_app_ids
         assert len(recorder) == 1
-        self._assert_request_is_correct(recorder[0], 'GET', TestListIosApps._LISTING_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestListIOSApps._LISTING_URL)
 
     def test_list_ios_apps_rpc_error(self):
         recorder = self._instrument_service(statuses=[503], responses=[UNAVAILABLE_RESPONSE])
@@ -870,7 +870,7 @@ class TestListIosApps(BaseProjectManagementTest):
 
         assert ios_apps == []
         assert len(recorder) == 1
-        self._assert_request_is_correct(recorder[0], 'GET', TestListIosApps._LISTING_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestListIOSApps._LISTING_URL)
 
     def test_list_ios_apps_multiple_pages(self):
         recorder = self._instrument_service(
@@ -882,8 +882,8 @@ class TestListIosApps(BaseProjectManagementTest):
         expected_app_ids = set(['1:12345678:ios:ca5cade5', '1:12345678:ios:ca5cade5cafe'])
         assert set(app.app_id for app in ios_apps) == expected_app_ids
         assert len(recorder) == 2
-        self._assert_request_is_correct(recorder[0], 'GET', TestListIosApps._LISTING_URL)
-        self._assert_request_is_correct(recorder[1], 'GET', TestListIosApps._LISTING_PAGE_2_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestListIOSApps._LISTING_URL)
+        self._assert_request_is_correct(recorder[1], 'GET', TestListIOSApps._LISTING_PAGE_2_URL)
 
     def test_list_ios_apps_multiple_pages_rpc_error(self):
         recorder = self._instrument_service(
@@ -1043,7 +1043,7 @@ class TestAndroidApp(BaseProjectManagementTest):
         recorder = self._instrument_service(statuses=[200], responses=[json.dumps({})])
 
         android_app.add_sha_certificate(
-            project_management.ShaCertificate('123456789a123456789a123456789a123456789a'))
+            project_management.SHACertificate('123456789a123456789a123456789a123456789a'))
 
         assert len(recorder) == 1
         body = {'shaHash': '123456789a123456789a123456789a123456789a', 'certType': 'SHA_1'}
@@ -1052,7 +1052,7 @@ class TestAndroidApp(BaseProjectManagementTest):
     def test_add_sha_256_certificate(self, android_app):
         recorder = self._instrument_service(statuses=[200], responses=[json.dumps({})])
 
-        android_app.add_sha_certificate(project_management.ShaCertificate(
+        android_app.add_sha_certificate(project_management.SHACertificate(
             '123456789a123456789a123456789a123456789a123456789a123456789a1234'))
 
         assert len(recorder) == 1
@@ -1067,7 +1067,7 @@ class TestAndroidApp(BaseProjectManagementTest):
 
         with pytest.raises(exceptions.AlreadyExistsError) as excinfo:
             android_app.add_sha_certificate(
-                project_management.ShaCertificate('123456789a123456789a123456789a123456789a'))
+                project_management.SHACertificate('123456789a123456789a123456789a123456789a'))
 
         assert 'The resource already exists' in str(excinfo.value)
         assert excinfo.value.cause is not None
@@ -1117,7 +1117,7 @@ class TestAndroidApp(BaseProjectManagementTest):
         testutils.run_without_project_id(evaluate)
 
 
-class TestIosApp(BaseProjectManagementTest):
+class TestIOSApp(BaseProjectManagementTest):
     _GET_METADATA_URL = ('https://firebase.googleapis.com/v1beta1/projects/-/iosApps/'
                          '1:12345678:ios:ca5cade5')
     _SET_DISPLAY_NAME_URL = ('https://firebase.googleapis.com/v1beta1/projects/-/iosApps/'
@@ -1141,7 +1141,7 @@ class TestIosApp(BaseProjectManagementTest):
         assert metadata.project_id == 'test-project-id'
         assert metadata.bundle_id == 'com.hello.world.ios'
         assert len(recorder) == 1
-        self._assert_request_is_correct(recorder[0], 'GET', TestIosApp._GET_METADATA_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestIOSApp._GET_METADATA_URL)
 
     def test_get_metadata(self, ios_app):
         recorder = self._instrument_service(statuses=[200], responses=[IOS_APP_METADATA_RESPONSE])
@@ -1154,7 +1154,7 @@ class TestIosApp(BaseProjectManagementTest):
         assert metadata.project_id == 'test-project-id'
         assert metadata.bundle_id == 'com.hello.world.ios'
         assert len(recorder) == 1
-        self._assert_request_is_correct(recorder[0], 'GET', TestIosApp._GET_METADATA_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestIOSApp._GET_METADATA_URL)
 
     def test_get_metadata_unknown_error(self, ios_app):
         recorder = self._instrument_service(
@@ -1189,7 +1189,7 @@ class TestIosApp(BaseProjectManagementTest):
         assert len(recorder) == 1
         body = {'displayName': new_display_name}
         self._assert_request_is_correct(
-            recorder[0], 'PATCH', TestIosApp._SET_DISPLAY_NAME_URL, body)
+            recorder[0], 'PATCH', TestIOSApp._SET_DISPLAY_NAME_URL, body)
 
     def test_set_display_name_not_found(self, ios_app):
         recorder = self._instrument_service(statuses=[404], responses=[NOT_FOUND_RESPONSE])
@@ -1210,7 +1210,7 @@ class TestIosApp(BaseProjectManagementTest):
 
         assert config == 'hello world'
         assert len(recorder) == 1
-        self._assert_request_is_correct(recorder[0], 'GET', TestIosApp._GET_CONFIG_URL)
+        self._assert_request_is_correct(recorder[0], 'GET', TestIOSApp._GET_CONFIG_URL)
 
     def test_get_config_not_found(self, ios_app):
         recorder = self._instrument_service(statuses=[404], responses=[NOT_FOUND_RESPONSE])


### PR DESCRIPTION
1. The deprecated `WebpushFcmOptions` type alias is removed.
2. Following type renames were made in the `project_management` module:
  a. `IosApp` --> `IOSApp`
  b. `IosAppMetadata` --> `IOSAppMetadata`
  c. `ShaCertificate` --> `SHACertificate`

2-c is probably the change with highest impact here. 2-a and 2-b are return types and therefore most developers don't have to type them in their code.

These are breaking changes, and will be released as v3.0.0