### PR TITLE
Updated release trigger mechanisms

### DIFF
--- a/.github/scripts/generate_changelog.sh
+++ b/.github/scripts/generate_changelog.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 set -u
 

--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 ###################################### Outputs #####################################
 
 # 1. version: The version of this release including the 'v' prefix (e.g. v1.2.3).

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 set -u
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,13 @@ on:
 
 jobs:
   stage_release:
-    # If triggered by a PR it must contain the label 'release:build'.
+    # To publish a release, merge the release PR with the label 'release:publish'.
+    # To stage a release without publishing it, send a 'firebase_build' event or apply
+    # the 'release:stage' label to a PR.
     if: github.event.action == 'firebase_build' ||
-      contains(github.event.pull_request.labels.*.name, 'release:build')
+      contains(github.event.pull_request.labels.*.name, 'release:stage') ||
+      (github.event.pull_request.merged &&
+        contains(github.event.pull_request.labels.*.name, 'release:publish'))
 
     runs-on: ubuntu-latest
 
@@ -78,9 +82,11 @@ jobs:
     # Check whether the release should be published. We publish only when the trigger PR is
     #   1. merged
     #   2. to the master branch
-    #   3. with the title prefix '[chore] Release '.
+    #   3. with the label 'release:publish', and
+    #   4. the title prefix '[chore] Release '.
     if: github.event.pull_request.merged &&
       github.ref == 'master' &&
+      contains(github.event.pull_request.labels.*.name, 'release:publish') &&
       startsWith(github.event.pull_request.title, '[chore] Release ')
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updating the trigger mechanisms to match the proposal in go/firebase-github-actions.

1. To trigger a publish, merge a PR to the master branch with the label `release:publish` and title prefix `[chore] Release`.
2. To stage a release, either send a `firebase_build` event to repository_dispatch or apply the `release:stage` label to any PR.
3. The `release:stage` label can also be used to test the release workflow itself.