### PR TITLE
chore(firestore): Update Firestore to include COUNT queries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pytest-mock >= 3.6.1
 cachecontrol >= 0.12.6
 google-api-core[grpc] >= 1.22.1, < 3.0.0dev; platform.python_implementation != 'PyPy'
 google-api-python-client >= 1.7.8
-google-cloud-firestore >= 2.1.0; platform.python_implementation != 'PyPy'
+google-cloud-firestore >= 2.9.1; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.37.1
 pyjwt[crypto] >= 2.5.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     'cachecontrol>=0.12.6',
     'google-api-core[grpc] >= 1.22.1, < 3.0.0dev; platform.python_implementation != "PyPy"',
     'google-api-python-client >= 1.7.8',
-    'google-cloud-firestore>=2.1.0; platform.python_implementation != "PyPy"',
+    'google-cloud-firestore>=2.9.1; platform.python_implementation != "PyPy"',
     'google-cloud-storage>=1.37.1',
     'pyjwt[crypto] >= 2.5.0',
 ]


### PR DESCRIPTION
- Update `google-cloud-firestore` to `2.9.1`. This will add support for `COUNT` queries.