### PR TITLE
fix(fcm): Increased FCM batch request limit to 500

### DIFF
--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -77,8 +77,8 @@ class MulticastMessage(object):
     def __init__(self, tokens, data=None, notification=None, android=None, webpush=None, apns=None,
                  fcm_options=None):
         _Validators.check_string_list('MulticastMessage.tokens', tokens)
-        if len(tokens) > 100:
-            raise ValueError('MulticastMessage.tokens must not contain more than 100 tokens.')
+        if len(tokens) > 500:
+            raise ValueError('MulticastMessage.tokens must not contain more than 500 tokens.')
         self.tokens = tokens
         self.data = data
         self.notification = notification

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -356,9 +356,9 @@ class _MessagingService(object):
     def send_all(self, messages, dry_run=False):
         """Sends the given messages to FCM via the batch API."""
         if not isinstance(messages, list):
-            raise ValueError('Messages must be an list of messaging.Message instances.')
-        if len(messages) > 100:
-            raise ValueError('send_all messages must not contain more than 100 messages.')
+            raise ValueError('messages must be a list of messaging.Message instances.')
+        if len(messages) > 500:
+            raise ValueError('messages must not contain more than 500 elements.')
 
         responses = []
 

--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -101,17 +101,17 @@ def test_send_all():
     assert isinstance(response.exception, exceptions.InvalidArgumentError)
     assert response.message_id is None
 
-def test_send_one_hundred():
+def test_send_all_500():
     messages = []
-    for msg_number in range(100):
+    for msg_number in range(500):
         topic = 'foo-bar-{0}'.format(msg_number % 10)
         messages.append(messaging.Message(topic=topic))
 
     batch_response = messaging.send_all(messages, dry_run=True)
 
-    assert batch_response.success_count == 100
+    assert batch_response.success_count == 500
     assert batch_response.failure_count == 0
-    assert len(batch_response.responses) == 100
+    assert len(batch_response.responses) == 500
     for response in batch_response.responses:
         assert response.success is True
         assert response.exception is None

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -102,15 +102,18 @@ class TestMulticastMessage(object):
             expected = 'MulticastMessage.tokens must be a list of strings.'
             assert str(excinfo.value) == expected
 
-    def test_tokens_over_one_hundred(self):
+    def test_tokens_over_500(self):
         with pytest.raises(ValueError) as excinfo:
-            messaging.MulticastMessage(tokens=['token' for _ in range(0, 101)])
-        expected = 'MulticastMessage.tokens must not contain more than 100 tokens.'
+            messaging.MulticastMessage(tokens=['token' for _ in range(0, 501)])
+        expected = 'MulticastMessage.tokens must not contain more than 500 tokens.'
         assert str(excinfo.value) == expected
 
     def test_tokens_type(self):
-        messaging.MulticastMessage(tokens=['token'])
-        messaging.MulticastMessage(tokens=['token' for _ in range(0, 100)])
+        message = messaging.MulticastMessage(tokens=['token'])
+        assert len(message.tokens) == 1
+
+        message = messaging.MulticastMessage(tokens=['token' for _ in range(0, 500)])
+        assert len(message.tokens) == 500
 
 
 class TestMessageEncoder(object):
@@ -1598,14 +1601,14 @@ class TestSendAll(TestBatch):
             expected = 'Message must be an instance of messaging.Message class.'
             assert str(excinfo.value) == expected
         else:
-            expected = 'Messages must be an list of messaging.Message instances.'
+            expected = 'messages must be a list of messaging.Message instances.'
             assert str(excinfo.value) == expected
 
-    def test_invalid_over_one_hundred(self):
+    def test_invalid_over_500(self):
         msg = messaging.Message(topic='foo')
         with pytest.raises(ValueError) as excinfo:
-            messaging.send_all([msg for _ in range(0, 101)])
-        expected = 'send_all messages must not contain more than 100 messages.'
+            messaging.send_all([msg for _ in range(0, 501)])
+        expected = 'messages must not contain more than 500 elements.'
         assert str(excinfo.value) == expected
 
     def test_send_all(self):


### PR DESCRIPTION
RELEASE NOTE: Batch messaging APIs `send_all()` and `send_multicast()` now support sending up to 500 messages in a single call.