### PR TITLE
fix(fcm): Convert event_time to UTC

### DIFF
--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -324,6 +324,8 @@ class MessageEncoder(json.JSONEncoder):
 
         event_time = result.get('event_time')
         if event_time:
+            # if the datetime instance is not naive (tzinfo is present), convert to UTC
+            # otherwise (tzinfo is None) assume the datetime instance is already in UTC
             if event_time.tzinfo is not None:
                 event_time = event_time.astimezone(datetime.timezone.utc)
             result['event_time'] = event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -324,8 +324,9 @@ class MessageEncoder(json.JSONEncoder):
 
         event_time = result.get('event_time')
         if event_time:
-            utc_event_time = event_time.astimezone(datetime.timezone.utc)
-            result['event_time'] = utc_event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            if event_time.tzinfo is not None:
+                event_time = event_time.astimezone(datetime.timezone.utc)
+            result['event_time'] = event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         priority = result.get('notification_priority')
         if priority:

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -19,6 +19,7 @@ import json
 import math
 import numbers
 import re
+import pytz
 
 import firebase_admin._messaging_utils as _messaging_utils
 
@@ -324,7 +325,12 @@ class MessageEncoder(json.JSONEncoder):
 
         event_time = result.get('event_time')
         if event_time:
-            result['event_time'] = str(event_time.isoformat()) + 'Z'
+            if event_time.tzinfo is None:
+                local_tzinfo = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+                timezone = pytz.timezone(str(local_tzinfo))
+                event_time = timezone.localize(event_time)
+            utc_event_time = event_time.astimezone(pytz.utc)
+            result['event_time'] = utc_event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         priority = result.get('notification_priority')
         if priority:

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -19,7 +19,6 @@ import json
 import math
 import numbers
 import re
-import pytz
 
 import firebase_admin._messaging_utils as _messaging_utils
 
@@ -325,11 +324,7 @@ class MessageEncoder(json.JSONEncoder):
 
         event_time = result.get('event_time')
         if event_time:
-            if event_time.tzinfo is None:
-                local_tzinfo = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
-                timezone = pytz.timezone(str(local_tzinfo))
-                event_time = timezone.localize(event_time)
-            utc_event_time = event_time.astimezone(pytz.utc)
+            utc_event_time = event_time.astimezone(datetime.timezone.utc)
             result['event_time'] = utc_event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         priority = result.get('notification_priority')

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -98,7 +98,8 @@ class AndroidNotification:
             the user clicks it (optional).
         event_timestamp: For notifications that inform users about events with an absolute time
             reference, sets the time that the event in the notification occurred as a
-            ``datetime.datetime`` instance. Notifications in the panel are sorted by this time
+            ``datetime.datetime`` instance. If the ``datetime.datetime`` instance is naive it will
+            be assumed to be in the UTC timezone. Notifications in the panel are sorted by this time
             (optional).
         local_only: Sets whether or not this notification is relevant only to the current device.
             Some notifications can be bridged to other devices for remote display, such as a Wear OS

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -98,8 +98,8 @@ class AndroidNotification:
             the user clicks it (optional).
         event_timestamp: For notifications that inform users about events with an absolute time
             reference, sets the time that the event in the notification occurred as a
-            ``datetime.datetime`` instance. If the ``datetime.datetime`` instance is naive it will
-            be assumed to be in the UTC timezone. Notifications in the panel are sorted by this time
+            ``datetime.datetime`` instance. If the ``datetime.datetime`` instance is naive, it
+            defaults to be in the UTC timezone. Notifications in the panel are sorted by this time
             (optional).
         local_only: Sets whether or not this notification is relevant only to the current device.
             Some notifications can be bridged to other devices for remote display, such as a Wear OS

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -547,7 +547,10 @@ class TestAndroidNotificationEncoder:
                     click_action='ca', title_loc_key='tlk', body_loc_key='blk',
                     title_loc_args=['t1', 't2'], body_loc_args=['b1', 'b2'], channel_id='c',
                     ticker='ticker', sticky=True,
-                    event_timestamp=datetime.datetime(2019, 10, 20, 15, 12, 23, 123),
+                    event_timestamp=datetime.datetime(
+                        2019, 10, 20, 15, 12, 23, 123,
+                        tzinfo=datetime.timezone(datetime.timedelta(hours=-5))
+                    ),
                     local_only=False,
                     priority='high', vibrate_timings_millis=[100, 50, 250],
                     default_vibrate_timings=False, default_sound=True,
@@ -577,7 +580,7 @@ class TestAndroidNotificationEncoder:
                     'channel_id': 'c',
                     'ticker': 'ticker',
                     'sticky': True,
-                    'event_time': '2019-10-20T15:12:23.000123Z',
+                    'event_time': '2019-10-20T20:12:23.000123Z',
                     'local_only': False,
                     'notification_priority': 'PRIORITY_HIGH',
                     'vibrate_timings': ['0.100000000s', '0.050000000s', '0.250000000s'],

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -604,6 +604,29 @@ class TestAndroidNotificationEncoder:
         }
         check_encoding(msg, expected)
 
+    def test_android_notification_naive_event_timestamp(self):
+        event_time = datetime.datetime.now()
+        utc_event_time = event_time.astimezone(datetime.timezone.utc)
+        msg = messaging.Message(
+            topic='topic',
+            android=messaging.AndroidConfig(
+                notification=messaging.AndroidNotification(
+                    title='t',
+                    event_timestamp=event_time,
+                )
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'android': {
+                'notification': {
+                    'title': 't',
+                    'event_time': utc_event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                },
+            },
+        }
+        check_encoding(msg, expected)
+
 
 class TestLightSettingsEncoder:
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -606,7 +606,6 @@ class TestAndroidNotificationEncoder:
 
     def test_android_notification_naive_event_timestamp(self):
         event_time = datetime.datetime.now()
-        utc_event_time = event_time.astimezone(datetime.timezone.utc)
         msg = messaging.Message(
             topic='topic',
             android=messaging.AndroidConfig(
@@ -621,7 +620,7 @@ class TestAndroidNotificationEncoder:
             'android': {
                 'notification': {
                     'title': 't',
-                    'event_time': utc_event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+                    'event_time': event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
                 },
             },
         }


### PR DESCRIPTION
- Check whether the `datetime` object is naive or timezone aware
- If a naive `datetime` object is provided then set its timezone to the local timezone
- Convert the `event_time` to UTC Zulu format

RELEASE NOTE: `AndroidNotification` class now correctly formats the `event_time` field sent to the Cloud Messaging service.