### PR TITLE
change: Deprecated support for Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Python Versions
 
-We currently support Python 3.5+. Firebase Admin Python SDK is also tested on
-PyPy and [Google App Engine](https://cloud.google.com/appengine/) environments.
+We currently support Python 3.5+. However, Python 3.5 support is deprecated,
+and the developers are strongly advised to use Python 3.6 or higher. Firebase
+Admin Python SDK is also tested on PyPy and
+[Google App Engine](https://cloud.google.com/appengine/) environments.
 
 
 ## Documentation


### PR DESCRIPTION
Python 3.5 has EoL'ed. 

RELEASE NOTE: Deprecated support for Python 3.5. Developers are advised to use Python 3.6 or higher when deploying the Admin SDK. 

