### PR TITLE
Using a default HTTP timeout in db module

### DIFF
--- a/firebase_admin/_utils.py
+++ b/firebase_admin/_utils.py
@@ -59,6 +59,9 @@ _HTTP_STATUS_TO_ERROR_CODE = {
 }
 
 
+DEFAULT_HTTP_TIMEOUT_SECONDS = 120
+
+
 def _get_initialized_app(app):
     """Returns a reference to an initialized App instance."""
     if app is None:
@@ -106,6 +109,10 @@ def handle_platform_error_from_requests(error, handle_func=None):
         exc = handle_func(error, message, error_dict)
 
     return exc if exc else _handle_func_requests(error, message, error_dict)
+
+
+def get_http_timeout(app):
+    return app.options.get('httpTimeout', DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 
 def _handle_func_requests(error, message, error_dict):

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -775,7 +775,7 @@ class _DatabaseService:
             self._auth_override = json.dumps(auth_override, separators=(',', ':'))
         else:
             self._auth_override = None
-        self._timeout = app.options.get('httpTimeout')
+        self._timeout = _utils.get_http_timeout(app)
         self._clients = {}
 
         emulator_host = os.environ.get(_EMULATOR_HOST_ENV_VAR)
@@ -935,10 +935,9 @@ class _Client(_http_client.JsonHttpClient):
                 query = extra_params + '&' + query
             else:
                 query = extra_params
-        kwargs['params'] = query
 
-        if self.timeout:
-            kwargs['timeout'] = self.timeout
+        kwargs['params'] = query
+        kwargs['timeout'] = self.timeout
         try:
             return super(_Client, self).request(method, url, **kwargs)
         except requests.exceptions.RequestException as error:

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -331,7 +331,7 @@ class _MessagingService:
             'X-FIREBASE-CLIENT': 'fire-admin-python/{0}'.format(firebase_admin.__version__),
         }
         self._client = _http_client.JsonHttpClient(credential=app.credential.get_credential())
-        self._timeout = app.options.get('httpTimeout')
+        self._timeout = _utils.get_http_timeout(app)
         self._transport = _auth.authorized_http(app.credential.get_credential())
 
     @classmethod

--- a/firebase_admin/project_management.py
+++ b/firebase_admin/project_management.py
@@ -482,7 +482,7 @@ class _ProjectManagementService:
             credential=app.credential.get_credential(),
             base_url=_ProjectManagementService.BASE_URL,
             headers={'X-Client-Version': version_header})
-        self._timeout = app.options.get('httpTimeout')
+        self._timeout = _utils.get_http_timeout(app)
 
     def get_android_app_metadata(self, app_id):
         return self._get_app_metadata(

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1561,7 +1561,7 @@ class TestTimeout:
     def test_topic_management(self, timeout):
         app = self._app_with_timeout(timeout)
         recorder = self._instrument_service(
-            app, 'https://iid.googleapis.com',{'results': [{}, {'error': 'error_reason'}]})
+            app, 'https://iid.googleapis.com', {'results': [{}, {'error': 'error_reason'}]})
         messaging.subscribe_to_topic(['1'], 'a')
         assert len(recorder) == 1
         if timeout is None:

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -23,6 +23,7 @@ import pytest
 import firebase_admin
 from firebase_admin import exceptions
 from firebase_admin import messaging
+from firebase_admin import _utils
 from tests import testutils
 
 
@@ -1537,42 +1538,50 @@ class TestApsAlertEncoder:
         }
         check_encoding(msg, expected)
 
+
 class TestTimeout:
 
-    @classmethod
-    def setup_class(cls):
-        cred = testutils.MockCredential()
-        firebase_admin.initialize_app(cred, {'httpTimeout': 4, 'projectId': 'explicit-project-id'})
-
-    @classmethod
-    def teardown_class(cls):
+    def teardown(self):
         testutils.cleanup_apps()
 
-    def setup(self):
-        app = firebase_admin.get_app()
-        self.fcm_service = messaging._get_messaging_service(app)
-        self.recorder = []
-
-    def test_send(self):
-        self.fcm_service._client.session.mount(
-            'https://fcm.googleapis.com',
-            testutils.MockAdapter(json.dumps({'name': 'message-id'}), 200, self.recorder))
+    @pytest.mark.parametrize('timeout', [4, None])
+    def test_send(self, timeout):
+        app = self._app_with_timeout(timeout)
+        recorder = self._instrument_service(
+            app, 'https://fcm.googleapis.com', {'name': 'message-id'})
         msg = messaging.Message(topic='foo')
         messaging.send(msg)
-        assert len(self.recorder) == 1
-        assert self.recorder[0]._extra_kwargs['timeout'] == pytest.approx(4, 0.001)
+        assert len(recorder) == 1
+        if timeout is None:
+            assert recorder[0]._extra_kwargs['timeout'] is None
+        else:
+            assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(timeout, 0.001)
 
-    def test_topic_management_timeout(self):
-        self.fcm_service._client.session.mount(
-            'https://iid.googleapis.com',
-            testutils.MockAdapter(
-                json.dumps({'results': [{}, {'error': 'error_reason'}]}),
-                200,
-                self.recorder)
-        )
+    @pytest.mark.parametrize('timeout', [4, None])
+    def test_topic_management(self, timeout):
+        app = self._app_with_timeout(timeout)
+        recorder = self._instrument_service(
+            app, 'https://iid.googleapis.com',{'results': [{}, {'error': 'error_reason'}]})
         messaging.subscribe_to_topic(['1'], 'a')
-        assert len(self.recorder) == 1
-        assert self.recorder[0]._extra_kwargs['timeout'] == pytest.approx(4, 0.001)
+        assert len(recorder) == 1
+        if timeout is None:
+            assert recorder[0]._extra_kwargs['timeout'] is None
+        else:
+            assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(timeout, 0.001)
+
+    def _app_with_timeout(self, timeout):
+        cred = testutils.MockCredential()
+        return firebase_admin.initialize_app(cred, {
+            'httpTimeout': timeout,
+            'projectId': 'explicit-project-id'
+        })
+
+    def _instrument_service(self, app, url, response):
+        fcm_service = messaging._get_messaging_service(app)
+        recorder = []
+        fcm_service._client.session.mount(
+            url, testutils.MockAdapter(json.dumps(response), 200, recorder))
+        return recorder
 
 
 class TestSend:
@@ -1641,7 +1650,8 @@ class TestSend:
         assert recorder[0].url == self._get_url('explicit-project-id')
         assert recorder[0].headers['X-GOOG-API-FORMAT-VERSION'] == '2'
         assert recorder[0].headers['X-FIREBASE-CLIENT'] == self._CLIENT_VERSION
-        assert recorder[0]._extra_kwargs['timeout'] is None
+        assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(
+            _utils.DEFAULT_HTTP_TIMEOUT_SECONDS, 0.001)
         body = {'message': messaging._MessagingService.encode_message(msg)}
         assert json.loads(recorder[0].body.decode()) == body
 
@@ -2224,6 +2234,8 @@ class TestTopicManagement:
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchAdd')
         assert json.loads(recorder[0].body.decode()) == args[2]
+        assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(
+            _utils.DEFAULT_HTTP_TIMEOUT_SECONDS, 0.001)
 
     @pytest.mark.parametrize('status, exc_type', HTTP_ERROR_CODES.items())
     def test_subscribe_to_topic_error(self, status, exc_type):
@@ -2256,6 +2268,8 @@ class TestTopicManagement:
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchRemove')
         assert json.loads(recorder[0].body.decode()) == args[2]
+        assert recorder[0]._extra_kwargs['timeout'] == pytest.approx(
+            _utils.DEFAULT_HTTP_TIMEOUT_SECONDS, 0.001)
 
     @pytest.mark.parametrize('status, exc_type', HTTP_ERROR_CODES.items())
     def test_unsubscribe_from_topic_error(self, status, exc_type):

--- a/tests/test_project_management.py
+++ b/tests/test_project_management.py
@@ -22,6 +22,7 @@ import pytest
 import firebase_admin
 from firebase_admin import exceptions
 from firebase_admin import project_management
+from firebase_admin import _utils
 from tests import testutils
 
 OPERATION_IN_PROGRESS_RESPONSE = json.dumps({
@@ -522,6 +523,8 @@ class BaseProjectManagementTest:
         assert request.url == expected_url
         client_version = 'Python/Admin/{0}'.format(firebase_admin.__version__)
         assert request.headers['X-Client-Version'] == client_version
+        assert request._extra_kwargs['timeout'] == pytest.approx(
+            _utils.DEFAULT_HTTP_TIMEOUT_SECONDS, 0.001)
         if expected_body is None:
             assert request.body is None
         else:


### PR DESCRIPTION
The `google-auth` package now sets a default timeout of 120 seconds for all outgoing requests (see https://github.com/googleapis/google-auth-library-python/pull/435). This is causing a couple of test failures in our codebase: https://github.com/firebase/firebase-admin-python/actions/runs/32412728

But more importantly this change leads to unpredictable default behavior in applications that use `firebase_admin`. Specifically, developers who are on older versions of `google-auth` won't get any timeout (`timeout=None`), while developers on new versions will get a 2 minutes timeout (`timeout=120`).

This PR addresses the above discrepancy by setting a default timeout in our own code. This has the following advantages:
1. Developers using `firebase_admin` will see consistent behavior regardless of their `google-auth` version.
2. We get more control over the default timeout, and are no longer affected by the changes in `google-auth`.

Note that `httpTimeout` option is currently only respected by a subset of our modules. Other modules (e.g. auth), will get their default timeout from `google-auth` for now. I'm using the same default value of 120 seconds to mitigate this, but we should properly address this for all modules in a subsequent PR.