### PR TITLE
Remove failing integration test added for nightly

### DIFF
--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -28,9 +28,6 @@ _REGISTRATION_TOKEN = ('fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKh
                        '1SsRoE')
 
 
-def test_to_trigger_nightly_email_notification():
-    assert 'a' == 'b'
-
 def test_send():
     msg = messaging.Message(
         topic='foo-bar',


### PR DESCRIPTION
- Remove the failing integration test added in #540 to test the nightly email notifications (the test runs are completed).

Note: staging to trigger integration tests. All tests should pass.
