### PR TITLE
Handling the EMAIL_EXISTS error code

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -257,6 +257,7 @@ class UserNotFoundError(exceptions.NotFoundError):
 _CODE_TO_EXC_TYPE = {
     'DUPLICATE_EMAIL': EmailAlreadyExistsError,
     'DUPLICATE_LOCAL_ID': UidAlreadyExistsError,
+    'EMAIL_EXISTS': EmailAlreadyExistsError,
     'INVALID_DYNAMIC_LINK_DOMAIN': InvalidDynamicLinkDomainError,
     'INVALID_ID_TOKEN': InvalidIdTokenError,
     'PHONE_NUMBER_EXISTS': PhoneNumberAlreadyExistsError,

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -292,6 +292,7 @@ class TestCreateUser(object):
     already_exists_errors = {
         'DUPLICATE_EMAIL': auth.EmailAlreadyExistsError,
         'DUPLICATE_LOCAL_ID': auth.UidAlreadyExistsError,
+        'EMAIL_EXISTS': auth.EmailAlreadyExistsError,
         'PHONE_NUMBER_EXISTS': auth.PhoneNumberAlreadyExistsError,
     }
 


### PR DESCRIPTION
Raising an `EmailAlreadyExistsError` when receiving the `EMAIL_EXISTS` error code.

RELEASE NOTE: User management APIs now correctly raise `auth.EmailAlreadyExistsError` when an already in-use email address is specified for a user.

Resolves #347 