### PR TITLE
Defined linter as a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,11 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint with pylint
-      if: matrix.python == '3.7'
-      run: ./lint.sh all
     - name: Test with pytest
-      if: success() || failure()
       run: pytest
     - name: Set up Node.js 10
       uses: actions/setup-node@v1
@@ -34,3 +29,17 @@ jobs:
       run: |
         npm install -g firebase-tools
         firebase emulators:exec --only database --project fake-project-id 'pytest integration/test_db.py'
+
+  lint:
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install Pylint
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint == 2.3.1
+    - name: Lint with pylint
+      run: ./lint.sh all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Install Pylint
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint==2.3.1
+        pip install -r requirements.txt
     - name: Lint with pylint
       run: ./lint.sh all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python }}
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
     - name: Install Pylint
       run: |
         python -m pip install --upgrade pip
-        pip install pylint == 2.3.1
+        pip install pylint==2.3.1
     - name: Lint with pylint
       run: ./lint.sh all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [3.5, 3.6, 3.7, pypy3]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         firebase emulators:exec --only database --project fake-project-id 'pytest integration/test_db.py'
 
   lint:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python }}


### PR DESCRIPTION
Currently the linter task is part of the Python 3.7 test task, which makes interpreting build results complicated. This PR defines the linter as a separate independent job.

Also turning `fail-fast` off in the build matrix, so that test failures in one Python version don't cancel other test runs.