### PR TITLE
feat(auth): Added InsufficientPermissionError type

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -211,6 +211,18 @@ class EmailAlreadyExistsError(exceptions.AlreadyExistsError):
         exceptions.AlreadyExistsError.__init__(self, message, cause, http_response)
 
 
+class InsufficientPermissionError(exceptions.PermissionDeniedError):
+    """The credential used to initialize the SDK lacks required permissions."""
+
+    default_message = ('The credential used to initialize the SDK has insufficient '
+                       'permissions to perform the requested operation. See '
+                       'https://firebase.google.com/docs/admin/setup for details '
+                       'on how to initialize the Admin SDK with appropriate permissions')
+
+    def __init__(self, message, cause, http_response):
+        exceptions.PermissionDeniedError.__init__(self, message, cause, http_response)
+
+
 class InvalidDynamicLinkDomainError(exceptions.InvalidArgumentError):
     """Dynamic link domain in ActionCodeSettings is not authorized."""
 
@@ -258,6 +270,7 @@ _CODE_TO_EXC_TYPE = {
     'DUPLICATE_EMAIL': EmailAlreadyExistsError,
     'DUPLICATE_LOCAL_ID': UidAlreadyExistsError,
     'EMAIL_EXISTS': EmailAlreadyExistsError,
+    'INSUFFICIENT_PERMISSION': InsufficientPermissionError,
     'INVALID_DYNAMIC_LINK_DOMAIN': InvalidDynamicLinkDomainError,
     'INVALID_ID_TOKEN': InvalidIdTokenError,
     'PHONE_NUMBER_EXISTS': PhoneNumberAlreadyExistsError,

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -43,6 +43,7 @@ __all__ = [
     'ExpiredSessionCookieError',
     'ExportedUserRecord',
     'ImportUserRecord',
+    'InsufficientPermissionError',
     'InvalidDynamicLinkDomainError',
     'InvalidIdTokenError',
     'InvalidSessionCookieError',
@@ -89,6 +90,7 @@ ExpiredIdTokenError = _token_gen.ExpiredIdTokenError
 ExpiredSessionCookieError = _token_gen.ExpiredSessionCookieError
 ExportedUserRecord = _user_mgt.ExportedUserRecord
 ImportUserRecord = _user_import.ImportUserRecord
+InsufficientPermissionError = _auth_utils.InsufficientPermissionError
 InvalidDynamicLinkDomainError = _auth_utils.InvalidDynamicLinkDomainError
 InvalidIdTokenError = _auth_utils.InvalidIdTokenError
 InvalidSessionCookieError = _token_gen.InvalidSessionCookieError

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -743,6 +743,20 @@ class TestListUsers(object):
             auth.list_users(app=user_mgt_app)
         assert str(excinfo.value) == 'Unexpected error response: {"error":"test"}'
 
+    def test_permission_error(self, user_mgt_app):
+        _instrument_user_manager(user_mgt_app, 400, '{"error": {"message": "INSUFFICIENT_PERMISSION"}}')
+        with pytest.raises(auth.InsufficientPermissionError) as excinfo:
+            auth.list_users(app=user_mgt_app)
+        assert isinstance(excinfo.value, exceptions.PermissionDeniedError)
+        msg = ('The credential used to initialize the SDK has insufficient '
+               'permissions to perform the requested operation. See '
+               'https://firebase.google.com/docs/admin/setup for details '
+               'on how to initialize the Admin SDK with appropriate permissions '
+               '(INSUFFICIENT_PERMISSION).')
+        assert str(excinfo.value) == msg
+        assert excinfo.value.http_response is not None
+        assert excinfo.value.cause is not None
+
     def _check_page(self, page):
         assert isinstance(page, auth.ListUsersPage)
         index = 0

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -744,7 +744,8 @@ class TestListUsers(object):
         assert str(excinfo.value) == 'Unexpected error response: {"error":"test"}'
 
     def test_permission_error(self, user_mgt_app):
-        _instrument_user_manager(user_mgt_app, 400, '{"error": {"message": "INSUFFICIENT_PERMISSION"}}')
+        _instrument_user_manager(
+            user_mgt_app, 400, '{"error": {"message": "INSUFFICIENT_PERMISSION"}}')
         with pytest.raises(auth.InsufficientPermissionError) as excinfo:
             auth.list_users(app=user_mgt_app)
         assert isinstance(excinfo.value, exceptions.PermissionDeniedError)


### PR DESCRIPTION
Firebase Auth sends back an `INSUFFICIENT_PERMISSION` error code when the credential lacks a required permission. This PR introduces a new `InsufficientPermissionError` type to properly handle this error code.

RELEASE NOTE: Added `auth.InsufficientPermissionError` type to represent operations that fail due to the credential lacking a required permission.