### PR TITLE
fix(fcm): Converting unexpected gapic runtime errors to FirebaseError

### DIFF
--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -16,7 +16,6 @@
 
 import json
 
-import googleapiclient
 from googleapiclient import http
 from googleapiclient import _auth
 import requests
@@ -388,7 +387,7 @@ class _MessagingService:
 
         try:
             batch.execute()
-        except googleapiclient.http.HttpError as error:
+        except Exception as error:
             raise self._handle_batch_error(error)
         else:
             return BatchResponse(responses)


### PR DESCRIPTION
The `googleapiclient` occasionally raises low-level runtime errors, which are currently not handled in the FCM implementation. These exceptions are directly exposed to the user, who typically only expect to handle instances of `FirebaseError`. This PR makes sure our FCM implementation handles all exceptions raised by `googleapiclient`, and they are correctly mapped to instances of `FirebaseError`.

Resolves #506 

RELEASE NOTE: Correctly handling low-level runtime errors raised by the `googleapiclient` package while sending batch requests.