### PR TITLE
Moved all public auth APIs to _AuthClient

### DIFF
--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -110,7 +110,7 @@ def _get_session_cookie(payload_overrides=None, header_overrides=None):
 
 def _instrument_user_manager(app, status, payload):
     auth_service = auth._get_auth_service(app)
-    user_manager = auth_service.user_manager
+    user_manager = auth_service._user_manager
     recorder = []
     user_manager._client.session.mount(
         auth._AuthService.ID_TOOLKIT_URL,
@@ -119,11 +119,11 @@ def _instrument_user_manager(app, status, payload):
 
 def _overwrite_cert_request(app, request):
     auth_service = auth._get_auth_service(app)
-    auth_service.token_verifier.request = request
+    auth_service._token_verifier.request = request
 
 def _overwrite_iam_request(app, request):
     auth_service = auth._get_auth_service(app)
-    auth_service.token_generator.request = request
+    auth_service._token_generator.request = request
 
 @pytest.fixture(scope='module')
 def auth_app():
@@ -246,7 +246,7 @@ class TestCreateCustomToken:
             _overwrite_iam_request(app, request)
             # Force initialization of the signing provider. This will invoke the Metadata service.
             auth_service = auth._get_auth_service(app)
-            assert auth_service.token_generator.signing_provider is not None
+            assert auth_service._token_generator.signing_provider is not None
             # Now invoke the IAM signer.
             signature = base64.b64encode(b'test').decode()
             request.response = testutils.MockResponse(

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -59,7 +59,7 @@ def user_mgt_app():
 
 def _instrument_user_manager(app, status, payload):
     auth_service = auth._get_auth_service(app)
-    user_manager = auth_service.user_manager
+    user_manager = auth_service._user_manager
     recorder = []
     user_manager._client.session.mount(
         auth._AuthService.ID_TOOLKIT_URL,
@@ -105,7 +105,7 @@ class TestAuthServiceInitialization:
 
     def test_default_timeout(self, user_mgt_app):
         auth_service = auth._get_auth_service(user_mgt_app)
-        user_manager = auth_service.user_manager
+        user_manager = auth_service._user_manager
         assert user_manager._client.timeout == _http_client.DEFAULT_TIMEOUT_SECONDS
 
     def test_fail_on_no_project_id(self):
@@ -1302,7 +1302,7 @@ class TestGenerateEmailActionLink:
     def test_bad_action_type(self, user_mgt_app):
         with pytest.raises(ValueError):
             auth._get_auth_service(user_mgt_app) \
-                .user_manager \
+                ._user_manager \
                 .generate_email_action_link('BAD_TYPE', 'test@test.com',
                                             action_code_settings=MOCK_ACTION_CODE_SETTINGS)
 


### PR DESCRIPTION
In a future PR `_AuthClient` will be simply renamed and exposed as `Client`. Furthermore we are planning to use it as the tenant-aware auth client so that we can have:

```
TenantManager.auth_for_tenant(tenant_id: str) -> auth.Client
```

As a first step towards this refactor, I'm moving all public auth APIs to the `_AuthClient` class. That includes pretty much all Auth APIs except `create_session_cookie()` and `verify_session_cookie()` which are not tenant-aware.