### PR TITLE
Fix broken test (which relied on default timeout being None).

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -739,7 +739,6 @@ class TestDatabaseInitialization:
         assert ref._client.timeout is None
         assert ref.get() == {}
         assert len(recorder) == 1
-        assert recorder[0]._extra_kwargs.get('timeout') is None
 
     @pytest.mark.parametrize('url', [
         None, '', 'foo', 'http://test.firebaseio.com', 'https://google.com',


### PR DESCRIPTION
The upstream behaviour has changed such that None is no longer the
default:

https://github.com/googleapis/google-auth-library-python/pull/435