### PR TITLE
Add rate limiting exceptions

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -405,6 +405,20 @@ class UserDisabledError(exceptions.InvalidArgumentError):
         exceptions.InvalidArgumentError.__init__(self, message, cause, http_response)
 
 
+class TooManyAttemptsTryLaterError(exceptions.ResourceExhaustedError):
+    """Rate limited because of too many attempts."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.ResourceExhaustedError.__init__(self, message, cause, http_response)
+
+
+class ResetPasswordExceedLimitError(exceptions.ResourceExhaustedError):
+    """Reset password emails exceeded their limits."""
+
+    def __init__(self, message, cause=None, http_response=None):
+        exceptions.ResourceExhaustedError.__init__(self, message, cause, http_response)
+
+
 _CODE_TO_EXC_TYPE = {
     'CONFIGURATION_NOT_FOUND': ConfigurationNotFoundError,
     'DUPLICATE_EMAIL': EmailAlreadyExistsError,
@@ -417,6 +431,8 @@ _CODE_TO_EXC_TYPE = {
     'PHONE_NUMBER_EXISTS': PhoneNumberAlreadyExistsError,
     'TENANT_NOT_FOUND': TenantNotFoundError,
     'USER_NOT_FOUND': UserNotFoundError,
+    'TOO_MANY_ATTEMPTS_TRY_LATER': TooManyAttemptsTryLaterError,
+    'RESET_PASSWORD_EXCEED_LIMIT': ResetPasswordExceedLimitError,
 }
 
 


### PR DESCRIPTION
This adds two exception types to enable users to detect rate limited calls which were previously swallowed and converted into a generic `InvalidArgumentError`, making it impossible to detect rate limiting situations and pass that information through to the end user.

This is being discussed in #666.

I chose to inherit from the `ResourceExhaustedError` base exception, which seemed to make most sense.