### PR TITLE
Move shebang to top of file.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 function lintAllFiles () {
   echo "Running linter on module $1"


### PR DESCRIPTION
It otherwise has no effect, causing the default shell to be tried (which
is /bin/sh on my home system).