### PR TITLE
chore: Update pypy tests to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', 'pypy3.7']
+        python: ['3.7', '3.8', '3.9', '3.10', 'pypy3.8']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- `pytest` crashes on `pypy3.7` blocking the release pipelines. The error logs are also not very helpful. It could be a transitive dependency that has dropped support for `pypy3.7` that's causing the issue.
- Upgrading `pypy` CI to `pypy3.8` to unblock the releases.