### PR TITLE
fix(fcm): Updated topic management error format

### DIFF
--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -457,9 +457,9 @@ class _MessagingService:
         msg = 'Error while calling the IID service'
         code = data.get('error')
         if code:
-            msg += ' ({0})'.format(code)
+            msg = 'Error while calling the IID service: {0}'.format(code)
         else:
-            msg += '; status: {0}; body: {1}'.format(
+            msg = 'Unexpected HTTP response with status: {0}; body: {1}'.format(
                 error.response.status_code, error.response.content.decode())
 
         return _utils.handle_requests_error(error, msg)

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -454,8 +454,8 @@ class _MessagingService:
             pass
 
         # IID error response format: {"error": "ErrorCode"}
-        msg = 'Error while calling the IID service'
         code = data.get('error')
+        msg = None
         if code:
             msg = 'Error while calling the IID service: {0}'.format(code)
         else:

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -453,10 +453,13 @@ class _MessagingService:
         except ValueError:
             pass
 
-        # IID error response format: {"error": "some error message"}
-        msg = data.get('error')
-        if not msg:
-            msg = 'Unexpected HTTP response with status: {0}; body: {1}'.format(
+        # IID error response format: {"error": "ErrorCode"}
+        msg = 'Error while calling the IID service'
+        code = data.get('error')
+        if code:
+            msg += ' ({0})'.format(code)
+        else:
+            msg += '; status: {0}; body: {1}'.format(
                 error.response.status_code, error.response.content.decode())
 
         return _utils.handle_requests_error(error, msg)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -2286,7 +2286,7 @@ class TestTopicManagement:
             status=status, payload=self._DEFAULT_ERROR_RESPONSE)
         with pytest.raises(exc_type) as excinfo:
             messaging.subscribe_to_topic('foo', 'test-topic')
-        assert str(excinfo.value) == 'error_reason'
+        assert str(excinfo.value) == 'Error while calling the IID service (error_reason)'
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchAdd')
@@ -2296,7 +2296,7 @@ class TestTopicManagement:
         _, recorder = self._instrument_iid_service(status=status, payload='not json')
         with pytest.raises(exc_type) as excinfo:
             messaging.subscribe_to_topic('foo', 'test-topic')
-        reason = 'Unexpected HTTP response with status: {0}; body: not json'.format(status)
+        reason = 'Error while calling the IID service; status: {0}; body: not json'.format(status)
         assert str(excinfo.value) == reason
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
@@ -2318,7 +2318,7 @@ class TestTopicManagement:
             status=status, payload=self._DEFAULT_ERROR_RESPONSE)
         with pytest.raises(exc_type) as excinfo:
             messaging.unsubscribe_from_topic('foo', 'test-topic')
-        assert str(excinfo.value) == 'error_reason'
+        assert str(excinfo.value) == 'Error while calling the IID service (error_reason)'
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchRemove')
@@ -2328,7 +2328,7 @@ class TestTopicManagement:
         _, recorder = self._instrument_iid_service(status=status, payload='not json')
         with pytest.raises(exc_type) as excinfo:
             messaging.unsubscribe_from_topic('foo', 'test-topic')
-        reason = 'Unexpected HTTP response with status: {0}; body: not json'.format(status)
+        reason = 'Error while calling the IID service; status: {0}; body: not json'.format(status)
         assert str(excinfo.value) == reason
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -2286,7 +2286,7 @@ class TestTopicManagement:
             status=status, payload=self._DEFAULT_ERROR_RESPONSE)
         with pytest.raises(exc_type) as excinfo:
             messaging.subscribe_to_topic('foo', 'test-topic')
-        assert str(excinfo.value) == 'Error while calling the IID service (error_reason)'
+        assert str(excinfo.value) == 'Error while calling the IID service: error_reason'
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchAdd')
@@ -2296,7 +2296,7 @@ class TestTopicManagement:
         _, recorder = self._instrument_iid_service(status=status, payload='not json')
         with pytest.raises(exc_type) as excinfo:
             messaging.subscribe_to_topic('foo', 'test-topic')
-        reason = 'Error while calling the IID service; status: {0}; body: not json'.format(status)
+        reason = 'Unexpected HTTP response with status: {0}; body: not json'.format(status)
         assert str(excinfo.value) == reason
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
@@ -2318,7 +2318,7 @@ class TestTopicManagement:
             status=status, payload=self._DEFAULT_ERROR_RESPONSE)
         with pytest.raises(exc_type) as excinfo:
             messaging.unsubscribe_from_topic('foo', 'test-topic')
-        assert str(excinfo.value) == 'Error while calling the IID service (error_reason)'
+        assert str(excinfo.value) == 'Error while calling the IID service: error_reason'
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'
         assert recorder[0].url == self._get_url('iid/v1:batchRemove')
@@ -2328,7 +2328,7 @@ class TestTopicManagement:
         _, recorder = self._instrument_iid_service(status=status, payload='not json')
         with pytest.raises(exc_type) as excinfo:
             messaging.unsubscribe_from_topic('foo', 'test-topic')
-        reason = 'Error while calling the IID service; status: {0}; body: not json'.format(status)
+        reason = 'Unexpected HTTP response with status: {0}; body: not json'.format(status)
         assert str(excinfo.value) == reason
         assert len(recorder) == 1
         assert recorder[0].method == 'POST'


### PR DESCRIPTION
Current error handling logic assumes topic management error responses contain an error message. In reality they only contain an error code. This PR updates the implementation to handle these responses correctly.

RELEASE NOTE: Returning more descriptive error messages from the topic management APIs.