### PR TITLE
fix(fcm): A workaround for the concurrency issues in googleapiclient

### DIFF
--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -330,9 +330,9 @@ class _MessagingService:
             'X-FIREBASE-CLIENT': 'fire-admin-python/{0}'.format(firebase_admin.__version__),
         }
         timeout = app.options.get('httpTimeout', _http_client.DEFAULT_TIMEOUT_SECONDS)
-        self._client = _http_client.JsonHttpClient(
-            credential=app.credential.get_credential(), timeout=timeout)
-        self._transport = _auth.authorized_http(app.credential.get_credential())
+        self._credential = app.credential.get_credential()
+        self._client = _http_client.JsonHttpClient(credential=self._credential, timeout=timeout)
+        self._build_transport = _auth.authorized_http
 
     @classmethod
     def encode_message(cls, message):
@@ -373,10 +373,11 @@ class _MessagingService:
 
         batch = http.BatchHttpRequest(
             callback=batch_callback, batch_uri=_MessagingService.FCM_BATCH_URL)
+        transport = self._build_transport(self._credential)
         for message in messages:
             body = json.dumps(self._message_data(message, dry_run))
             req = http.HttpRequest(
-                http=self._transport,
+                http=transport,
                 postproc=self._postproc,
                 uri=self._fcm_url,
                 method='POST',

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1813,20 +1813,23 @@ class TestBatch:
         testutils.cleanup_apps()
 
     def _instrument_batch_messaging_service(self, app=None, status=200, payload='', exc=None):
-        if not app:
-            app = firebase_admin.get_app()
+        def build_mock_transport(_):
+            if exc:
+                return _HttpMockException(exc)
 
-        fcm_service = messaging._get_messaging_service(app)
-        if exc:
-            fcm_service._transport = _HttpMockException(exc)
-        else:
             if status == 200:
                 content_type = 'multipart/mixed; boundary=boundary'
             else:
                 content_type = 'application/json'
-            fcm_service._transport = http.HttpMockSequence([
+            return http.HttpMockSequence([
                 ({'status': str(status), 'content-type': content_type}, payload),
             ])
+
+        if not app:
+            app = firebase_admin.get_app()
+
+        fcm_service = messaging._get_messaging_service(app)
+        fcm_service._build_transport = build_mock_transport
         return fcm_service
 
     def _batch_payload(self, payloads):


### PR DESCRIPTION
This is a possible solution to the problem outlined in #507. I wasn't quite able to repro the exception in the bug report, but the threading issues in `googleapiclient` are well known, and I can easily reproduce some concurrency issues by calling `send_all()` from just 3-4 parallel threads. The proposed solution is to instantiate a new transport instance for each invocation of `send_all()` (as opposed to using a shared transport across calls), and tests indeed confirm that it resolves the issues I managed to reproduce.

