### PR TITLE
change: Drop Python 3.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.6, 3.7, 3.9, pypy3]
+        python: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.5, 3.6, 3.7, 3.9, pypy3]
+        python: [3.6, 3.7, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ information on using pull requests.
 
 ### Initial Setup
 
-You need Python 3.4+ to build and test the code in this repo.
+You need Python 3.6+ to build and test the code in this repo.
 
 We recommend using [pip](https://pypi.python.org/pypi/pip) for installing the necessary tools and
 project dependencies. Most recent versions of Python ship with pip. If your development environment

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Python Versions
 
-We currently support Python 3.5+. However, Python 3.5 support is deprecated,
-and the developers are strongly advised to use Python 3.6 or higher. Firebase
+We currently support Python 3.6+. Firebase
 Admin Python SDK is also tested on PyPy and
 [Google App Engine](https://cloud.google.com/appengine/) environments.
 

--- a/integration/test_project_management.py
+++ b/integration/test_project_management.py
@@ -28,8 +28,6 @@ TEST_APP_BUNDLE_ID = 'com.firebase.adminsdk-python-integration-test'
 TEST_APP_PACKAGE_NAME = 'com.firebase.adminsdk_python_integration_test'
 TEST_APP_DISPLAY_NAME_PREFIX = 'Created By Firebase AdminSDK Python Integration Testing'
 
-SHA_1_HASH_1 = '123456789a123456789a123456789a123456789a'
-SHA_1_HASH_2 = 'aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb'
 SHA_256_HASH_1 = '123456789a123456789a123456789a123456789a123456789a123456789a1234'
 SHA_256_HASH_2 = 'cafef00dba5eba11b01dfaceacc01adeda7aba5eca55e77e0b57ac1e5ca1ab1e'
 SHA_1 = project_management.SHACertificate.SHA_1
@@ -119,17 +117,13 @@ def test_android_sha_certificates(android_app):
     for cert in android_app.get_sha_certificates():
         android_app.delete_sha_certificate(cert)
 
-    # Add four different certs and assert that they have all been added successfully.
-    android_app.add_sha_certificate(project_management.SHACertificate(SHA_1_HASH_1))
-    android_app.add_sha_certificate(project_management.SHACertificate(SHA_1_HASH_2))
+    # Add two different certs and assert that they have all been added successfully.
     android_app.add_sha_certificate(project_management.SHACertificate(SHA_256_HASH_1))
     android_app.add_sha_certificate(project_management.SHACertificate(SHA_256_HASH_2))
 
     cert_list = android_app.get_sha_certificates()
 
-    sha_1_hashes = set(cert.sha_hash for cert in cert_list if cert.cert_type == SHA_1)
     sha_256_hashes = set(cert.sha_hash for cert in cert_list if cert.cert_type == SHA_256)
-    assert sha_1_hashes == set([SHA_1_HASH_1, SHA_1_HASH_2])
     assert sha_256_hashes == set([SHA_256_HASH_1, SHA_256_HASH_2])
     for cert in cert_list:
         assert cert.name

--- a/integration/test_project_management.py
+++ b/integration/test_project_management.py
@@ -189,12 +189,8 @@ def test_list_ios_apps(ios_app):
 def test_get_ios_app_config(ios_app, project_id):
     config = ios_app.get_config()
 
-    # In Python 2.7, the plistlib module works with strings, while in Python 3, it is significantly
-    # redesigned and works with bytes objects instead.
-    try:
-        plist = plistlib.loads(config.encode('utf-8'))
-    except AttributeError:  # Python 2.7 plistlib does not have the loads attribute.
-        plist = plistlib.readPlistFromString(config)  # pylint: disable=no-member
+    plist = plistlib.loads(config.encode('utf-8'))
+
     assert plist['BUNDLE_ID'] == TEST_APP_BUNDLE_ID
     assert plist['PROJECT_ID'] == project_id
     assert plist['GOOGLE_APP_ID'] == ios_app.app_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 astroid == 2.3.3
 pylint == 2.3.1
-pytest >= 3.6.0
+pytest >= 6.2.0
 pytest-cov >= 2.4.0
 pytest-localserver >= 0.4.1
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: Apache Software License',
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ from setuptools import setup
 
 
 (major, minor) = (sys.version_info.major, sys.version_info.minor)
-if major != 3 or minor < 5:
-    print('firebase_admin requires python >= 3.5', file=sys.stderr)
+if major != 3 or minor < 6:
+    print('firebase_admin requires python >= 3.6', file=sys.stderr)
     sys.exit(1)
 
 # Read in the package metadata per recommendations from:
@@ -55,13 +55,12 @@ setup(
     keywords='firebase cloud development',
     install_requires=install_requires,
     packages=['firebase_admin'],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.9',

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -16,7 +16,7 @@
 import io
 import os
 
-import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from google.auth import credentials
 from google.auth import transport
@@ -61,12 +61,7 @@ def run_without_project_id(func):
 
 
 def new_monkeypatch():
-    try:
-        return pytest.MonkeyPatch()
-    except AttributeError:
-        # Fallback for Python 3.5
-        from _pytest.monkeypatch import MonkeyPatch
-        return MonkeyPatch()
+    return MonkeyPatch()
 
 
 class MockResponse(transport.Response):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -16,7 +16,7 @@
 import io
 import os
 
-from _pytest.monkeypatch import MonkeyPatch
+import pytest
 
 from google.auth import credentials
 from google.auth import transport
@@ -61,7 +61,7 @@ def run_without_project_id(func):
 
 
 def new_monkeypatch():
-    return MonkeyPatch()
+    return pytest.MonkeyPatch()
 
 
 class MockResponse(transport.Response):


### PR DESCRIPTION
- Drop Python 3.5 support (Python 3.5 has reached EoL)
- Resolves #522 

RELEASE NOTE: Dropped support for Python 3.5. Developers should to use Python 3.6 or higher when deploying the Admin SDK.