### PR TITLE
Removing universal flag from binary dist configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
As per https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels universal flag should only be used if the code works on both Python 2 and 3 without changes.

```
Only use the --universal setting, if:

1. Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
2. Your project does not have any C extensions.
```

Removing the flag to only build for Python 3 from here on.