### PR TITLE
fix(fcm): String representation in Message class

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -57,6 +57,9 @@ class Message(object):
         self.topic = topic
         self.condition = condition
 
+    def __str__(self):
+        return json.dumps(MessageEncoder().default(self))
+
 
 class MulticastMessage(object):
     """A message that can be sent to multiple tokens via Firebase Cloud Messaging.

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -58,7 +58,7 @@ class Message(object):
         self.condition = condition
 
     def __str__(self):
-        return json.dumps(MessageEncoder().default(self))
+        return json.dumps(self, cls=MessageEncoder, sort_keys=True)
 
 
 class MulticastMessage(object):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -61,6 +61,34 @@ def check_exception(exception, message, status):
     assert exception.http_response.status_code == status
 
 
+class TestMessageStr(object):
+
+    @pytest.mark.parametrize('msg', [
+        messaging.Message(),
+        messaging.Message(topic='topic', token='token'),
+        messaging.Message(topic='topic', condition='condition'),
+        messaging.Message(condition='condition', token='token'),
+        messaging.Message(topic='topic', token='token', condition='condition'),
+    ])
+    def test_invalid_target_message(self, msg):
+        with pytest.raises(ValueError) as excinfo:
+            str(msg)
+        assert str(
+            excinfo.value) == 'Exactly one of token, topic or condition must be specified.'
+
+    def test_empty_message(self):
+        assert str(messaging.Message(token='value')) == '{"token": "value"}'
+        assert str(messaging.Message(topic='value')) == '{"topic": "value"}'
+        assert str(messaging.Message(condition='value')
+                   ) == '{"condition": "value"}'
+
+    def test_data_message(self):
+        assert str(messaging.Message(topic='topic', data={})
+                   ) == '{"topic": "topic"}'
+        assert str(messaging.Message(topic='topic', data={
+                   'k1': 'v1', 'k2': 'v2'})) == '{"data": {"k1": "v1", "k2": "v2"}, "topic": "topic"}'
+
+
 class TestMulticastMessage(object):
 
     @pytest.mark.parametrize('tokens', NON_LIST_ARGS)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -80,13 +80,13 @@ class TestMessageStr(object):
         assert str(messaging.Message(token='value')) == '{"token": "value"}'
         assert str(messaging.Message(topic='value')) == '{"topic": "value"}'
         assert str(messaging.Message(condition='value')
-                   ) == '{"condition": "value"}'
+                  ) == '{"condition": "value"}'
 
     def test_data_message(self):
         assert str(messaging.Message(topic='topic', data={})
-                   ) == '{"topic": "topic"}'
+                  ) == '{"topic": "topic"}'
         assert str(messaging.Message(topic='topic', data={
-                   'k1': 'v1', 'k2': 'v2'})) == '{"data": {"k1": "v1", "k2": "v2"}, "topic": "topic"}'
+            'k1': 'v1', 'k2': 'v2'})) == '{"data": {"k1": "v1", "k2": "v2"}, "topic": "topic"}'
 
 
 class TestMulticastMessage(object):


### PR DESCRIPTION
### Discussion

  * Add string representation in `Message` class
  * Use `MessageEncoder` to convert `Message` objects to valid JSON strings

### Testing

   * None

### API Changes

   * None

Resolves: #349 

RELEASE NOTE: `Message` class now implements the `__str__()` contract which can be used to obtain a string representation of a `Message` instance.