### PR TITLE
Added option clockSkewInSeconds to allow setting clock_skew_in_seconds parameter for token verification

### DIFF
--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -28,7 +28,7 @@ _clock = datetime.datetime.utcnow
 
 _DEFAULT_APP_NAME = '[DEFAULT]'
 _FIREBASE_CONFIG_ENV_VAR = 'FIREBASE_CONFIG'
-_CONFIG_VALID_KEYS = ['databaseAuthVariableOverride', 'databaseURL', 'httpTimeout', 'projectId',
+_CONFIG_VALID_KEYS = ['clockSkewInSeconds', 'databaseAuthVariableOverride', 'databaseURL', 'httpTimeout', 'projectId',
                       'storageBucket']
 
 def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
@@ -48,9 +48,10 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
       credential: A credential object used to initialize the SDK (optional). If none is provided,
           Google Application Default Credentials are used.
       options: A dictionary of configuration options (optional). Supported options include
-          ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``,
-          ``serviceAccountId`` and ``httpTimeout``. If ``httpTimeout`` is not set, the SDK
-          uses a default timeout of 120 seconds.
+          ``clockSkewInSeconds``, ``databaseURL``, ``storageBucket``, ``projectId``,
+          ``databaseAuthVariableOverride``, ``serviceAccountId`` and ``httpTimeout``.
+          If ``httpTimeout`` is not set, the SDK uses a default timeout of 120 seconds.
+          If ``clockSkewInSeconds`` is not set, 0 is used when verifying a token.
       name: Name of the app (optional).
     Returns:
       App: A newly initialized instance of App.

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -393,7 +393,8 @@ class _JWTVerifier:
                     token,
                     request=request,
                     audience=self.project_id,
-                    certs_url=self.cert_url)
+                    certs_url=self.cert_url,
+                    clock_skew_in_seconds=60)
             verified_claims['uid'] = verified_claims['sub']
             return verified_claims
         except google.auth.exceptions.TransportError as error:


### PR DESCRIPTION
Adding the optional parameter clock_skew_in_seconds=60 to the call to google.oauth2.id_token.verify_token now allows for the token-issuing server's clock to be off by up to a minute without the token becoming invalid due to a 'issued-at-time' timestamp that is in the future.

### Discussion

Issue #624 

### Testing

No additional tests required.

### API Changes

n/a