### PR TITLE
Upgraded cachecontrol to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest-cov >= 2.4.0
 pytest-localserver >= 0.4.1
 tox >= 3.6.0
 
-cachecontrol >= 0.12.4
+cachecontrol >= 0.12.6
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev; platform.python_implementation != 'PyPy'
 google-api-python-client >= 1.7.8
 google-cloud-firestore >= 1.4.0; platform.python_implementation != 'PyPy'

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open(about_path) as fp:
 long_description = ('The Firebase Admin Python SDK enables server-side (backend) Python developers '
                     'to integrate Firebase into their services and applications.')
 install_requires = [
-    'cachecontrol>=0.12.4',
+    'cachecontrol>=0.12.6',
     'google-api-core[grpc] >= 1.14.0, < 2.0.0dev; platform.python_implementation != "PyPy"',
     'google-api-python-client >= 1.7.8',
     'google-cloud-firestore>=1.4.0; platform.python_implementation != "PyPy"',

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -819,7 +819,7 @@ class TestDatabaseInitialization(object):
             assert ref._client.timeout == 60
             assert ref.get() == {}
             assert len(recorder) == 1
-            assert recorder[0]._extra_kwargs['timeout'] == 60
+            assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(60, 0.001)
 
     def test_app_delete(self):
         app = firebase_admin.initialize_app(

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1562,7 +1562,7 @@ class TestTimeout(object):
         msg = messaging.Message(topic='foo')
         messaging.send(msg)
         assert len(self.recorder) == 1
-        assert self.recorder[0]._extra_kwargs['timeout'] == 4
+        assert self.recorder[0]._extra_kwargs['timeout'] == pytest.approx(4, 0.001)
 
     def test_topic_management_timeout(self):
         self.fcm_service._client.session.mount(
@@ -1574,7 +1574,7 @@ class TestTimeout(object):
         )
         messaging.subscribe_to_topic(['1'], 'a')
         assert len(self.recorder) == 1
-        assert self.recorder[0]._extra_kwargs['timeout'] == 4
+        assert self.recorder[0]._extra_kwargs['timeout'] == pytest.approx(4, 0.001)
 
 
 class TestSend(object):


### PR DESCRIPTION
Resolves #377 

Also fixed some unit tests that started failing unexpectedly. It seems `requests` is now setting the timeout as a float value.