### PR TITLE
Create a GitHub Actions based CI Pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.4, 3.5, 3.6, 3.7, pypy3]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with pylint
+      if: matrix.python == '3.7'
+      run: ./lint.sh all
+    - name: Test with pytest
+      run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
     - name: Test with pytest
       if: success() || failure()
       run: pytest
+    - name: Set up Node.js 10
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Run integration tests against emulator
+      run: |
+        npm install -g firebase-tools
+        firebase emulators:exec --only database --project fake-project-id 'pytest integration/test_db.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.4, 3.5, 3.6, 3.7, pypy3]
+        python: [3.5, 3.6, 3.7, pypy3]
 
     steps:
     - uses: actions/checkout@v1
@@ -24,4 +24,5 @@ jobs:
       if: matrix.python == '3.7'
       run: ./lint.sh all
     - name: Test with pytest
+      if: success() || failure()
       run: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
 language: python
 python:
   - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "pypy3.5"
-
-jobs:
-  include:
-    - name: "Lint"
-      python: "3.7"
-      script: ./lint.sh all
 
 before_install:
   - nvm install 8 && npm install -g firebase-tools


### PR DESCRIPTION
Moved CI tasks to GitHub Actions. Kept the Travis CI job for testing on Py3.4, as that's not supported in GitHub Actions. Hopefully we can get rid of it completely once https://github.com/googleapis/google-cloud-python/issues/10136 is addressed.