### PR TITLE
feat(auth): Add auth emulator support via the FIREBASE_AUTH_EMULATOR_HOST environment variable.

### DIFF
--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -128,7 +128,7 @@ class Client:
                 raise _auth_utils.TenantIdMismatchError(
                     'Invalid tenant ID: {0}'.format(token_tenant_id))
 
-        if not self.emulated and check_revoked:
+        if check_revoked:
             self._check_jwt_revoked(verified_claims, _token_gen.RevokedIdTokenError, 'ID token')
         return verified_claims
 

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -24,6 +24,7 @@ from firebase_admin import _token_gen
 from firebase_admin import _user_identifier
 from firebase_admin import _user_import
 from firebase_admin import _user_mgt
+from firebase_admin import _utils
 
 
 class Client:
@@ -36,18 +37,37 @@ class Client:
             2. set the project ID explicitly via Firebase App options, or
             3. set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.""")
 
-        credential = app.credential.get_credential()
+        credential = None
         version_header = 'Python/Admin/{0}'.format(firebase_admin.__version__)
         timeout = app.options.get('httpTimeout', _http_client.DEFAULT_TIMEOUT_SECONDS)
+        # Non-default endpoint URLs for emulator support are set in this dict later.
+        endpoint_urls = {}
+        self.emulated = False
+
+        # If an emulator is present, check that the given value matches the expected format and set
+        # endpoint URLs to use the emulator. Additionally, use a fake credential.
+        emulator_host = _auth_utils.get_emulator_host()
+        if emulator_host:
+            base_url = 'http://{0}/identitytoolkit.googleapis.com'.format(emulator_host)
+            endpoint_urls['v1'] = base_url + '/v1'
+            endpoint_urls['v2beta1'] = base_url + '/v2beta1'
+            credential = _utils.EmulatorAdminCredentials()
+            self.emulated = True
+        else:
+            # Use credentials if provided
+            credential = app.credential.get_credential()
+
         http_client = _http_client.JsonHttpClient(
             credential=credential, headers={'X-Client-Version': version_header}, timeout=timeout)
 
         self._tenant_id = tenant_id
-        self._token_generator = _token_gen.TokenGenerator(app, http_client)
+        self._token_generator = _token_gen.TokenGenerator(
+            app, http_client, url_override=endpoint_urls.get('v1'))
         self._token_verifier = _token_gen.TokenVerifier(app)
-        self._user_manager = _user_mgt.UserManager(http_client, app.project_id, tenant_id)
+        self._user_manager = _user_mgt.UserManager(
+            http_client, app.project_id, tenant_id, url_override=endpoint_urls.get('v1'))
         self._provider_manager = _auth_providers.ProviderConfigClient(
-            http_client, app.project_id, tenant_id)
+            http_client, app.project_id, tenant_id, url_override=endpoint_urls.get('v2beta1'))
 
     @property
     def tenant_id(self):
@@ -108,7 +128,7 @@ class Client:
                 raise _auth_utils.TenantIdMismatchError(
                     'Invalid tenant ID: {0}'.format(token_tenant_id))
 
-        if check_revoked:
+        if not self.emulated and check_revoked:
             self._check_jwt_revoked(verified_claims, _token_gen.RevokedIdTokenError, 'ID token')
         return verified_claims
 

--- a/firebase_admin/_auth_providers.py
+++ b/firebase_admin/_auth_providers.py
@@ -166,9 +166,10 @@ class ProviderConfigClient:
 
     PROVIDER_CONFIG_URL = 'https://identitytoolkit.googleapis.com/v2beta1'
 
-    def __init__(self, http_client, project_id, tenant_id=None):
+    def __init__(self, http_client, project_id, tenant_id=None, url_override=None):
         self.http_client = http_client
-        self.base_url = '{0}/projects/{1}'.format(self.PROVIDER_CONFIG_URL, project_id)
+        url_prefix = url_override or self.PROVIDER_CONFIG_URL
+        self.base_url = '{0}/projects/{1}'.format(url_prefix, project_id)
         if tenant_id:
             self.base_url += '/tenants/{0}'.format(tenant_id)
 

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -15,6 +15,7 @@
 """Firebase auth utils."""
 
 import json
+import os
 import re
 from urllib import parse
 
@@ -22,6 +23,7 @@ from firebase_admin import exceptions
 from firebase_admin import _utils
 
 
+EMULATOR_HOST_ENV_VAR = 'FIREBASE_AUTH_EMULATOR_HOST'
 MAX_CLAIMS_PAYLOAD_SIZE = 1000
 RESERVED_CLAIMS = set([
     'acr', 'amr', 'at_hash', 'aud', 'auth_time', 'azp', 'cnf', 'c_hash', 'exp', 'iat',
@@ -64,6 +66,19 @@ class PageIterator:
 
     def __iter__(self):
         return self
+
+
+def get_emulator_host():
+    emulator_host = os.getenv(EMULATOR_HOST_ENV_VAR, '')
+    if emulator_host and '//' in emulator_host:
+        raise ValueError(
+            'Invalid {0}: "{1}". It must follow format "host:port".'.format(
+                EMULATOR_HOST_ENV_VAR, emulator_host))
+    return emulator_host
+
+
+def is_emulated():
+    return get_emulator_host() != ''
 
 
 def validate_uid(uid, required=False):

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -84,11 +84,12 @@ class TokenGenerator:
 
     ID_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1'
 
-    def __init__(self, app, http_client):
+    def __init__(self, app, http_client, url_override=None):
         self.app = app
         self.http_client = http_client
         self.request = transport.requests.Request()
-        self.base_url = '{0}/projects/{1}'.format(self.ID_TOOLKIT_URL, app.project_id)
+        url_prefix = url_override or self.ID_TOOLKIT_URL
+        self.base_url = '{0}/projects/{1}'.format(url_prefix, app.project_id)
         self._signing_provider = None
 
     def _init_signing_provider(self):

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -53,6 +53,19 @@ RESERVED_CLAIMS = set([
 METADATA_SERVICE_URL = ('http://metadata.google.internal/computeMetadata/v1/instance/'
                         'service-accounts/default/email')
 
+# Emulator fake account
+AUTH_EMULATOR_EMAIL = 'firebase-auth-emulator@example.com'
+
+
+class _EmulatedSigner(google.auth.crypt.Signer):
+    key_id = None
+
+    def __init__(self):
+        pass
+
+    def sign(self, message):
+        return b''
+
 
 class _SigningProvider:
     """Stores a reference to a google.auth.crypto.Signer."""
@@ -78,6 +91,10 @@ class _SigningProvider:
         signer = iam.Signer(request, google_cred, service_account)
         return _SigningProvider(signer, service_account)
 
+    @classmethod
+    def for_emulator(cls):
+        return _SigningProvider(_EmulatedSigner(), AUTH_EMULATOR_EMAIL)
+
 
 class TokenGenerator:
     """Generates custom tokens and session cookies."""
@@ -94,6 +111,8 @@ class TokenGenerator:
 
     def _init_signing_provider(self):
         """Initializes a signing provider by following the go/firebase-admin-sign protocol."""
+        if _auth_utils.is_emulated():
+            return _SigningProvider.for_emulator()
         # If the SDK was initialized with a service account, use it to sign bytes.
         google_cred = self.app.credential.get_credential()
         if isinstance(google_cred, google.oauth2.service_account.Credentials):
@@ -286,12 +305,14 @@ class _JWTVerifier:
         verify_id_token_msg = (
             'See {0} for details on how to retrieve {1}.'.format(self.url, self.short_name))
 
+        emulated = _auth_utils.is_emulated()
+
         error_message = None
         if audience == FIREBASE_AUDIENCE:
             error_message = (
                 '{0} expects {1}, but was given a custom '
                 'token.'.format(self.operation, self.articled_short_name))
-        elif not header.get('kid'):
+        elif not emulated and not header.get('kid'):
             if header.get('alg') == 'HS256' and payload.get(
                     'v') == 0 and 'uid' in payload.get('d', {}):
                 error_message = (
@@ -299,7 +320,7 @@ class _JWTVerifier:
                     'token.'.format(self.operation, self.articled_short_name))
             else:
                 error_message = 'Firebase {0} has no "kid" claim.'.format(self.short_name)
-        elif header.get('alg') != 'RS256':
+        elif not emulated and header.get('alg') != 'RS256':
             error_message = (
                 'Firebase {0} has incorrect algorithm. Expected "RS256" but got '
                 '"{1}". {2}'.format(self.short_name, header.get('alg'), verify_id_token_msg))
@@ -330,11 +351,14 @@ class _JWTVerifier:
             raise self._invalid_token_error(error_message)
 
         try:
-            verified_claims = google.oauth2.id_token.verify_token(
-                token,
-                request=request,
-                audience=self.project_id,
-                certs_url=self.cert_url)
+            if emulated:
+                verified_claims = payload
+            else:
+                verified_claims = google.oauth2.id_token.verify_token(
+                    token,
+                    request=request,
+                    audience=self.project_id,
+                    certs_url=self.cert_url)
             verified_claims['uid'] = verified_claims['sub']
             return verified_claims
         except google.auth.exceptions.TransportError as error:

--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -573,9 +573,10 @@ class UserManager:
 
     ID_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v1'
 
-    def __init__(self, http_client, project_id, tenant_id=None):
+    def __init__(self, http_client, project_id, tenant_id=None, url_override=None):
         self.http_client = http_client
-        self.base_url = '{0}/projects/{1}'.format(self.ID_TOOLKIT_URL, project_id)
+        url_prefix = url_override or self.ID_TOOLKIT_URL
+        self.base_url = '{0}/projects/{1}'.format(url_prefix, project_id)
         if tenant_id:
             self.base_url += '/tenants/{0}'.format(tenant_id)
 

--- a/firebase_admin/_utils.py
+++ b/firebase_admin/_utils.py
@@ -18,6 +18,7 @@ import io
 import json
 import socket
 
+import google.auth
 import googleapiclient
 import httplib2
 import requests
@@ -339,3 +340,20 @@ def _parse_platform_error(content, status_code):
     if not msg:
         msg = 'Unexpected HTTP response with status: {0}; body: {1}'.format(status_code, content)
     return error_dict, msg
+
+
+# Temporarily disable the lint rule. For more information see:
+# https://github.com/googleapis/google-auth-library-python/pull/561
+# pylint: disable=abstract-method
+class EmulatorAdminCredentials(google.auth.credentials.Credentials):
+    """ Credentials for use with the firebase local emulator.
+
+    This is used instead of user-supplied credentials or ADC.  It will silently do nothing when
+    asked to refresh credentials.
+    """
+    def __init__(self):
+        google.auth.credentials.Credentials.__init__(self)
+        self.token = 'owner'
+
+    def refresh(self, request):
+        pass

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -27,7 +27,6 @@ import sys
 import threading
 from urllib import parse
 
-import google.auth
 import requests
 
 import firebase_admin
@@ -808,7 +807,7 @@ class _DatabaseService:
 
         emulator_config = self._get_emulator_config(parsed_url)
         if emulator_config:
-            credential = _EmulatorAdminCredentials()
+            credential = _utils.EmulatorAdminCredentials()
             base_url = emulator_config.base_url
             params = {'ns': emulator_config.namespace}
         else:
@@ -965,14 +964,3 @@ class _Client(_http_client.JsonHttpClient):
             message = 'Unexpected response from database: {0}'.format(response.content.decode())
 
         return message
-
-# Temporarily disable the lint rule. For more information see:
-# https://github.com/googleapis/google-auth-library-python/pull/561
-# pylint: disable=abstract-method
-class _EmulatorAdminCredentials(google.auth.credentials.Credentials):
-    def __init__(self):
-        google.auth.credentials.Credentials.__init__(self)
-        self.token = 'owner'
-
-    def refresh(self, request):
-        pass

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -21,10 +21,18 @@ import pytest
 import firebase_admin
 from firebase_admin import auth
 from firebase_admin import exceptions
-from firebase_admin import _auth_providers
 from tests import testutils
 
-USER_MGT_URL_PREFIX = 'https://identitytoolkit.googleapis.com/v2beta1/projects/mock-project-id'
+ID_TOOLKIT_URL = 'https://identitytoolkit.googleapis.com/v2beta1'
+EMULATOR_HOST_ENV_VAR = 'FIREBASE_AUTH_EMULATOR_HOST'
+AUTH_EMULATOR_HOST = 'localhost:9099'
+EMULATED_ID_TOOLKIT_URL = 'http://{}/identitytoolkit.googleapis.com/v2beta1'.format(
+    AUTH_EMULATOR_HOST)
+URL_PROJECT_SUFFIX = '/projects/mock-project-id'
+USER_MGT_URLS = {
+    'ID_TOOLKIT': ID_TOOLKIT_URL,
+    'PREFIX': ID_TOOLKIT_URL + URL_PROJECT_SUFFIX,
+}
 OIDC_PROVIDER_CONFIG_RESPONSE = testutils.resource('oidc_provider_config.json')
 SAML_PROVIDER_CONFIG_RESPONSE = testutils.resource('saml_provider_config.json')
 LIST_OIDC_PROVIDER_CONFIGS_RESPONSE = testutils.resource('list_oidc_provider_configs.json')
@@ -39,12 +47,18 @@ CONFIG_NOT_FOUND_RESPONSE = """{
 INVALID_PROVIDER_IDS = [None, True, False, 1, 0, list(), tuple(), dict(), '']
 
 
-@pytest.fixture(scope='module')
-def user_mgt_app():
+@pytest.fixture(scope='module', params=[{'emulated': False}, {'emulated': True}])
+def user_mgt_app(request):
+    monkeypatch = pytest.MonkeyPatch()
+    if request.param['emulated']:
+        monkeypatch.setenv(EMULATOR_HOST_ENV_VAR, AUTH_EMULATOR_HOST)
+        monkeypatch.setitem(USER_MGT_URLS, 'ID_TOOLKIT', EMULATED_ID_TOOLKIT_URL)
+        monkeypatch.setitem(USER_MGT_URLS, 'PREFIX', EMULATED_ID_TOOLKIT_URL + URL_PROJECT_SUFFIX)
     app = firebase_admin.initialize_app(testutils.MockCredential(), name='providerConfig',
                                         options={'projectId': 'mock-project-id'})
     yield app
     firebase_admin.delete_app(app)
+    monkeypatch.undo()
 
 
 def _instrument_provider_mgt(app, status, payload):
@@ -52,7 +66,7 @@ def _instrument_provider_mgt(app, status, payload):
     provider_manager = client._provider_manager
     recorder = []
     provider_manager.http_client.session.mount(
-        _auth_providers.ProviderConfigClient.PROVIDER_CONFIG_URL,
+        USER_MGT_URLS['ID_TOOLKIT'],
         testutils.MockAdapter(payload, status, recorder))
     return recorder
 
@@ -90,7 +104,7 @@ class TestOIDCProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/oauthIdpConfigs/oidc.provider')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'], '/oauthIdpConfigs/oidc.provider')
 
     @pytest.mark.parametrize('invalid_opts', [
         {'provider_id': None}, {'provider_id': ''}, {'provider_id': 'saml.provider'},
@@ -116,7 +130,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/oauthIdpConfigs?oauthIdpConfigId=oidc.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == self.OIDC_CONFIG_REQUEST
 
@@ -136,7 +150,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/oauthIdpConfigs?oauthIdpConfigId=oidc.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == want
 
@@ -156,7 +170,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/oauthIdpConfigs?oauthIdpConfigId=oidc.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == want
 
@@ -186,7 +200,7 @@ class TestOIDCProviderConfig:
         assert req.method == 'PATCH'
         mask = ['clientId', 'displayName', 'enabled', 'issuer']
         assert req.url == '{0}/oauthIdpConfigs/oidc.provider?updateMask={1}'.format(
-            USER_MGT_URL_PREFIX, ','.join(mask))
+            USER_MGT_URLS['PREFIX'], ','.join(mask))
         got = json.loads(req.body.decode())
         assert got == self.OIDC_CONFIG_REQUEST
 
@@ -201,7 +215,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'PATCH'
         assert req.url == '{0}/oauthIdpConfigs/oidc.provider?updateMask=displayName'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == {'displayName': 'oidcProviderName'}
 
@@ -217,7 +231,7 @@ class TestOIDCProviderConfig:
         assert req.method == 'PATCH'
         mask = ['displayName', 'enabled']
         assert req.url == '{0}/oauthIdpConfigs/oidc.provider?updateMask={1}'.format(
-            USER_MGT_URL_PREFIX, ','.join(mask))
+            USER_MGT_URLS['PREFIX'], ','.join(mask))
         got = json.loads(req.body.decode())
         assert got == {'displayName': None, 'enabled': False}
 
@@ -236,7 +250,7 @@ class TestOIDCProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'DELETE'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/oauthIdpConfigs/oidc.provider')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'], '/oauthIdpConfigs/oidc.provider')
 
     @pytest.mark.parametrize('arg', [None, 'foo', list(), dict(), 0, -1, 101, False])
     def test_invalid_max_results(self, user_mgt_app, arg):
@@ -259,7 +273,7 @@ class TestOIDCProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/oauthIdpConfigs?pageSize=100')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'], '/oauthIdpConfigs?pageSize=100')
 
     def test_list_multiple_pages(self, user_mgt_app):
         sample_response = json.loads(OIDC_PROVIDER_CONFIG_RESPONSE)
@@ -277,7 +291,7 @@ class TestOIDCProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}/oauthIdpConfigs?pageSize=10'.format(USER_MGT_URL_PREFIX)
+        assert req.url == '{0}/oauthIdpConfigs?pageSize=10'.format(USER_MGT_URLS['PREFIX'])
 
         # Page 2 (also the last page)
         response = {'oauthIdpConfigs': configs[2:]}
@@ -289,7 +303,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'GET'
         assert req.url == '{0}/oauthIdpConfigs?pageSize=10&pageToken=token'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
 
     def test_paged_iteration(self, user_mgt_app):
         sample_response = json.loads(OIDC_PROVIDER_CONFIG_RESPONSE)
@@ -310,7 +324,7 @@ class TestOIDCProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}/oauthIdpConfigs?pageSize=100'.format(USER_MGT_URL_PREFIX)
+        assert req.url == '{0}/oauthIdpConfigs?pageSize=100'.format(USER_MGT_URLS['PREFIX'])
 
         # Page 2 (also the last page)
         response = {'oauthIdpConfigs': configs[2:]}
@@ -322,7 +336,7 @@ class TestOIDCProviderConfig:
         req = recorder[0]
         assert req.method == 'GET'
         assert req.url == '{0}/oauthIdpConfigs?pageSize=100&pageToken=token'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
 
         with pytest.raises(StopIteration):
             next(iterator)
@@ -421,7 +435,8 @@ class TestSAMLProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/inboundSamlConfigs/saml.provider')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'],
+                                          '/inboundSamlConfigs/saml.provider')
 
     @pytest.mark.parametrize('invalid_opts', [
         {'provider_id': None}, {'provider_id': ''}, {'provider_id': 'oidc.provider'},
@@ -451,7 +466,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/inboundSamlConfigs?inboundSamlConfigId=saml.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == self.SAML_CONFIG_REQUEST
 
@@ -471,7 +486,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/inboundSamlConfigs?inboundSamlConfigId=saml.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == want
 
@@ -491,7 +506,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'POST'
         assert req.url == '{0}/inboundSamlConfigs?inboundSamlConfigId=saml.provider'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == want
 
@@ -528,7 +543,7 @@ class TestSAMLProviderConfig:
             'idpConfig.ssoUrl', 'spConfig.callbackUri', 'spConfig.spEntityId',
         ]
         assert req.url == '{0}/inboundSamlConfigs/saml.provider?updateMask={1}'.format(
-            USER_MGT_URL_PREFIX, ','.join(mask))
+            USER_MGT_URLS['PREFIX'], ','.join(mask))
         got = json.loads(req.body.decode())
         assert got == self.SAML_CONFIG_REQUEST
 
@@ -543,7 +558,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'PATCH'
         assert req.url == '{0}/inboundSamlConfigs/saml.provider?updateMask=displayName'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
         got = json.loads(req.body.decode())
         assert got == {'displayName': 'samlProviderName'}
 
@@ -559,7 +574,7 @@ class TestSAMLProviderConfig:
         assert req.method == 'PATCH'
         mask = ['displayName', 'enabled']
         assert req.url == '{0}/inboundSamlConfigs/saml.provider?updateMask={1}'.format(
-            USER_MGT_URL_PREFIX, ','.join(mask))
+            USER_MGT_URLS['PREFIX'], ','.join(mask))
         got = json.loads(req.body.decode())
         assert got == {'displayName': None, 'enabled': False}
 
@@ -578,7 +593,8 @@ class TestSAMLProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'DELETE'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/inboundSamlConfigs/saml.provider')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'],
+                                          '/inboundSamlConfigs/saml.provider')
 
     def test_config_not_found(self, user_mgt_app):
         _instrument_provider_mgt(user_mgt_app, 500, CONFIG_NOT_FOUND_RESPONSE)
@@ -613,7 +629,8 @@ class TestSAMLProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}{1}'.format(USER_MGT_URL_PREFIX, '/inboundSamlConfigs?pageSize=100')
+        assert req.url == '{0}{1}'.format(USER_MGT_URLS['PREFIX'],
+                                          '/inboundSamlConfigs?pageSize=100')
 
     def test_list_multiple_pages(self, user_mgt_app):
         sample_response = json.loads(SAML_PROVIDER_CONFIG_RESPONSE)
@@ -631,7 +648,7 @@ class TestSAMLProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}/inboundSamlConfigs?pageSize=10'.format(USER_MGT_URL_PREFIX)
+        assert req.url == '{0}/inboundSamlConfigs?pageSize=10'.format(USER_MGT_URLS['PREFIX'])
 
         # Page 2 (also the last page)
         response = {'inboundSamlConfigs': configs[2:]}
@@ -643,7 +660,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'GET'
         assert req.url == '{0}/inboundSamlConfigs?pageSize=10&pageToken=token'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
 
     def test_paged_iteration(self, user_mgt_app):
         sample_response = json.loads(SAML_PROVIDER_CONFIG_RESPONSE)
@@ -664,7 +681,7 @@ class TestSAMLProviderConfig:
         assert len(recorder) == 1
         req = recorder[0]
         assert req.method == 'GET'
-        assert req.url == '{0}/inboundSamlConfigs?pageSize=100'.format(USER_MGT_URL_PREFIX)
+        assert req.url == '{0}/inboundSamlConfigs?pageSize=100'.format(USER_MGT_URLS['PREFIX'])
 
         # Page 2 (also the last page)
         response = {'inboundSamlConfigs': configs[2:]}
@@ -676,7 +693,7 @@ class TestSAMLProviderConfig:
         req = recorder[0]
         assert req.method == 'GET'
         assert req.url == '{0}/inboundSamlConfigs?pageSize=100&pageToken=token'.format(
-            USER_MGT_URL_PREFIX)
+            USER_MGT_URLS['PREFIX'])
 
         with pytest.raises(StopIteration):
             next(iterator)

--- a/tests/test_auth_providers.py
+++ b/tests/test_auth_providers.py
@@ -49,7 +49,7 @@ INVALID_PROVIDER_IDS = [None, True, False, 1, 0, list(), tuple(), dict(), '']
 
 @pytest.fixture(scope='module', params=[{'emulated': False}, {'emulated': True}])
 def user_mgt_app(request):
-    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch = testutils.new_monkeypatch()
     if request.param['emulated']:
         monkeypatch.setenv(EMULATOR_HOST_ENV_VAR, AUTH_EMULATOR_HOST)
         monkeypatch.setitem(USER_MGT_URLS, 'ID_TOOLKIT', EMULATED_ID_TOOLKIT_URL)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -26,6 +26,7 @@ from firebase_admin import db
 from firebase_admin import exceptions
 from firebase_admin import _http_client
 from firebase_admin import _sseclient
+from firebase_admin import _utils
 from tests import testutils
 
 
@@ -730,7 +731,7 @@ class TestDatabaseInitialization:
             assert ref._client._base_url == expected_base_url
             assert ref._client.params.get('ns') == expected_namespace
             if expected_base_url.startswith('http://localhost'):
-                assert isinstance(ref._client.credential, db._EmulatorAdminCredentials)
+                assert isinstance(ref._client.credential, _utils.EmulatorAdminCredentials)
             else:
                 assert isinstance(ref._client.credential, testutils.MockGoogleCredential)
         finally:

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -148,7 +148,7 @@ def auth_app(request):
     This can be used in any scenario where the private key is required. Use user_mgt_app
     for everything else.
     """
-    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch = testutils.new_monkeypatch()
     if request.param['emulated']:
         monkeypatch.setenv(EMULATOR_HOST_ENV_VAR, AUTH_EMULATOR_HOST)
         monkeypatch.setitem(TOKEN_MGT_URLS, 'ID_TOOLKIT', EMULATED_ID_TOOLKIT_URL)
@@ -159,7 +159,7 @@ def auth_app(request):
 
 @pytest.fixture(scope='module', params=[{'emulated': False}, {'emulated': True}])
 def user_mgt_app(request):
-    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch = testutils.new_monkeypatch()
     if request.param['emulated']:
         monkeypatch.setenv(EMULATOR_HOST_ENV_VAR, AUTH_EMULATOR_HOST)
         monkeypatch.setitem(TOKEN_MGT_URLS, 'ID_TOOLKIT', EMULATED_ID_TOOLKIT_URL)

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -64,7 +64,7 @@ USER_MGT_URLS = {
 
 @pytest.fixture(scope='module', params=[{'emulated': False}, {'emulated': True}])
 def user_mgt_app(request):
-    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch = testutils.new_monkeypatch()
     if request.param['emulated']:
         monkeypatch.setenv(EMULATOR_HOST_ENV_VAR, AUTH_EMULATOR_HOST)
         monkeypatch.setitem(USER_MGT_URLS, 'ID_TOOLKIT', EMULATED_ID_TOOLKIT_URL)

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -62,7 +62,7 @@ USER_MGT_URLS = {
     'PREFIX': ID_TOOLKIT_URL + URL_PROJECT_SUFFIX,
 }
 
-@pytest.fixture(scope='module', params=[{'emulated': False}, {'emulated': True}])
+@pytest.fixture(params=[{'emulated': False}, {'emulated': True}])
 def user_mgt_app(request):
     monkeypatch = testutils.new_monkeypatch()
     if request.param['emulated']:
@@ -75,7 +75,7 @@ def user_mgt_app(request):
     firebase_admin.delete_app(app)
     monkeypatch.undo()
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def user_mgt_app_with_timeout():
     app = firebase_admin.initialize_app(
         testutils.MockCredential(),

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -16,6 +16,8 @@
 import io
 import os
 
+import pytest
+
 from google.auth import credentials
 from google.auth import transport
 from requests import adapters
@@ -56,6 +58,15 @@ def run_without_project_id(func):
             gcloud_project = env_values[idx]
             if gcloud_project:
                 os.environ[env_var] = gcloud_project
+
+
+def new_monkeypatch():
+    try:
+        return pytest.MonkeyPatch()
+    except AttributeError:
+        # Fallback for Python 3.5
+        from _pytest.monkeypatch import MonkeyPatch
+        return MonkeyPatch()
 
 
 class MockResponse(transport.Response):


### PR DESCRIPTION
### Discussion

Closes #503, by adding support for the authentication emulator via the `FIREBASE_AUTH_EMULATOR_HOST` environment variable.

Additionally, I added a change that *shouldn't* break anything, but does make the SDK work better with the emulator,  fixing the equivalent of https://github.com/firebase/firebase-admin-node/issues/1084. I ran into this while testing these changes in a project, and I feel it should be part of "supporting" the emulator, but I am open to putting it in a separate PR if it doesn't belong.

### Testing

- [x] Existing tests pass
- [x] Modified the existing tests for user management, token generation and providers to run for both emulated and non-emulated cases.

### API Changes

None, except insofar that the `FIREBASE_AUTH_EMULATOR_HOST` environment variable becomes part of the API.