### PR TITLE
Fixing TypeError Invalid keyword argument 'status'

### DIFF
--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -28,7 +28,7 @@ _ANY_METHOD = None
 # Retries up to 4 times on HTTP 500 and 503 errors, with exponential backoff. Returns the
 # last response upon exhausting all retries.
 DEFAULT_RETRY_CONFIG = retry.Retry(
-    connect=1, read=1, status=4, status_forcelist=[500, 503], method_whitelist=_ANY_METHOD,
+    connect=1, read=1, status_forcelist=[500, 503], method_whitelist=_ANY_METHOD,
     raise_on_status=False, backoff_factor=0.5)
 
 


### PR DESCRIPTION
Tested in python2.7 and 3.6.9
Retry class in `urllib`  does not accept any argument named 'status' thus throwing TypeError.
Here's the snippet of `retry` class init:
```
def __init__(self, total=10, connect=None, read=None, redirect=None,
                   method_whitelist=DEFAULT_METHOD_WHITELIST, status_forcelist=None,
                   backoff_factor=0, raise_on_redirect=True, raise_on_status=True,
                  _observed_errors=0):
```
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
