### PR TITLE
fix(auth): Make auth client respect app options httpTimeout

### DIFF
--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -38,8 +38,9 @@ class Client:
 
         credential = app.credential.get_credential()
         version_header = 'Python/Admin/{0}'.format(firebase_admin.__version__)
+        timeout = app.options.get('httpTimeout', _http_client.DEFAULT_TIMEOUT_SECONDS)
         http_client = _http_client.JsonHttpClient(
-            credential=credential, headers={'X-Client-Version': version_header})
+            credential=credential, headers={'X-Client-Version': version_header}, timeout=timeout)
 
         self._tenant_id = tenant_id
         self._token_generator = _token_gen.TokenGenerator(app, http_client)


### PR DESCRIPTION
https://github.com/firebase/firebase-admin-python/issues/535

This takes care of half of the above ticket, the other half being to specify a timeout on the http transport given to google.oauth2.id_token.verify_token().

I tried to stay locally consistent and tried not to change the test setup too much.
