### PR TITLE
Add release notes to project URLs in PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     long_description=long_description,
     url=about['__url__'],
     project_urls={
+        'Release Notes': 'https://firebase.google.com/support/release-notes/admin/python',
         'Source': 'https://github.com/firebase/firebase-admin-python',
     },
     author=about['__author__'],


### PR DESCRIPTION
It's useful to be able to navigate to the release notes easily from the package index when upgrading.

"Release Notes" is a special keyword that will have the scroll icon in the project page.

A random example:

* https://pypi.org/project/streamlit/
* https://github.com/streamlit/streamlit/blob/815a3ea6fa3e7f9099b479e8365bd3a5874ddc35/lib/setup.py#L111

Looks like this:

![Screenshot 2023-03-08 at 15 36 15](https://user-images.githubusercontent.com/4542383/223844447-12578363-4705-426c-bc82-c3eb085f3134.png)
