### PR TITLE
fix: Correctly catch DefaultCredentialsError when looking up project_id

### DIFF
--- a/firebase_admin/__init__.py
+++ b/firebase_admin/__init__.py
@@ -18,6 +18,7 @@ import json
 import os
 import threading
 
+from google.auth.exceptions import DefaultCredentialsError
 from firebase_admin import credentials
 from firebase_admin.__about__ import __version__
 
@@ -257,7 +258,7 @@ class App:
         if not project_id:
             try:
                 project_id = self._credential.project_id
-            except AttributeError:
+            except (AttributeError, DefaultCredentialsError):
                 pass
         if not project_id:
             project_id = os.environ.get('GOOGLE_CLOUD_PROJECT',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -320,8 +320,6 @@ class TestFirebaseApp:
         def evaluate():
             app = firebase_admin.initialize_app(app_credential, name='myApp')
             app._credential._g_credential = None
-
-
             old_env_var = os.environ.get(env_var_name)
             if old_env_var:
                 del os.environ[env_var_name]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -315,6 +315,22 @@ class TestFirebaseApp:
             assert app.project_id is None
         testutils.run_without_project_id(evaluate)
 
+    def test_no_project_id_from_environment(self, app_credential):
+        env_var_name = 'GOOGLE_APPLICATION_CREDENTIALS'
+        def evaluate():
+            app = firebase_admin.initialize_app(app_credential, name='myApp')
+            app._credential._g_credential = None
+
+
+            old_env_var = os.environ.get(env_var_name)
+            if old_env_var:
+                del os.environ[env_var_name]
+            project_id = app.project_id
+            if old_env_var:
+                os.environ[env_var_name] = old_env_var
+            assert project_id is None
+        testutils.run_without_project_id(evaluate)
+
     def test_non_string_project_id(self):
         options = {'projectId': {'key': 'not a string'}}
         with pytest.raises(ValueError):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 import os
 
 import pytest
+from google.auth.exceptions import DefaultCredentialsError
 
 import firebase_admin
 from firebase_admin import credentials
@@ -316,16 +317,23 @@ class TestFirebaseApp:
         testutils.run_without_project_id(evaluate)
 
     def test_no_project_id_from_environment(self, app_credential):
-        env_var_name = 'GOOGLE_APPLICATION_CREDENTIALS'
+        default_env = 'GOOGLE_APPLICATION_CREDENTIALS'
+        gcloud_env = 'CLOUDSDK_CONFIG'
         def evaluate():
             app = firebase_admin.initialize_app(app_credential, name='myApp')
             app._credential._g_credential = None
-            old_env_var = os.environ.get(env_var_name)
-            if old_env_var:
-                del os.environ[env_var_name]
+            old_gcloud_var = os.environ.get(gcloud_env)
+            os.environ[gcloud_env] = ''
+            old_default_var = os.environ.get(default_env)
+            if old_default_var:
+                del os.environ[default_env]
+            with pytest.raises((AttributeError, DefaultCredentialsError)):
+                project_id = app._credential.project_id
             project_id = app.project_id
-            if old_env_var:
-                os.environ[env_var_name] = old_env_var
+            if old_default_var:
+                os.environ[default_env] = old_default_var
+            if old_gcloud_var:
+                os.environ[gcloud_env] = old_gcloud_var
             assert project_id is None
         testutils.run_without_project_id(evaluate)
 


### PR DESCRIPTION
`DefaultCredentialsError` was not being caught when trying to load `project_id` from credentials.

Added a catch for this error along with unit tests.

Related: #609 