### PR TITLE
chore: Update Node.js version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: pytest
-    - name: Set up Node.js 12
+    - name: Set up Node.js 16
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
     - name: Run integration tests against emulator
       run: |
         npm install -g firebase-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         pip install -r requirements.txt
     - name: Test with pytest
       run: pytest
-    - name: Set up Node.js 10
+    - name: Set up Node.js 12
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 12.x
     - name: Run integration tests against emulator
       run: |
         npm install -g firebase-tools


### PR DESCRIPTION
- Firebase CLI dropped support for Node.js 10. Updating the Node.js version to ~12~ 16 for emulator test setup.
