### PR TITLE
fix: Updates for latest version of google-auth

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -27,7 +27,7 @@ import sys
 import threading
 from urllib import parse
 
-import google.auth
+from google.auth import credentials
 import requests
 
 import firebase_admin
@@ -802,7 +802,7 @@ class _DatabaseService:
             credential = self._credential.get_credential()
         else:
             # Emulator base_url. Use fake credentials and specify ?ns=foo in query params.
-            credential = _EmulatorAdminCredentials()
+            credential = credentials.AnonymousCredentials()
             params = {'ns': namespace}
         if self._auth_override:
             params['auth_variable_override'] = self._auth_override
@@ -978,12 +978,3 @@ class _Client(_http_client.JsonHttpClient):
             message = 'Unexpected response from database: {0}'.format(response.content.decode())
 
         return message
-
-
-class _EmulatorAdminCredentials(google.auth.credentials.Credentials):
-    def __init__(self):
-        google.auth.credentials.Credentials.__init__(self)
-        self.token = 'owner'
-
-    def refresh(self, request):
-        pass

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -221,7 +221,7 @@ class TestCreateCustomToken:
             testutils.MockCredential(), name='iam-signer-app', options=options)
         try:
             signature = base64.b64encode(b'test').decode()
-            iam_resp = '{{"signature": "{0}"}}'.format(signature)
+            iam_resp = '{{"signedBlob": "{0}"}}'.format(signature)
             _overwrite_iam_request(app, testutils.MockRequest(200, iam_resp))
             custom_token = auth.create_custom_token(MOCK_UID, app=app).decode()
             assert custom_token.endswith('.' + signature.rstrip('='))
@@ -259,7 +259,7 @@ class TestCreateCustomToken:
             # Now invoke the IAM signer.
             signature = base64.b64encode(b'test').decode()
             request.response = testutils.MockResponse(
-                200, '{{"signature": "{0}"}}'.format(signature))
+                200, '{{"signedBlob": "{0}"}}'.format(signature))
             custom_token = auth.create_custom_token(MOCK_UID, app=app).decode()
             assert custom_token.endswith('.' + signature.rstrip('='))
             self._verify_signer(custom_token, 'discovered-service-account')


### PR DESCRIPTION
The latest version of `google-auth` uses the IAM service accounts API to sign tokens (see  https://github.com/googleapis/google-auth-library-python/pull/553). We need to update our unit test mocks to be compatible with this change. 

At the same time I'm replacing our `_EmulatorAdminCredentials` type with `AnonymousCredentials` type provided in google-auth which serves the same purpose.