### PR TITLE
feat: add clockSkewInSeconds

### DIFF
--- a/firebase_admin/__about__.py
+++ b/firebase_admin/__about__.py
@@ -14,7 +14,7 @@
 
 """About information (version, etc) for Firebase Admin SDK."""
 
-__version__ = '6.2.0'
+__version__ = '6.2.1'
 __title__ = 'firebase_admin'
 __author__ = 'Firebase'
 __license__ = 'Apache License 2.0'

--- a/firebase_admin/__about__.py
+++ b/firebase_admin/__about__.py
@@ -14,7 +14,7 @@
 
 """About information (version, etc) for Firebase Admin SDK."""
 
-__version__ = '6.2.1'
+__version__ = '6.2.0'
 __title__ = 'firebase_admin'
 __author__ = 'Firebase'
 __license__ = 'Apache License 2.0'

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -29,8 +29,8 @@ _clock = datetime.datetime.utcnow
 
 _DEFAULT_APP_NAME = '[DEFAULT]'
 _FIREBASE_CONFIG_ENV_VAR = 'FIREBASE_CONFIG'
-_CONFIG_VALID_KEYS = ['databaseAuthVariableOverride', 'databaseURL', 'httpTimeout', 'projectId',
-                      'storageBucket']
+_CONFIG_VALID_KEYS = ['clockSkewInSeconds', 'databaseAuthVariableOverride', 'databaseURL',
+                      'httpTimeout', 'projectId', 'storageBucket']
 
 def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
     """Initializes and returns a new App instance.
@@ -49,9 +49,11 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
       credential: A credential object used to initialize the SDK (optional). If none is provided,
           Google Application Default Credentials are used.
       options: A dictionary of configuration options (optional). Supported options include
-          ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``,
-          ``serviceAccountId`` and ``httpTimeout``. If ``httpTimeout`` is not set, the SDK
-          uses a default timeout of 120 seconds.
+          ``clockSkewInSeconds``, ``databaseURL``, ``storageBucket``, ``projectId``,
+          ``databaseAuthVariableOverride``, ``serviceAccountId`` and ``httpTimeout``. If
+          ``httpTimeout`` is not set, the SDK uses a default timeout of 120 seconds. If
+          ``clockSkewInSeconds`` is not set, 0 is used when verifying a token or cookie.
+
       name: Name of the app (optional).
     Returns:
       App: A newly initialized instance of App.

--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -29,8 +29,8 @@ _clock = datetime.datetime.utcnow
 
 _DEFAULT_APP_NAME = '[DEFAULT]'
 _FIREBASE_CONFIG_ENV_VAR = 'FIREBASE_CONFIG'
-_CONFIG_VALID_KEYS = ['clockSkewInSeconds', 'databaseAuthVariableOverride', 'databaseURL',
-                      'httpTimeout', 'projectId', 'storageBucket']
+_CONFIG_VALID_KEYS = ['databaseAuthVariableOverride', 'databaseURL', 'httpTimeout', 'projectId',
+                      'storageBucket']
 
 def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
     """Initializes and returns a new App instance.
@@ -49,10 +49,9 @@ def initialize_app(credential=None, options=None, name=_DEFAULT_APP_NAME):
       credential: A credential object used to initialize the SDK (optional). If none is provided,
           Google Application Default Credentials are used.
       options: A dictionary of configuration options (optional). Supported options include
-          ``clockSkewInSeconds``, ``databaseURL``, ``storageBucket``, ``projectId``,
-          ``databaseAuthVariableOverride``, ``serviceAccountId`` and ``httpTimeout``. If
-          ``httpTimeout`` is not set, the SDK uses a default timeout of 120 seconds. If
-          ``clockSkewInSeconds`` is not set, 0 is used when verifying a token or cookie.
+          ``databaseURL``, ``storageBucket``, ``projectId``, ``databaseAuthVariableOverride``,
+          ``serviceAccountId`` and ``httpTimeout``. If ``httpTimeout`` is not set, the SDK uses
+          a default timeout of 120 seconds.
 
       name: Name of the app (optional).
     Returns:

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -92,7 +92,7 @@ class Client:
         return self._token_generator.create_custom_token(
             uid, developer_claims, tenant_id=self.tenant_id)
 
-    def verify_id_token(self, id_token, check_revoked=False, clock_skew_in_seconds=0):
+    def verify_id_token(self, id_token, check_revoked=False, clock_skew_seconds=0):
         """Verifies the signature and data for the provided JWT.
 
         Accepts a signed token string, verifies that it is current, was issued
@@ -102,7 +102,8 @@ class Client:
             id_token: A string of the encoded JWT.
             check_revoked: Boolean, If true, checks whether the token has been revoked or
                 the user disabled (optional).
-            clock_skew_in_seconds: The number of seconds to tolerate when checking the token
+            clock_skew_seconds: The number of seconds to tolerate when checking the token.
+                Must be between 0-60. Defaults to 0.
 
         Returns:
             dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -125,7 +126,7 @@ class Client:
             raise ValueError('Illegal check_revoked argument. Argument must be of type '
                              ' bool, but given "{0}".'.format(type(check_revoked)))
 
-        verified_claims = self._token_verifier.verify_id_token(id_token, clock_skew_in_seconds)
+        verified_claims = self._token_verifier.verify_id_token(id_token, clock_skew_seconds)
         if self.tenant_id:
             token_tenant_id = verified_claims.get('firebase', {}).get('tenant')
             if self.tenant_id != token_tenant_id:

--- a/firebase_admin/_auth_client.py
+++ b/firebase_admin/_auth_client.py
@@ -92,7 +92,7 @@ class Client:
         return self._token_generator.create_custom_token(
             uid, developer_claims, tenant_id=self.tenant_id)
 
-    def verify_id_token(self, id_token, check_revoked=False):
+    def verify_id_token(self, id_token, check_revoked=False, clock_skew_in_seconds=0):
         """Verifies the signature and data for the provided JWT.
 
         Accepts a signed token string, verifies that it is current, was issued
@@ -102,6 +102,7 @@ class Client:
             id_token: A string of the encoded JWT.
             check_revoked: Boolean, If true, checks whether the token has been revoked or
                 the user disabled (optional).
+            clock_skew_in_seconds: The number of seconds to tolerate when checking the token
 
         Returns:
             dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -124,7 +125,7 @@ class Client:
             raise ValueError('Illegal check_revoked argument. Argument must be of type '
                              ' bool, but given "{0}".'.format(type(check_revoked)))
 
-        verified_claims = self._token_verifier.verify_id_token(id_token)
+        verified_claims = self._token_verifier.verify_id_token(id_token, clock_skew_in_seconds)
         if self.tenant_id:
             token_tenant_id = verified_claims.get('firebase', {}).get('tenant')
             if self.tenant_id != token_tenant_id:

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -289,11 +289,11 @@ class TokenVerifier:
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)
 
-    def verify_id_token(self, id_token):
-        return self.id_token_verifier.verify(id_token, self.request)
+    def verify_id_token(self, id_token, clock_skew_in_seconds=0):
+        return self.id_token_verifier.verify(id_token, self.request, clock_skew_in_seconds)
 
-    def verify_session_cookie(self, cookie):
-        return self.cookie_verifier.verify(cookie, self.request)
+    def verify_session_cookie(self, cookie, clock_skew_in_seconds=0):
+        return self.cookie_verifier.verify(cookie, self.request, clock_skew_in_seconds)
 
 
 class _JWTVerifier:
@@ -313,7 +313,7 @@ class _JWTVerifier:
         self._invalid_token_error = kwargs.pop('invalid_token_error')
         self._expired_token_error = kwargs.pop('expired_token_error')
 
-    def verify(self, token, request):
+    def verify(self, token, request, clock_skew_in_seconds=0):
         """Verifies the signature and data for the provided JWT."""
         token = token.encode('utf-8') if isinstance(token, str) else token
         if not isinstance(token, bytes) or not token:
@@ -393,7 +393,8 @@ class _JWTVerifier:
                     token,
                     request=request,
                     audience=self.project_id,
-                    certs_url=self.cert_url)
+                    certs_url=self.cert_url,
+                    clock_skew_in_seconds=clock_skew_in_seconds)
             verified_claims['uid'] = verified_claims['sub']
             return verified_claims
         except google.auth.exceptions.TransportError as error:

--- a/firebase_admin/_token_gen.py
+++ b/firebase_admin/_token_gen.py
@@ -289,11 +289,11 @@ class TokenVerifier:
             invalid_token_error=InvalidSessionCookieError,
             expired_token_error=ExpiredSessionCookieError)
 
-    def verify_id_token(self, id_token, clock_skew_in_seconds=0):
-        return self.id_token_verifier.verify(id_token, self.request, clock_skew_in_seconds)
+    def verify_id_token(self, id_token, clock_skew_seconds=0):
+        return self.id_token_verifier.verify(id_token, self.request, clock_skew_seconds)
 
-    def verify_session_cookie(self, cookie, clock_skew_in_seconds=0):
-        return self.cookie_verifier.verify(cookie, self.request, clock_skew_in_seconds)
+    def verify_session_cookie(self, cookie, clock_skew_seconds=0):
+        return self.cookie_verifier.verify(cookie, self.request, clock_skew_seconds)
 
 
 class _JWTVerifier:
@@ -313,7 +313,7 @@ class _JWTVerifier:
         self._invalid_token_error = kwargs.pop('invalid_token_error')
         self._expired_token_error = kwargs.pop('expired_token_error')
 
-    def verify(self, token, request, clock_skew_in_seconds=0):
+    def verify(self, token, request, clock_skew_seconds=0):
         """Verifies the signature and data for the provided JWT."""
         token = token.encode('utf-8') if isinstance(token, str) else token
         if not isinstance(token, bytes) or not token:
@@ -327,6 +327,11 @@ class _JWTVerifier:
                 'ID is required to call {0}. Initialize the app with a credentials.Certificate '
                 'or set your Firebase project ID as an app option. Alternatively set the '
                 'GOOGLE_CLOUD_PROJECT environment variable.'.format(self.operation))
+
+        if clock_skew_seconds < 0 or clock_skew_seconds > 60:
+            raise ValueError(
+                'Illegal clock_skew_seconds value: {0}. Must be between 0 and 60, inclusive.'
+                .format(clock_skew_seconds))
 
         header, payload = self._decode_unverified(token)
         issuer = payload.get('iss')
@@ -394,7 +399,7 @@ class _JWTVerifier:
                     request=request,
                     audience=self.project_id,
                     certs_url=self.cert_url,
-                    clock_skew_in_seconds=clock_skew_in_seconds)
+                    clock_skew_in_seconds=clock_skew_seconds)
             verified_claims['uid'] = verified_claims['sub']
             return verified_claims
         except google.auth.exceptions.TransportError as error:

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -256,7 +256,7 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_s
         check_revoked: Boolean, if true, checks whether the cookie has been revoked or the
             user disabled (optional).
         app: An App instance (optional).
-        clock_skew_seconds: The number of seconds to tolerate when checking the cookie
+        clock_skew_seconds: The number of seconds to tolerate when checking the cookie.
 
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -191,7 +191,7 @@ def create_custom_token(uid, developer_claims=None, app=None):
     return client.create_custom_token(uid, developer_claims)
 
 
-def verify_id_token(id_token, app=None, check_revoked=False):
+def verify_id_token(id_token, app=None, check_revoked=False, clock_skew_in_seconds=0):
     """Verifies the signature and data for the provided JWT.
 
     Accepts a signed token string, verifies that it is current, and issued
@@ -202,6 +202,7 @@ def verify_id_token(id_token, app=None, check_revoked=False):
         app: An App instance (optional).
         check_revoked: Boolean, If true, checks whether the token has been revoked or
             the user disabled (optional).
+        clock_skew_in_seconds: The number of seconds to tolerate when checking the token.
 
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -217,7 +218,8 @@ def verify_id_token(id_token, app=None, check_revoked=False):
             record is disabled.
     """
     client = _get_client(app)
-    return client.verify_id_token(id_token, check_revoked=check_revoked)
+    return client.verify_id_token(
+        id_token, check_revoked=check_revoked, clock_skew_in_seconds=clock_skew_in_seconds)
 
 
 def create_session_cookie(id_token, expires_in, app=None):
@@ -243,7 +245,7 @@ def create_session_cookie(id_token, expires_in, app=None):
     return client._token_generator.create_session_cookie(id_token, expires_in)
 
 
-def verify_session_cookie(session_cookie, check_revoked=False, app=None):
+def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_skew_in_seconds=0):
     """Verifies a Firebase session cookie.
 
     Accepts a session cookie string, verifies that it is current, and issued
@@ -254,6 +256,7 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None):
         check_revoked: Boolean, if true, checks whether the cookie has been revoked or the
             user disabled (optional).
         app: An App instance (optional).
+        clock_skew_in_seconds: The number of seconds to tolerate when checking the cookie
 
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -270,7 +273,8 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None):
     """
     client = _get_client(app)
     # pylint: disable=protected-access
-    verified_claims = client._token_verifier.verify_session_cookie(session_cookie)
+    verified_claims = client._token_verifier.verify_session_cookie(
+        session_cookie, clock_skew_in_seconds)
     if check_revoked:
         client._check_jwt_revoked_or_disabled(
             verified_claims, RevokedSessionCookieError, 'session cookie')

--- a/firebase_admin/auth.py
+++ b/firebase_admin/auth.py
@@ -191,7 +191,7 @@ def create_custom_token(uid, developer_claims=None, app=None):
     return client.create_custom_token(uid, developer_claims)
 
 
-def verify_id_token(id_token, app=None, check_revoked=False, clock_skew_in_seconds=0):
+def verify_id_token(id_token, app=None, check_revoked=False, clock_skew_seconds=0):
     """Verifies the signature and data for the provided JWT.
 
     Accepts a signed token string, verifies that it is current, and issued
@@ -202,8 +202,8 @@ def verify_id_token(id_token, app=None, check_revoked=False, clock_skew_in_secon
         app: An App instance (optional).
         check_revoked: Boolean, If true, checks whether the token has been revoked or
             the user disabled (optional).
-        clock_skew_in_seconds: The number of seconds to tolerate when checking the token.
-
+        clock_skew_seconds: The number of seconds to tolerate when checking the token.
+            Must be between 0-60. Defaults to 0.
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.
 
@@ -219,7 +219,7 @@ def verify_id_token(id_token, app=None, check_revoked=False, clock_skew_in_secon
     """
     client = _get_client(app)
     return client.verify_id_token(
-        id_token, check_revoked=check_revoked, clock_skew_in_seconds=clock_skew_in_seconds)
+        id_token, check_revoked=check_revoked, clock_skew_seconds=clock_skew_seconds)
 
 
 def create_session_cookie(id_token, expires_in, app=None):
@@ -245,7 +245,7 @@ def create_session_cookie(id_token, expires_in, app=None):
     return client._token_generator.create_session_cookie(id_token, expires_in)
 
 
-def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_skew_in_seconds=0):
+def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_skew_seconds=0):
     """Verifies a Firebase session cookie.
 
     Accepts a session cookie string, verifies that it is current, and issued
@@ -256,7 +256,7 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_s
         check_revoked: Boolean, if true, checks whether the cookie has been revoked or the
             user disabled (optional).
         app: An App instance (optional).
-        clock_skew_in_seconds: The number of seconds to tolerate when checking the cookie
+        clock_skew_seconds: The number of seconds to tolerate when checking the cookie
 
     Returns:
         dict: A dictionary of key-value pairs parsed from the decoded JWT.
@@ -274,7 +274,7 @@ def verify_session_cookie(session_cookie, check_revoked=False, app=None, clock_s
     client = _get_client(app)
     # pylint: disable=protected-access
     verified_claims = client._token_verifier.verify_session_cookie(
-        session_cookie, clock_skew_in_seconds)
+        session_cookie, clock_skew_seconds)
     if check_revoked:
         client._check_jwt_revoked_or_disabled(
             verified_claims, RevokedSessionCookieError, 'session cookie')

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -655,14 +655,15 @@ def test_verify_session_cookie_revoked(new_user, api_key):
 
 def test_verify_session_cookie_tolerance(new_user, api_key):
     expired_session_cookie = auth.create_session_cookie(
-        _sign_in(auth.create_custom_token(new_user.uid), api_key), 
+        _sign_in(auth.create_custom_token(new_user.uid), api_key),
         expires_in=datetime.timedelta(seconds=3)
     )
     time.sleep(3)
     # Verify the session cookie with a tolerance of 0 seconds. This should
     # raise an exception because the cookie is expired.
     with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
-        auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=0)
+        auth.verify_session_cookie(expired_session_cookie, check_revoked=False,
+                                   clock_skew_seconds=0)
     assert str(excinfo.value) == 'The Firebase session cookie is expired.'
 
     # Verify the session cookie with a tolerance of 2 seconds. This should
@@ -671,22 +672,24 @@ def test_verify_session_cookie_tolerance(new_user, api_key):
 
 def test_verify_session_cookie_clock_skew_seconds_range(new_user, api_key):
     expired_session_cookie = auth.create_session_cookie(
-        _sign_in(auth.create_custom_token(new_user.uid), api_key), 
+        _sign_in(auth.create_custom_token(new_user.uid), api_key),
         expires_in=datetime.timedelta(seconds=3)
     )
     # Verify the session cookie with a tolerance of 0 seconds. This should
     # raise an exception because the cookie is expired.
     with pytest.raises(ValueError) as excinfo:
-        auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=-1)
+        auth.verify_session_cookie(
+            expired_session_cookie, check_revoked=False, clock_skew_seconds=-1)
     assert str(excinfo.value) == 'clock_skew_seconds must be between 0 and 60.'
     with pytest.raises(ValueError) as excinfo:
-        auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=61)
+        auth.verify_session_cookie(
+            expired_session_cookie, check_revoked=False, clock_skew_seconds=61)
     assert str(excinfo.value) == 'clock_skew_seconds must be between 0 and 60.'
 
     # Verify the session cookie with a tolerance of 2 seconds. This should
     # not raise an exception because the cookie is within the tolerance.
     auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=2)
-    
+
 
 def test_verify_session_cookie_disabled(new_user, api_key):
     custom_token = auth.create_custom_token(new_user.uid)

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -601,11 +601,11 @@ def test_verify_id_token_revoked(new_user, api_key):
     assert claims['iat'] * 1000 >= user.tokens_valid_after_timestamp
 
 def test_verify_id_token_tolerance(new_user, api_key):
-    expired_id_token = _sign_in_with_password(new_user.email, 'password', api_key)
+    expired_id_token = _sign_in_with_password(new_user_with_params())
     time.sleep(1)
     # Verify the ID token with a tolerance of 0 seconds. This should
     # raise an exception because the token is expired.
-    with pytest.raises(auth.InvalidIdTokenError) as excinfo:
+    with pytest.raises(auth.ExpiredIdTokenError) as excinfo:
         auth.verify_id_token(expired_id_token, check_revoked=False, clock_skew_seconds=0)
     assert str(excinfo.value) == 'The Firebase ID token is expired.'
 
@@ -661,7 +661,7 @@ def test_verify_session_cookie_tolerance(new_user, api_key):
     time.sleep(3)
     # Verify the session cookie with a tolerance of 0 seconds. This should
     # raise an exception because the cookie is expired.
-    with pytest.raises(auth.InvalidSessionCookieError) as excinfo:
+    with pytest.raises(auth.ExpiredSessionCookieError) as excinfo:
         auth.verify_session_cookie(expired_session_cookie, check_revoked=False,
                                    clock_skew_seconds=0)
     assert str(excinfo.value) == 'The Firebase session cookie is expired.'

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -600,19 +600,6 @@ def test_verify_id_token_revoked(new_user, api_key):
     claims = auth.verify_id_token(id_token, check_revoked=True)
     assert claims['iat'] * 1000 >= user.tokens_valid_after_timestamp
 
-def test_verify_id_token_tolerance(new_user, api_key):
-    expired_id_token = _sign_in_with_password(new_user_with_params())
-    time.sleep(1)
-    # Verify the ID token with a tolerance of 0 seconds. This should
-    # raise an exception because the token is expired.
-    with pytest.raises(auth.ExpiredIdTokenError) as excinfo:
-        auth.verify_id_token(expired_id_token, check_revoked=False, clock_skew_seconds=0)
-    assert str(excinfo.value) == 'The Firebase ID token is expired.'
-
-    # Verify the ID token with a tolerance of 2 seconds. This should
-    # not raise an exception because the token is within the tolerance.
-    auth.verify_id_token(expired_id_token, check_revoked=False, clock_skew_seconds=2)
-
 def test_verify_id_token_disabled(new_user, api_key):
     custom_token = auth.create_custom_token(new_user.uid)
     id_token = _sign_in(custom_token, api_key)

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -160,29 +160,6 @@ def test_session_cookies(api_key):
     estimated_exp = int(time.time() + expires_in.total_seconds())
     assert abs(claims['exp'] - estimated_exp) < 5
 
-def test_session_cookies_with_tolerance(api_key):
-    dev_claims = {'premium' : True, 'subscription' : 'silver'}
-    custom_token = auth.create_custom_token('user3', dev_claims)
-    id_token = _sign_in(custom_token, api_key)
-    expires_in = datetime.timedelta(seconds=3)
-    session_cookie = auth.create_session_cookie(id_token, expires_in=expires_in)
-    time.sleep(4)
-    # expect this to fail because the cookie is expired
-    with pytest.raises(auth.ExpiredSessionCookieError):
-        auth.verify_session_cookie(session_cookie)
-
-    # expect this to succeed because we're within the tolerance
-    claims = auth.verify_session_cookie(session_cookie, check_revoked=False, clock_skew_seconds=2)
-    assert claims['uid'] == 'user3'
-    assert claims['premium'] is True
-    assert claims['subscription'] == 'silver'
-    assert claims['iss'].startswith('https://session.firebase.google.com')
-
-    with pytest.raises(ValueError):
-        auth.verify_session_cookie(session_cookie, clock_skew_seconds=-1)
-    with pytest.raises(ValueError):
-        auth.verify_session_cookie(session_cookie, clock_skew_seconds=61)
-
 def test_session_cookie_error():
     expires_in = datetime.timedelta(days=1)
     with pytest.raises(auth.InvalidIdTokenError):
@@ -639,43 +616,6 @@ def test_verify_session_cookie_revoked(new_user, api_key):
     session_cookie = auth.create_session_cookie(id_token, expires_in=datetime.timedelta(days=1))
     claims = auth.verify_session_cookie(session_cookie, check_revoked=True)
     assert claims['iat'] * 1000 >= user.tokens_valid_after_timestamp
-
-def test_verify_session_cookie_tolerance(new_user, api_key):
-    expired_session_cookie = auth.create_session_cookie(
-        _sign_in(auth.create_custom_token(new_user.uid), api_key),
-        expires_in=datetime.timedelta(seconds=3)
-    )
-    time.sleep(3)
-    # Verify the session cookie with a tolerance of 0 seconds. This should
-    # raise an exception because the cookie is expired.
-    with pytest.raises(auth.ExpiredSessionCookieError) as excinfo:
-        auth.verify_session_cookie(expired_session_cookie, check_revoked=False,
-                                   clock_skew_seconds=0)
-    assert str(excinfo.value) == 'The Firebase session cookie is expired.'
-
-    # Verify the session cookie with a tolerance of 2 seconds. This should
-    # not raise an exception because the cookie is within the tolerance.
-    auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=2)
-
-def test_verify_session_cookie_clock_skew_seconds_range(new_user, api_key):
-    expired_session_cookie = auth.create_session_cookie(
-        _sign_in(auth.create_custom_token(new_user.uid), api_key),
-        expires_in=datetime.timedelta(seconds=3)
-    )
-    # Verify the session cookie with a tolerance of 0 seconds. This should
-    # raise an exception because the cookie is expired.
-    with pytest.raises(ValueError) as excinfo:
-        auth.verify_session_cookie(
-            expired_session_cookie, check_revoked=False, clock_skew_seconds=-1)
-    assert str(excinfo.value) == 'clock_skew_seconds must be between 0 and 60.'
-    with pytest.raises(ValueError) as excinfo:
-        auth.verify_session_cookie(
-            expired_session_cookie, check_revoked=False, clock_skew_seconds=61)
-    assert str(excinfo.value) == 'clock_skew_seconds must be between 0 and 60.'
-
-    # Verify the session cookie with a tolerance of 2 seconds. This should
-    # not raise an exception because the cookie is within the tolerance.
-    auth.verify_session_cookie(expired_session_cookie, check_revoked=False, clock_skew_seconds=2)
 
 
 def test_verify_session_cookie_disabled(new_user, api_key):

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -440,6 +440,10 @@ class TestVerifyIdToken:
             'iat': int(time.time()) - 10000,
             'exp': int(time.time()) - 3600
         }),
+        'ExpiredTokenShort': _get_id_token({
+            'iat': int(time.time()) - 10000,
+            'exp': int(time.time()) - 30
+        }),
         'BadFormatToken': 'foobar'
     }
 
@@ -447,7 +451,8 @@ class TestVerifyIdToken:
         'NoKid',
         'WrongKid',
         'FutureToken',
-        'ExpiredToken'
+        'ExpiredToken',
+        'ExpiredTokenShort',
     ]
 
     def _assert_valid_token(self, id_token, app):
@@ -557,17 +562,17 @@ class TestVerifyIdToken:
     
     def test_expired_token_with_tolerance(self, user_mgt_app):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
-        id_token = self.invalid_tokens['ExpiredToken']
+        id_token = self.invalid_tokens['ExpiredTokenShort']
         if _is_emulated():
             self._assert_valid_token(id_token, user_mgt_app)
             return
         claims = auth.verify_id_token(id_token, app=user_mgt_app, 
-                                      clock_skew_in_seconds=3700)
+                                      clock_skew_seconds=60)
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
         with pytest.raises(auth.ExpiredIdTokenError) as excinfo:
             auth.verify_id_token(id_token, app=user_mgt_app, 
-                                 clock_skew_in_seconds=3500)
+                                 clock_skew_seconds=20)
 
     def test_project_id_option(self):
         app = firebase_admin.initialize_app(
@@ -633,6 +638,10 @@ class TestVerifySessionCookie:
             'iat': int(time.time()) - 10000,
             'exp': int(time.time()) - 3600
         }),
+        'ExpiredCookieShort': _get_session_cookie({
+            'iat': int(time.time()) - 10000,
+            'exp': int(time.time()) - 30
+        }),
         'BadFormatCookie': 'foobar',
         'IDToken': TEST_ID_TOKEN,
     }
@@ -641,7 +650,8 @@ class TestVerifySessionCookie:
         'NoKid',
         'WrongKid',
         'FutureCookie',
-        'ExpiredCookie'
+        'ExpiredCookie',
+        'ExpiredCookieShort',
     ]
 
     def _assert_valid_cookie(self, cookie, app, check_revoked=False):
@@ -731,17 +741,17 @@ class TestVerifySessionCookie:
 
     def test_expired_cookie_with_tolerance(self, user_mgt_app):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
-        cookie = self.invalid_cookies['ExpiredCookie']
+        cookie = self.invalid_cookies['ExpiredCookieShort']
         if _is_emulated():
             self._assert_valid_cookie(cookie, user_mgt_app)
             return
         claims = auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=False,
-                                            clock_skew_in_seconds=7200)
+                                            clock_skew_seconds=59)
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
         with pytest.raises(auth.ExpiredSessionCookieError) as excinfo:
             auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=False,
-                                       clock_skew_in_seconds=3500)
+                                       clock_skew_seconds=29)
 
     def test_project_id_option(self):
         app = firebase_admin.initialize_app(

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -559,19 +559,19 @@ class TestVerifyIdToken:
         assert 'Token expired' in str(excinfo.value)
         assert excinfo.value.cause is not None
         assert excinfo.value.http_response is None
-    
+
     def test_expired_token_with_tolerance(self, user_mgt_app):
         _overwrite_cert_request(user_mgt_app, MOCK_REQUEST)
         id_token = self.invalid_tokens['ExpiredTokenShort']
         if _is_emulated():
             self._assert_valid_token(id_token, user_mgt_app)
             return
-        claims = auth.verify_id_token(id_token, app=user_mgt_app, 
+        claims = auth.verify_id_token(id_token, app=user_mgt_app,
                                       clock_skew_seconds=60)
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
-        with pytest.raises(auth.ExpiredIdTokenError) as excinfo:
-            auth.verify_id_token(id_token, app=user_mgt_app, 
+        with pytest.raises(auth.ExpiredIdTokenError):
+            auth.verify_id_token(id_token, app=user_mgt_app,
                                  clock_skew_seconds=20)
 
     def test_project_id_option(self):
@@ -749,7 +749,7 @@ class TestVerifySessionCookie:
                                             clock_skew_seconds=59)
         assert claims['admin'] is True
         assert claims['uid'] == claims['sub']
-        with pytest.raises(auth.ExpiredSessionCookieError) as excinfo:
+        with pytest.raises(auth.ExpiredSessionCookieError):
             auth.verify_session_cookie(cookie, app=user_mgt_app, check_revoked=False,
                                        clock_skew_seconds=29)
 


### PR DESCRIPTION
### Discussion

  * See #624 and #625
  * Implements the feedback in  https://github.com/firebase/firebase-admin-python/pull/625#issuecomment-1331197410 - with the suggested API and additional unit/integration tests

### Testing

  * All unit tests pass with `pytest`. 
  * Lint passes.
  * Integration tests are pretty annoying. Not sure how to create an expired token to use, and the session cookies have a minimum expiry time of 300 seconds - the naive sleep 300 means that tests take 5 min to run. Happy to take guidance on improving that.

### API Changes

  * The API changes here were suggested/approved in the linked discussion.