### PR TITLE
password_hash obtained from Firebase Auth backend needs to be base64URL decoded before import to avoid double encoding

### DIFF
--- a/snippets/auth/index.py
+++ b/snippets/auth/index.py
@@ -571,8 +571,8 @@ def import_with_scrypt():
         auth.ImportUserRecord(
             uid='some-uid',
             email='user@example.com',
-            password_hash=b'password_hash',
-            password_salt=b'salt'
+            password_hash=base64.urlsafe_b64decode('password_hash'),
+            password_salt=base64.urlsafe_b64decode('salt')
         ),
     ]
 


### PR DESCRIPTION
This is implementing the same change as https://github.com/firebase/firebase-admin-go/pull/480 just on this python Admin SDK.

When developers export users from Firebase Auth's backend they arrive with an encoded password hash and salt. This change decodes the password hash and salt, so that it isn't double encoded upon importing these users back to Firebase.

We don't need to change other python samples (e.g. HMAC) that provide password hash and salt as they are being migrated from other auth systems that use other hashing algorithms. It is fair to assume (we won't know) that the password hash and salt from those other backends has been decoded properly.

Tests:
* If you export a user and use the import code as it is written in the public docs it will successfully import the user, but you will be unable to sign in because of the double encoding effectively changing the password
* With this decoding you can successfully import a user and sign in after now that the double encoding is removed.
