### PR TITLE
Support deleting custom claims by passing None

### DIFF
--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -421,6 +421,8 @@ def set_custom_user_claims(uid, custom_claims, app=None):
         FirebaseError: If an error occurs while updating the user account.
     """
     user_manager = _get_auth_service(app).user_manager
+    if custom_claims is None:
+        custom_claims = DELETE_ATTRIBUTE
     user_manager.update_user(uid, custom_claims=custom_claims)
 
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -310,9 +310,9 @@ def test_update_custom_user_claims(new_user):
 def test_disable_user(new_user_with_params):
     user = auth.update_user(
         new_user_with_params.uid,
-        display_name=None,
-        photo_url=None,
-        phone_number=None,
+        display_name=auth.DELETE_ATTRIBUTE,
+        photo_url=auth.DELETE_ATTRIBUTE,
+        phone_number=auth.DELETE_ATTRIBUTE,
         disabled=True)
     assert user.uid == new_user_with_params.uid
     assert user.email == new_user_with_params.email

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -551,9 +551,10 @@ class TestSetCustomUserClaims(object):
         request = json.loads(recorder[0].body.decode())
         assert request == {'localId' : 'testuser', 'customAttributes' : claims}
 
-    def test_set_custom_user_claims_remove(self, user_mgt_app):
+    @pytest.mark.parametrize('claims', [None, auth.DELETE_ATTRIBUTE])
+    def test_set_custom_user_claims_remove(self, user_mgt_app, claims):
         _, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
-        auth.set_custom_user_claims('testuser', auth.DELETE_ATTRIBUTE, app=user_mgt_app)
+        auth.set_custom_user_claims('testuser', claims, app=user_mgt_app)
         request = json.loads(recorder[0].body.decode())
         assert request == {'localId' : 'testuser', 'customAttributes' : json.dumps({})}
 


### PR DESCRIPTION
In #320 we removed the ability to delete user attributes by passing `None` to `auth.update_user()`. This change inadvertently affected the `auth.set_custom_user_claims()` method which *should* support deleting claims via passing `None`. This caused an integration test failure:

```
_______________________________________________________________________________ test_update_custom_user_claims _______________________________________________________________________________

new_user = <firebase_admin._user_mgt.UserRecord object at 0x7f876c0e1d10>

    def test_update_custom_user_claims(new_user):
        assert new_user.custom_claims is None
        claims = {'admin' : True, 'package' : 'gold'}
        auth.set_custom_user_claims(new_user.uid, claims)
        user = auth.get_user(new_user.uid)
        assert user.custom_claims == claims
    
        claims = {'admin' : False, 'subscription' : 'guest'}
        auth.set_custom_user_claims(new_user.uid, claims)
        user = auth.get_user(new_user.uid)
        assert user.custom_claims == claims
    
        auth.set_custom_user_claims(new_user.uid, None)
        user = auth.get_user(new_user.uid)
>       assert user.custom_claims is None
E       AssertionError: assert {'admin': False, 'subscription': 'guest'} is None
E        +  where {'admin': False, 'subscription': 'guest'} = <firebase_admin._user_mgt.UserRecord object at 0x7f876c01b590>.custom_claims

../integration/test_auth.py:308: AssertionError
```

This PR fixes the `set_custom_user_claims()` method, which now supports removing claims via both `None` and `DELETE_ATTRIBUTE`. I also updated the `update_user()` integration test to use `DELETE_ATTRIBUTE` instead of `None`.