### PR TITLE
chore: Temporarily disabling a lint rule

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -979,7 +979,9 @@ class _Client(_http_client.JsonHttpClient):
 
         return message
 
-
+# Temporarily disable the lint rule. For more information see:
+# https://github.com/googleapis/google-auth-library-python/pull/561
+# pylint: disable=abstract-method
 class _EmulatorAdminCredentials(google.auth.credentials.Credentials):
     def __init__(self):
         google.auth.credentials.Credentials.__init__(self)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -105,6 +105,9 @@ class MockFailedRequest(transport.Request):
         raise self.error
 
 
+# Temporarily disable the lint rule. For more information see:
+# https://github.com/googleapis/google-auth-library-python/pull/561
+# pylint: disable=abstract-method
 class MockGoogleCredential(credentials.Credentials):
     """A mock Google authentication credential."""
     def refresh(self, request):


### PR DESCRIPTION
New versions of `google-auth` introduced a `with_quota_project()` method to the `Credential` class. Pylint considers this method to be abstract and raises a warning when it's not explicitly overriden in child classes. We are hoping to get this addressed upstream at https://github.com/googleapis/google-auth-library-python/pull/561. In the meantime I'm silencing the lint warning so that CI checks can proceed.