### PR TITLE
Allows google-api-core[grpc] versions 2.X.X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest-cov >= 2.4.0
 pytest-localserver >= 0.4.1
 
 cachecontrol >= 0.12.6
-google-api-core[grpc] >= 1.22.1, < 2.0.0dev; platform.python_implementation != 'PyPy'
+google-api-core[grpc] >= 1.22.1, < 3.0.0dev; platform.python_implementation != 'PyPy'
 google-api-python-client >= 1.7.8
 google-cloud-firestore >= 2.1.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.37.1

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ long_description = ('The Firebase Admin Python SDK enables server-side (backend)
                     'to integrate Firebase into their services and applications.')
 install_requires = [
     'cachecontrol>=0.12.6',
-    'google-api-core[grpc] >= 1.22.1, < 2.0.0dev; platform.python_implementation != "PyPy"',
+    'google-api-core[grpc] >= 1.22.1, < 3.0.0dev; platform.python_implementation != "PyPy"',
     'google-api-python-client >= 1.7.8',
     'google-cloud-firestore>=2.1.0; platform.python_implementation != "PyPy"',
     'google-cloud-storage>=1.37.1',


### PR DESCRIPTION
From #575

Loosens the version ranges to allow for google-api-core[grpc] versions 2.X.X.