### PR TITLE
[chore] Release 4.4.0 Take 2

### DIFF
--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -75,7 +75,7 @@ def test_send_invalid_token():
         token=_REGISTRATION_TOKEN,
         notification=messaging.Notification('test-title', 'test-body')
     )
-    with pytest.raises(messaging.SenderIdMismatchError):
+    with pytest.raises(messaging.UnregisteredError):
         messaging.send(msg, dry_run=True)
 
 def test_send_malformed_token():


### PR DESCRIPTION
- The registration token used in integration tests are now deleted/unregistered
- Changing the expected error in the test from `SENDER_ID_MISMATCH` to `UNREGISTERED`