### PR TITLE
fix(auth): check if user disabled on check_revoked

### DIFF
--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -100,7 +100,8 @@ class Client:
 
         Args:
             id_token: A string of the encoded JWT.
-            check_revoked: Boolean, If true, checks whether the token has been revoked (optional).
+            check_revoked: Boolean, If true, checks whether the token has been revoked or
+                the user disabled (optional).
 
         Returns:
             dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -115,6 +116,8 @@ class Client:
                 this ``Client`` instance.
             CertificateFetchError: If an error occurs while fetching the public key certificates
                 required to verify the ID token.
+            UserDisabledError: If ``check_revoked`` is ``True`` and the corresponding user
+                record is disabled.
         """
         if not isinstance(check_revoked, bool):
             # guard against accidental wrong assignment.
@@ -129,7 +132,8 @@ class Client:
                     'Invalid tenant ID: {0}'.format(token_tenant_id))
 
         if check_revoked:
-            self._check_jwt_revoked(verified_claims, _token_gen.RevokedIdTokenError, 'ID token')
+            self._check_jwt_revoked_or_disabled(
+                verified_claims, _token_gen.RevokedIdTokenError, 'ID token')
         return verified_claims
 
     def revoke_refresh_tokens(self, uid):
@@ -720,7 +724,9 @@ class Client:
         """
         return self._provider_manager.list_saml_provider_configs(page_token, max_results)
 
-    def _check_jwt_revoked(self, verified_claims, exc_type, label):
+    def _check_jwt_revoked_or_disabled(self, verified_claims, exc_type, label):
         user = self.get_user(verified_claims.get('uid'))
         if verified_claims.get('iat') * 1000 < user.tokens_valid_after_timestamp:
             raise exc_type('The Firebase {0} has been revoked.'.format(label))
+        if user.disabled:
+            raise _auth_utils.UserDisabledError('The user record is disabled.')

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -726,7 +726,7 @@ class Client:
 
     def _check_jwt_revoked_or_disabled(self, verified_claims, exc_type, label):
         user = self.get_user(verified_claims.get('uid'))
-        if verified_claims.get('iat') * 1000 < user.tokens_valid_after_timestamp:
-            raise exc_type('The Firebase {0} has been revoked.'.format(label))
         if user.disabled:
             raise _auth_utils.UserDisabledError('The user record is disabled.')
+        if verified_claims.get('iat') * 1000 < user.tokens_valid_after_timestamp:
+            raise exc_type('The Firebase {0} has been revoked.'.format(label))

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -385,6 +385,15 @@ class ConfigurationNotFoundError(exceptions.NotFoundError):
         exceptions.NotFoundError.__init__(self, message, cause, http_response)
 
 
+class UserDisabledError(exceptions.FailedPreconditionError):
+    """An operation failed due to a user record being disabled."""
+
+    default_message = 'The user record is disabled'
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.FailedPreconditionError.__init__(self, message, cause, http_response)
+
+
 _CODE_TO_EXC_TYPE = {
     'CONFIGURATION_NOT_FOUND': ConfigurationNotFoundError,
     'DUPLICATE_EMAIL': EmailAlreadyExistsError,

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -385,13 +385,13 @@ class ConfigurationNotFoundError(exceptions.NotFoundError):
         exceptions.NotFoundError.__init__(self, message, cause, http_response)
 
 
-class UserDisabledError(exceptions.FailedPreconditionError):
+class UserDisabledError(exceptions.InvalidArgumentError):
     """An operation failed due to a user record being disabled."""
 
     default_message = 'The user record is disabled'
 
     def __init__(self, message, cause=None, http_response=None):
-        exceptions.FailedPreconditionError.__init__(self, message, cause, http_response)
+        exceptions.InvalidArgumentError.__init__(self, message, cause, http_response)
 
 
 _CODE_TO_EXC_TYPE = {

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -62,6 +62,7 @@ __all__ = [
     'TokenSignError',
     'UidAlreadyExistsError',
     'UnexpectedResponseError',
+    'UserDisabledError',
     'UserImportHash',
     'UserImportResult',
     'UserInfo',
@@ -135,6 +136,7 @@ SAMLProviderConfig = _auth_providers.SAMLProviderConfig
 TokenSignError = _token_gen.TokenSignError
 UidAlreadyExistsError = _auth_utils.UidAlreadyExistsError
 UnexpectedResponseError = _auth_utils.UnexpectedResponseError
+UserDisabledError = _auth_utils.UserDisabledError
 UserImportHash = _user_import.UserImportHash
 UserImportResult = _user_import.UserImportResult
 UserInfo = _user_mgt.UserInfo
@@ -198,7 +200,8 @@ def verify_id_token(id_token, app=None, check_revoked=False):
     Args:
         id_token: A string of the encoded JWT.
         app: An App instance (optional).
-        check_revoked: Boolean, If true, checks whether the token has been revoked (optional).
+        check_revoked: Boolean, If true, checks whether the token has been revoked or
+            the user disabled (optional).
 
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -210,6 +213,8 @@ def verify_id_token(id_token, app=None, check_revoked=False):
         RevokedIdTokenError: If ``check_revoked`` is ``True`` and the ID token has been revoked.
         CertificateFetchError: If an error occurs while fetching the public key certificates
             required to verify the ID token.
+        UserDisabledError: If ``check_revoked`` is ``True`` and the corresponding user
+            record is disabled.
     """
     client = _get_client(app)
     return client.verify_id_token(id_token, check_revoked=check_revoked)
@@ -246,7 +251,8 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None):
 
     Args:
         session_cookie: A session cookie string to verify.
-        check_revoked: Boolean, if true, checks whether the cookie has been revoked (optional).
+        check_revoked: Boolean, if true, checks whether the cookie has been revoked or the
+            user disabled (optional).
         app: An App instance (optional).
 
     Returns:
@@ -259,12 +265,15 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None):
         RevokedSessionCookieError: If ``check_revoked`` is ``True`` and the cookie has been revoked.
         CertificateFetchError: If an error occurs while fetching the public key certificates
             required to verify the session cookie.
+        UserDisabledError: If ``check_revoked`` is ``True`` and the corresponding user
+            record is disabled.
     """
     client = _get_client(app)
     # pylint: disable=protected-access
     verified_claims = client._token_verifier.verify_session_cookie(session_cookie)
     if check_revoked:
-        client._check_jwt_revoked(verified_claims, RevokedSessionCookieError, 'session cookie')
+        client._check_jwt_revoked_or_disabled(
+            verified_claims, RevokedSessionCookieError, 'session cookie')
     return verified_claims
 
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -569,6 +569,24 @@ def test_verify_id_token_revoked(new_user, api_key):
     claims = auth.verify_id_token(id_token, check_revoked=True)
     assert claims['iat'] * 1000 >= user.tokens_valid_after_timestamp
 
+def test_verify_id_token_disabled(new_user, api_key):
+    custom_token = auth.create_custom_token(new_user.uid)
+    id_token = _sign_in(custom_token, api_key)
+    claims = auth.verify_id_token(id_token, check_revoked=True)
+
+    # Disable the user record.
+    auth.update_user(new_user.uid, disabled=True)
+    # Verify the ID token without checking revocation. This should
+    # not raise.
+    claims = auth.verify_id_token(id_token, check_revoked=False)
+    assert claims['sub'] == new_user.uid
+
+    # Verify the ID token while checking revocation. This should
+    # raise an exception.
+    with pytest.raises(auth.UserDisabledError) as excinfo:
+        auth.verify_id_token(id_token, check_revoked=True)
+    assert str(excinfo.value) == 'The user record is disabled.'
+
 def test_verify_session_cookie_revoked(new_user, api_key):
     custom_token = auth.create_custom_token(new_user.uid)
     id_token = _sign_in(custom_token, api_key)
@@ -590,6 +608,24 @@ def test_verify_session_cookie_revoked(new_user, api_key):
     session_cookie = auth.create_session_cookie(id_token, expires_in=datetime.timedelta(days=1))
     claims = auth.verify_session_cookie(session_cookie, check_revoked=True)
     assert claims['iat'] * 1000 >= user.tokens_valid_after_timestamp
+
+def test_verify_session_cookie_disabled(new_user, api_key):
+    custom_token = auth.create_custom_token(new_user.uid)
+    id_token = _sign_in(custom_token, api_key)
+    session_cookie = auth.create_session_cookie(id_token, expires_in=datetime.timedelta(days=1))
+
+    # Disable the user record.
+    auth.update_user(new_user.uid, disabled=True)
+    # Verify the session cookie without checking revocation. This should
+    # not raise.
+    claims = auth.verify_session_cookie(session_cookie, check_revoked=False)
+    assert claims['sub'] == new_user.uid
+
+    # Verify the session cookie while checking revocation. This should
+    # raise an exception.
+    with pytest.raises(auth.UserDisabledError) as excinfo:
+        auth.verify_session_cookie(session_cookie, check_revoked=True)
+    assert str(excinfo.value) == 'The user record is disabled.'
 
 def test_import_users():
     uid, email = _random_id()

--- a/snippets/auth/index.py
+++ b/snippets/auth/index.py
@@ -150,6 +150,9 @@ def verify_token_uid_check_revoke(id_token):
     except auth.RevokedIdTokenError:
         # Token revoked, inform the user to reauthenticate or signOut().
         pass
+    except auth.UserDisabledError:
+        # Token belongs to a disabled user record.
+        pass
     except auth.InvalidIdTokenError:
         # Token is invalid
         pass
@@ -1026,6 +1029,9 @@ def verify_id_token_and_check_revoked_tenant(tenant_client, id_token):
         pass
     except auth.RevokedIdTokenError:
         # Token revoked, inform the user to reauthenticate or signOut().
+        pass
+    except auth.UserDisabledError:
+        # Token belongs to a disabled user record.
         pass
     except auth.InvalidIdTokenError:
         # Token is invalid

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -500,7 +500,7 @@ class TestVerifyIdToken:
         assert claims['uid'] == claims['sub']
 
     @pytest.mark.parametrize('id_token', valid_tokens.values(), ids=list(valid_tokens))
-    def test_disabled_user_do_not_check_disabled(
+    def test_disabled_user_do_not_check_revoked(
             self, user_mgt_app, get_user_disabled_response, id_token):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, get_user_disabled_response)
@@ -654,7 +654,7 @@ class TestVerifySessionCookie:
         assert str(excinfo.value) == 'The user record is disabled.'
 
     @pytest.mark.parametrize('cookie', valid_cookies.values(), ids=list(valid_cookies))
-    def test_disabled_user_does_not_check_disabled(
+    def test_disabled_user_does_not_check_revoked(
             self, user_mgt_app, get_user_disabled_response, cookie):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, get_user_disabled_response)

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -493,11 +493,10 @@ class TestVerifyIdToken:
         assert str(excinfo.value) == 'The user record is disabled.'
 
     @pytest.mark.parametrize('id_token', valid_tokens.values(), ids=list(valid_tokens))
-    def test_disabled_revoked_check_revoked(
+    def test_check_disabled_before_revoked(
             self, user_mgt_app, user_disabled_and_revoked, id_token):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, user_disabled_and_revoked)
-        # User disabled check should have higher priority.
         with pytest.raises(auth.UserDisabledError) as excinfo:
             auth.verify_id_token(id_token, app=user_mgt_app, check_revoked=True)
         assert str(excinfo.value) == 'The user record is disabled.'
@@ -670,11 +669,10 @@ class TestVerifySessionCookie:
         assert str(excinfo.value) == 'The user record is disabled.'
 
     @pytest.mark.parametrize('cookie', valid_cookies.values(), ids=list(valid_cookies))
-    def test_disabled_revoked_check_revoked(
+    def test_check_disabled_before_revoked(
             self, user_mgt_app, user_disabled_and_revoked, cookie):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         _instrument_user_manager(user_mgt_app, 200, user_disabled_and_revoked)
-        # User disabled check should have higher priority.
         with pytest.raises(auth.UserDisabledError) as excinfo:
             auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=True)
         assert str(excinfo.value) == 'The user record is disabled.'


### PR DESCRIPTION
When `verify_session_cookie` or `verify_id_token` is called with
`check_revoked` set to `True` we should also check if the user is
disabled.

If disabled the `UserDisabledError` is raised.
