### PR TITLE
feat(auth): Adding SAMLProviderConfig type and the getter method

### DIFF
--- a/firebase_admin/_auth_providers.py
+++ b/firebase_admin/_auth_providers.py
@@ -1,0 +1,101 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+
+from firebase_admin import _auth_utils
+
+
+class ProviderConfig:
+    """Parent type for all authentication provider config types."""
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def provider_id(self):
+        name = self._data['name']
+        return name.split('/')[-1]
+
+    @property
+    def display_name(self):
+        return self._data.get('displayName')
+
+    @property
+    def enabled(self):
+        return self._data['enabled']
+
+
+class SAMLProviderConfig(ProviderConfig):
+    """Represents he SAML auth provider configuration.
+
+    See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html."""
+
+    def __init__(self, data):
+        super().__init__(data)
+
+    @property
+    def idp_entity_id(self):
+        return self._data.get('idpConfig', {})['idpEntityId']
+
+    @property
+    def sso_url(self):
+        return self._data.get('idpConfig', {})['ssoUrl']
+
+    @property
+    def x509_certificates(self):
+        certs = self._data.get('idpConfig', {})['idpCertificates']
+        return [c['x509Certificate'] for c in certs]
+
+    @property
+    def request_signing_enabled(self):
+        return self._data.get('idpConfig', {})['signRequest']
+
+    @property
+    def callback_url(self):
+        return self._data.get('spConfig', {})['callbackUri']
+
+    @property
+    def rp_entity_id(self):
+        return self._data.get('spConfig', {})['spEntityId']
+
+
+class ProviderConfigClient:
+    """Client for managing Auth provider configurations."""
+
+    PROVIDER_CONFIG_URL = 'https://identitytoolkit.googleapis.com/v2beta1'
+
+    def __init__(self, http_client, project_id, tenant_id=None):
+        self.http_client = http_client
+        self.base_url = '{0}/projects/{1}'.format(self.PROVIDER_CONFIG_URL, project_id)
+        if tenant_id:
+            self.base_url += '/tenants/{0}'.format(tenant_id)
+
+    def get_saml_provider_config(self, provider_id):
+        if not isinstance(provider_id, str):
+            raise ValueError(
+                'Invalid SAML provider ID: {0}. Provider ID must be a non-empty string.'.format(
+                    provider_id))
+        if not provider_id.startswith('saml.'):
+            raise ValueError('Invalid SAML provider ID: {0}.'.format(provider_id))
+
+        body = self._make_request('get', '/inboundSamlConfigs/{0}'.format(provider_id))
+        return SAMLProviderConfig(body)
+
+    def _make_request(self, method, path, body=None):
+        url = '{0}{1}'.format(self.base_url, path)
+        try:
+            return self.http_client.body(method, url, json=body)
+        except requests.exceptions.RequestException as error:
+            raise _auth_utils.handle_auth_backend_error(error)

--- a/firebase_admin/_auth_providers.py
+++ b/firebase_admin/_auth_providers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Firebase auth providers management sub module."""
+
 import requests
 
 from firebase_admin import _auth_utils
@@ -41,9 +43,6 @@ class SAMLProviderConfig(ProviderConfig):
     """Represents he SAML auth provider configuration.
 
     See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html."""
-
-    def __init__(self, data):
-        super().__init__(data)
 
     @property
     def idp_entity_id(self):

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -307,7 +307,17 @@ class TenantIdMismatchError(exceptions.InvalidArgumentError):
         exceptions.InvalidArgumentError.__init__(self, message)
 
 
+class ConfigurationNotFoundError(exceptions.NotFoundError):
+    """No auth provider found for the specified identifier."""
+
+    default_message = 'No auth provider found for the given identifier'
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.NotFoundError.__init__(self, message, cause, http_response)
+
+
 _CODE_TO_EXC_TYPE = {
+    'CONFIGURATION_NOT_FOUND': ConfigurationNotFoundError,
     'DUPLICATE_EMAIL': EmailAlreadyExistsError,
     'DUPLICATE_LOCAL_ID': UidAlreadyExistsError,
     'EMAIL_EXISTS': EmailAlreadyExistsError,

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -51,8 +51,10 @@ __all__ = [
     'InvalidSessionCookieError',
     'ListUsersPage',
     'PhoneNumberAlreadyExistsError',
+    'ProviderConfig',
     'RevokedIdTokenError',
     'RevokedSessionCookieError',
+    'SAMLProviderConfig',
     'TokenSignError',
     'UidAlreadyExistsError',
     'UnexpectedResponseError',
@@ -71,6 +73,7 @@ __all__ = [
     'generate_email_verification_link',
     'generate_password_reset_link',
     'generate_sign_in_with_email_link',
+    'get_saml_provider_config',
     'get_user',
     'get_user_by_email',
     'get_user_by_phone_number',
@@ -85,6 +88,7 @@ __all__ = [
 
 ActionCodeSettings = _user_mgt.ActionCodeSettings
 CertificateFetchError = _token_gen.CertificateFetchError
+ConfigurationNotFoundError = _auth_utils.ConfigurationNotFoundError
 DELETE_ATTRIBUTE = _user_mgt.DELETE_ATTRIBUTE
 EmailAlreadyExistsError = _auth_utils.EmailAlreadyExistsError
 ErrorInfo = _user_import.ErrorInfo
@@ -98,8 +102,10 @@ InvalidIdTokenError = _auth_utils.InvalidIdTokenError
 InvalidSessionCookieError = _token_gen.InvalidSessionCookieError
 ListUsersPage = _user_mgt.ListUsersPage
 PhoneNumberAlreadyExistsError = _auth_utils.PhoneNumberAlreadyExistsError
+ProviderConfig = _auth_providers.ProviderConfigClient
 RevokedIdTokenError = _token_gen.RevokedIdTokenError
 RevokedSessionCookieError = _token_gen.RevokedSessionCookieError
+SAMLProviderConfig = _auth_providers.SAMLProviderConfig
 TokenSignError = _token_gen.TokenSignError
 UidAlreadyExistsError = _auth_utils.UidAlreadyExistsError
 UnexpectedResponseError = _auth_utils.UnexpectedResponseError
@@ -522,6 +528,7 @@ def generate_sign_in_with_email_link(email, action_code_settings, app=None):
             the link is to be handled by a mobile app and the additional state information to be
             passed in the deep link.
         app: An App instance (optional).
+
     Returns:
         link: The email sign-in link created by the API
 
@@ -535,6 +542,20 @@ def generate_sign_in_with_email_link(email, action_code_settings, app=None):
 
 
 def get_saml_provider_config(provider_id, app=None):
+    """Returns the SAMLProviderConfig with the given ID.
+
+    Args:
+        provider_id: Provider ID string.
+        app: An App instance (optional).
+
+    Returns:
+        SAMLProviderConfig: A SAMLProviderConfig instance.
+
+    Raises:
+        ValueError: If the provider ID is invalid, empty or does not have ``saml.`` prefix.
+        ConfigurationNotFoundError: If no SAML provider is available with the given identifier.
+        FirebaseError: If an error occurs while retrieving the SAML provider.
+    """
     client = _get_client(app)
     return client.get_saml_provider_config(provider_id)
 
@@ -905,6 +926,19 @@ class Client:
             'EMAIL_SIGNIN', email, action_code_settings=action_code_settings)
 
     def get_saml_provider_config(self, provider_id):
+        """Returns the SAMLProviderConfig with the given ID.
+
+        Args:
+            provider_id: Provider ID string.
+
+        Returns:
+            SAMLProviderConfig: A SAMLProviderConfig instance.
+
+        Raises:
+            ValueError: If the provider ID is invalid, empty or does not have ``saml.`` prefix.
+            ConfigurationNotFoundError: If no SAML provider is available with the given identifier.
+            FirebaseError: If an error occurs while retrieving the SAML provider.
+        """
         return self._provider_manager.get_saml_provider_config(provider_id)
 
     def _check_jwt_revoked(self, verified_claims, exc_type, label):

--- a/tests/data/saml_provider_config.json
+++ b/tests/data/saml_provider_config.json
@@ -1,0 +1,18 @@
+{
+  "name": "projects/mock-project-id/inboundSamlConfigs/saml.provider",
+  "idpConfig": {
+      "idpEntityId": "IDP_ENTITY_ID",
+      "ssoUrl": "https://example.com/login",
+      "signRequest": true,
+      "idpCertificates": [
+          {"x509Certificate": "CERT1"},
+          {"x509Certificate": "CERT2"}
+      ]
+  },
+  "spConfig": {
+      "spEntityId": "RP_ENTITY_ID",
+      "callbackUri": "https://projectId.firebaseapp.com/__/auth/handler"
+  },
+  "displayName": "samlProviderName",
+  "enabled": true
+}

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -1,0 +1,75 @@
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the firebase_admin._auth_providers module."""
+
+import pytest
+
+import firebase_admin
+from firebase_admin import auth
+from firebase_admin import _auth_providers
+from tests import testutils
+
+USER_MGT_URL_PREFIX = 'https://identitytoolkit.googleapis.com/v2beta1/projects/mock-project-id'
+SAML_PROVIDER_CONFIG_RESPONSE = testutils.resource('saml_provider_config.json')
+
+
+@pytest.fixture(scope='module')
+def user_mgt_app():
+    app = firebase_admin.initialize_app(testutils.MockCredential(), name='providerConfig',
+                                        options={'projectId': 'mock-project-id'})
+    yield app
+    firebase_admin.delete_app(app)
+
+
+def _instrument_provider_mgt(app, status, payload):
+    client = auth._get_client(app)
+    provider_manager = client._provider_manager
+    recorder = []
+    provider_manager.http_client.session.mount(
+        _auth_providers.ProviderConfigClient.PROVIDER_CONFIG_URL,
+        testutils.MockAdapter(payload, status, recorder))
+    return recorder
+
+
+class TestSAMLProviderConfig:
+
+    @pytest.mark.parametrize('provider_id', [
+        None, True, False, 1, 0, list(), tuple(), dict(), '', 'oidc.provider'
+    ])
+    def test_invalid_provider_id(self, user_mgt_app, provider_id):
+        with pytest.raises(ValueError) as excinfo:
+            auth.get_saml_provider_config(provider_id, app=user_mgt_app)
+
+        assert str(excinfo.value).startswith('Invalid SAML provider ID')
+
+    def test_get_saml_provider_config(self, user_mgt_app):
+        recorder = _instrument_provider_mgt(user_mgt_app, 200, SAML_PROVIDER_CONFIG_RESPONSE)
+
+        provider_config = auth.get_saml_provider_config('saml.provider', app=user_mgt_app)
+
+        assert provider_config.provider_id == 'saml.provider'
+        assert provider_config.display_name == 'samlProviderName'
+        assert provider_config.enabled is True
+        assert provider_config.idp_entity_id == 'IDP_ENTITY_ID'
+        assert provider_config.sso_url == 'https://example.com/login'
+        assert provider_config.request_signing_enabled is True
+        assert provider_config.x509_certificates == ['CERT1', 'CERT2']
+        assert provider_config.rp_entity_id == 'RP_ENTITY_ID'
+        assert provider_config.callback_url == 'https://projectId.firebaseapp.com/__/auth/handler'
+
+        assert len(recorder) == 1
+        req = recorder[0]
+        assert req.method == 'GET'
+        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/inboundSamlConfigs/saml.provider')

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -120,8 +120,8 @@ def _instrument_user_manager(app, status, payload):
     client = auth._get_client(app)
     user_manager = client._user_manager
     recorder = []
-    user_manager._client.session.mount(
-        auth.Client.ID_TOOLKIT_URL,
+    user_manager.http_client.session.mount(
+        _token_gen.TokenGenerator.ID_TOOLKIT_URL,
         testutils.MockAdapter(payload, status, recorder))
     return user_manager, recorder
 


### PR DESCRIPTION
Starting to implement the Auth provider config management APIs.

```
class ProviderConfig
  provider_id: str
  display_name: str
  enabled: boolean

class SAMLProviderConfig(ProviderConfig)
  idp_entity_id: str
  sso_url: str
  request_signing_enabled: boolean
  callback_url: str
  rp_entity_id: str
  x509_certificates: list<str>

class ConfigurationNotFoundError(exceptions.NotFoundError)

auth <module>
  get_saml_provider_config(provider_id, app=None): SAMLProviderConfig
  class Client:
    get_saml_provider_config(provider_id): SAMLProviderConfig
```