### PR TITLE
correct `**kwargs` documentation in docstrings

### DIFF
--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -284,7 +284,7 @@ class Client:
         """Creates a new user account with the specified properties.
 
         Args:
-            kwargs: A series of keyword arguments (optional).
+            **kwargs: A series of keyword arguments (optional).
 
         Keyword Args:
             uid: User ID to assign to the newly created user (optional).
@@ -312,7 +312,7 @@ class Client:
 
         Args:
             uid: A user ID string.
-            kwargs: A series of keyword arguments (optional).
+            **kwargs: A series of keyword arguments (optional).
 
         Keyword Args:
             display_name: The user's display name (optional). Can be removed by explicitly passing

--- a/firebase_admin/_http_client.py
+++ b/firebase_admin/_http_client.py
@@ -104,7 +104,7 @@ class HttpClient:
         Args:
           method: HTTP method name as a string (e.g. get, post).
           url: URL of the remote endpoint.
-          kwargs: An additional set of keyword arguments to be passed into the requests API
+          **kwargs: An additional set of keyword arguments to be passed into the requests API
               (e.g. json, params, timeout).
 
         Returns:

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -341,7 +341,7 @@ class APNSPayload:
 
     Args:
         aps: A ``messaging.Aps`` instance to be included in the payload.
-        kwargs: Arbitrary keyword arguments to be included as custom fields in the payload
+        **kwargs: Arbitrary keyword arguments to be included as custom fields in the payload
             (optional).
     """
 

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -407,7 +407,7 @@ def create_user(**kwargs): # pylint: disable=differing-param-doc
     """Creates a new user account with the specified properties.
 
     Args:
-        kwargs: A series of keyword arguments (optional).
+        **kwargs: A series of keyword arguments (optional).
 
     Keyword Args:
         uid: User ID to assign to the newly created user (optional).
@@ -438,7 +438,7 @@ def update_user(uid, **kwargs): # pylint: disable=differing-param-doc
 
     Args:
         uid: A user ID string.
-        kwargs: A series of keyword arguments (optional).
+        **kwargs: A series of keyword arguments (optional).
 
     Keyword Args:
         display_name: The user's display name (optional). Can be removed by explicitly passing

--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -907,7 +907,7 @@ class _Client(_http_client.JsonHttpClient):
         Args:
           method: HTTP method name as a string (e.g. get, post).
           url: URL path of the remote endpoint. This will be appended to the server's base URL.
-          kwargs: An additional set of keyword arguments to be passed into requests API
+          **kwargs: An additional set of keyword arguments to be passed into requests API
               (e.g. json, params).
 
         Returns:


### PR DESCRIPTION
Hi :wave: 

first of all thanks for maintaining and developing this great SDK!

This PR fixes `kwargs` documentation in `Args` section of docstrings.
According to Google Python Style Guide `*args` and `**kwargs` should be documented in [`Args`](https://google.github.io/styleguide/pyguide.html#doc-function-args) section using following format:

> If a function accepts *foo (variable length argument lists) and/or **bar (arbitrary keyword arguments), they should be listed as *foo and **bar.