### PR TITLE
feat(auth): ability to delete provider in auth

### DIFF
--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -336,6 +336,7 @@ class Client:
             valid_since: An integer signifying the seconds since the epoch (optional). This field
                 is set by ``revoke_refresh_tokens`` and it is discouraged to set this field
                 directly.
+            delete_providers: The list of provider IDs to unlink, eg: 'google.com', 'password', etc. 
 
         Returns:
             UserRecord: An updated UserRecord instance for the user.

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -336,7 +336,7 @@ class Client:
             valid_since: An integer signifying the seconds since the epoch (optional). This field
                 is set by ``revoke_refresh_tokens`` and it is discouraged to set this field
                 directly.
-            delete_providers: The list of provider IDs to unlink, eg: 'google.com', 'password', etc. 
+            delete_providers: The list of provider IDs to unlink, eg: 'google.com', 'password', etc.
 
         Returns:
             UserRecord: An updated UserRecord instance for the user.

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -336,7 +336,8 @@ class Client:
             valid_since: An integer signifying the seconds since the epoch (optional). This field
                 is set by ``revoke_refresh_tokens`` and it is discouraged to set this field
                 directly.
-            delete_providers: The list of provider IDs to unlink, eg: 'google.com', 'password', etc.
+            providers_to_delete: The list of provider IDs to unlink,
+                eg: 'google.com', 'password', etc.
 
         Returns:
             UserRecord: An updated UserRecord instance for the user.

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -267,9 +267,9 @@ def validate_action_type(action_type):
     return action_type
 
 def validate_provider_ids(provider_ids, required=False):
-    if provider_ids is None:
+    if not provider_ids:
         if required:
-            raise ValueError('Invalid provider IDs. The list must be non-empty.')
+            raise ValueError('Invalid provider IDs. Provider ids should be provided')
         return []
     for provider_id in provider_ids:
         validate_provider_id(provider_id, True)

--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -266,6 +266,15 @@ def validate_action_type(action_type):
             Valid values are {1}'.format(action_type, ', '.join(VALID_EMAIL_ACTION_TYPES)))
     return action_type
 
+def validate_provider_ids(provider_ids, required=False):
+    if provider_ids is None:
+        if required:
+            raise ValueError('Invalid provider IDs. The list must be non-empty.')
+        return []
+    for provider_id in provider_ids:
+        validate_provider_id(provider_id, True)
+    return provider_ids
+
 def build_update_mask(params):
     """Creates an update mask list from the given dictionary."""
     mask = []

--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -700,7 +700,7 @@ class UserManager:
         }
 
         remove = []
-        removeProvider = []
+        remove_provider = []
         if display_name is not None:
             if display_name is DELETE_ATTRIBUTE:
                 remove.append('DISPLAY_NAME')
@@ -716,7 +716,7 @@ class UserManager:
 
         if phone_number is not None:
             if phone_number is DELETE_ATTRIBUTE:
-                removeProvider.append('phone')
+                remove_provider.append('phone')
             else:
                 payload['phoneNumber'] = _auth_utils.validate_phone(phone_number)
 
@@ -728,9 +728,9 @@ class UserManager:
             payload['customAttributes'] = _auth_utils.validate_custom_claims(json_claims)
 
         if delete_providers is not None and isinstance(delete_providers, list):
-            removeProvider += delete_providers
-        if removeProvider:
-            payload['deleteProvider'] = list(set(removeProvider))
+            remove_provider += delete_providers
+        if remove_provider:
+            payload['deleteProvider'] = list(set(remove_provider))
 
         payload = {k: v for k, v in payload.items() if v is not None}
         body, http_resp = self._make_request('post', '/accounts:update', json=payload)

--- a/firebase_admin/_user_mgt.py
+++ b/firebase_admin/_user_mgt.py
@@ -688,7 +688,7 @@ class UserManager:
 
     def update_user(self, uid, display_name=None, email=None, phone_number=None,
                     photo_url=None, password=None, disabled=None, email_verified=None,
-                    valid_since=None, custom_claims=None, delete_providers=None):
+                    valid_since=None, custom_claims=None, providers_to_delete=None):
         """Updates an existing user account with the specified properties"""
         payload = {
             'localId': _auth_utils.validate_uid(uid, required=True),
@@ -700,7 +700,7 @@ class UserManager:
         }
 
         remove = []
-        remove_provider = []
+        remove_provider = _auth_utils.validate_provider_ids(providers_to_delete)
         if display_name is not None:
             if display_name is DELETE_ATTRIBUTE:
                 remove.append('DISPLAY_NAME')
@@ -727,8 +727,6 @@ class UserManager:
                 custom_claims, dict) else custom_claims
             payload['customAttributes'] = _auth_utils.validate_custom_claims(json_claims)
 
-        if delete_providers is not None and isinstance(delete_providers, list):
-            remove_provider += delete_providers
         if remove_provider:
             payload['deleteProvider'] = list(set(remove_provider))
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -496,6 +496,14 @@ def test_disable_user(new_user_with_params):
     assert user.disabled is True
     assert len(user.provider_data) == 1
 
+def test_remove_provider(new_user_with_provider):
+    provider_ids = map(lambda x: x.provider_id, user.provider_data)
+    assert 'google.com' in provider_ids
+    user = auth.update_user(new_user_with_provider, delete_providers=['google.com'])
+    assert user.uid == new_user_with_params.uid
+    new_provider_ids = map(lambda x: x.provider_id, user.provider_data)
+    assert 'google.com' not in new_provider_ids
+
 def test_delete_user():
     user = auth.create_user()
     auth.delete_user(user.uid)

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -499,7 +499,7 @@ def test_disable_user(new_user_with_params):
 def test_remove_provider(new_user_with_provider):
     provider_ids = [provider.provider_id for provider in new_user_with_provider.provider_data]
     assert 'google.com' in provider_ids
-    user = auth.update_user(new_user_with_provider, delete_providers=['google.com'])
+    user = auth.update_user(new_user_with_provider, providers_to_delete=['google.com'])
     assert user.uid == new_user_with_params.uid
     new_provider_ids = [provider.provider_id for provider in user.provider_data]
     assert 'google.com' not in new_provider_ids

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -497,7 +497,7 @@ def test_disable_user(new_user_with_params):
     assert len(user.provider_data) == 1
 
 def test_remove_provider(new_user_with_provider):
-    provider_ids = map(lambda x: x.provider_id, user.provider_data)
+    provider_ids = map(lambda x: x.provider_id, new_user_with_provider.provider_data)
     assert 'google.com' in provider_ids
     user = auth.update_user(new_user_with_provider, delete_providers=['google.com'])
     assert user.uid == new_user_with_params.uid

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -497,11 +497,11 @@ def test_disable_user(new_user_with_params):
     assert len(user.provider_data) == 1
 
 def test_remove_provider(new_user_with_provider):
-    provider_ids = map(lambda x: x.provider_id, new_user_with_provider.provider_data)
+    provider_ids = [provider.provider_id for provider in new_user_with_provider.provider_data]
     assert 'google.com' in provider_ids
     user = auth.update_user(new_user_with_provider, delete_providers=['google.com'])
     assert user.uid == new_user_with_params.uid
-    new_provider_ids = map(lambda x: x.provider_id, user.provider_data)
+    new_provider_ids = [provider.provider_id for provider in user.provider_data]
     assert 'google.com' not in new_provider_ids
 
 def test_delete_user():

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -668,7 +668,7 @@ class TestUpdateUser:
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
         user_mgt.update_user('testuser', delete_providers=arg)
         request = json.loads(recorder[0].body.decode())
-        assert request['deleteProvider'] == arg
+        assert set(request['deleteProvider']) == set(arg)
 
     @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -670,7 +670,7 @@ class TestUpdateUser:
         request = json.loads(recorder[0].body.decode())
         assert set(request['deleteProvider']) == set(arg)
 
-    @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
+    @pytest.mark.parametrize('arg', [[], ['phone'], ['google.com'], ['google.com', 'phone']])
     def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
         user_mgt.update_user('testuser',

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -666,14 +666,14 @@ class TestUpdateUser:
     @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
-        user_mgt.update_user('testuser', delete_providers=arg)
+        user_mgt.update_user('testuser', providers_to_delete=arg)
         request = json.loads(recorder[0].body.decode())
         assert set(request['deleteProvider']) == set(arg)
 
     @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
-        user_mgt.update_user('testuser', delete_providers=arg, phone_number=auth.DELETE_ATTRIBUTE)
+        user_mgt.update_user('testuser', providers_to_delete=arg, phone_number=auth.DELETE_ATTRIBUTE)
         request = json.loads(recorder[0].body.decode())
         assert 'phone' in request['deleteProvider']
         assert len(set(request['deleteProvider'])) == len(request['deleteProvider'])

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -663,6 +663,21 @@ class TestUpdateUser:
         request = json.loads(recorder[0].body.decode())
         assert request == {'localId': 'testuser', 'validSince': int(arg)}
 
+    @pytest.mark.parametrize('arg', [[], ['phone'], ['google.com', 'phone']])
+    def test_update_user_delete_provider(self, user_mgt_app, arg):
+        user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
+        user_mgt.update_user('testuser', delete_providers=arg)
+        request = json.loads(recorder[0].body.decode())
+        assert request['deleteProvider'] == arg
+
+    @pytest.mark.parametrize('arg', [[], ['phone'], ['google.com', 'phone']])
+    def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):
+        user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
+        user_mgt.update_user('testuser', delete_providers=arg, phone_number=auth.DELETE_ATTRIBUTE)
+        request = json.loads(recorder[0].body.decode())
+        assert 'phone' in request['deleteProvider']
+        assert len(set(request['deleteProvider'])) == len(request['deleteProvider'])
+        assert set(arg) - set(request['deleteProvider']) == set()
 
 class TestSetCustomUserClaims:
 

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -663,14 +663,14 @@ class TestUpdateUser:
         request = json.loads(recorder[0].body.decode())
         assert request == {'localId': 'testuser', 'validSince': int(arg)}
 
-    @pytest.mark.parametrize('arg', [[], ['phone'], ['google.com', 'phone']])
+    @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
         user_mgt.update_user('testuser', delete_providers=arg)
         request = json.loads(recorder[0].body.decode())
         assert request['deleteProvider'] == arg
 
-    @pytest.mark.parametrize('arg', [[], ['phone'], ['google.com', 'phone']])
+    @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
         user_mgt.update_user('testuser', delete_providers=arg, phone_number=auth.DELETE_ATTRIBUTE)

--- a/tests/test_user_mgt.py
+++ b/tests/test_user_mgt.py
@@ -673,7 +673,9 @@ class TestUpdateUser:
     @pytest.mark.parametrize('arg', [['phone'], ['google.com', 'phone']])
     def test_update_user_delete_provider_and_phone(self, user_mgt_app, arg):
         user_mgt, recorder = _instrument_user_manager(user_mgt_app, 200, '{"localId":"testuser"}')
-        user_mgt.update_user('testuser', providers_to_delete=arg, phone_number=auth.DELETE_ATTRIBUTE)
+        user_mgt.update_user('testuser',
+                             providers_to_delete=arg,
+                             phone_number=auth.DELETE_ATTRIBUTE)
         request = json.loads(recorder[0].body.decode())
         assert 'phone' in request['deleteProvider']
         assert len(set(request['deleteProvider'])) == len(request['deleteProvider'])


### PR DESCRIPTION
This address #578, 
Adds the feature in the python admin sdk (which has been present in the nodejs sdk) that will allow users to delete providers (like google.com, facebook.com). Basically add delete_providers as input to update_user method in auth.