### PR TITLE
chore: Installing wheel package during build staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install wheel
 
     - name: Run tests
       run: |


### PR DESCRIPTION
This seems to be required to build wheel distributions, and it's not available on Actions runtime by default.

See the error reported at: https://github.com/firebase/firebase-admin-python/actions/runs/35606539