### PR TITLE
fix: Make rtdb `ref.push()` only create local node when no value is passed

### DIFF
--- a/firebase_admin/_db_utils.py
+++ b/firebase_admin/_db_utils.py
@@ -1,0 +1,88 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal utilities for Firebase Realtime Database module"""
+
+import time
+import random
+import math
+
+_PUSH_CHARS = '-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz'
+
+def time_now():
+    return int(time.time()*1000)
+
+def _generate_next_push_id():
+    """Creates a unique push id generator.
+
+    Creates 20-character string identifiers with the following properties:
+        1. They're based on timestamps so that they sort after any existing ids.
+
+        2. They contain 96-bits of random data after the timestamp so that IDs won't
+        collide with other clients' IDs.
+
+        3. They sort lexicographically*(so the timestamp is converted to characters
+        that will sort properly).
+
+        4. They're monotonically increasing. Even if you generate more than one in
+        the same timestamp, the latter ones will sort after the former ones. We do
+        this by using the previous random bits but "incrementing" them by 1 (only
+        in the case of a timestamp collision).
+    """
+
+    # Timestamp of last push, used to prevent local collisions if you push twice
+    # in one ms.
+    last_push_time = 0
+
+    # We generate 96-bits of randomness which get turned into 12 characters and
+    # appended to the timestamp to prevent collisions with other clients. We
+    # store the last characters we generated because in the event of a collision,
+    # we'll use those same characters except "incremented" by one.
+    last_rand_chars_indexes = []
+
+    def next_push_id(now):
+        nonlocal last_push_time
+        nonlocal last_rand_chars_indexes
+        is_duplicate_time = now == last_push_time
+        last_push_time = now
+
+        push_id = ''
+        for _ in range(8):
+            push_id = _PUSH_CHARS[now % 64] + push_id
+            now = math.floor(now / 64)
+
+        if not is_duplicate_time:
+            last_rand_chars_indexes = []
+            for _ in range(12):
+                last_rand_chars_indexes.append(random.randrange(64))
+        else:
+            for index in range(11, -1, -1):
+                if last_rand_chars_indexes[index] == 63:
+                    last_rand_chars_indexes[index] = 0
+                else:
+                    break
+            if index != 0:
+                last_rand_chars_indexes[index] += 1
+            elif index == 0 and last_rand_chars_indexes[index] != 0:
+                last_rand_chars_indexes[index] += 1
+
+        for index in range(12):
+            push_id += _PUSH_CHARS[last_rand_chars_indexes[index]]
+
+        if len(push_id) != 20:
+            raise ValueError("push_id length should be 20")
+        return push_id
+    return next_push_id
+
+get_next_push_id = _generate_next_push_id()

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -205,6 +205,8 @@ class MessageEncoder(json.JSONEncoder):
                 'AndroidConfig.restricted_package_name', android.restricted_package_name),
             'ttl': cls.encode_ttl(android.ttl),
             'fcm_options': cls.encode_android_fcm_options(android.fcm_options),
+            'direct_boot_ok': _Validators.check_boolean(
+                'AndroidFCMOptions.direct_boot_ok', android.direct_boot_ok),
         }
         result = cls.remove_null_values(result)
         priority = result.get('priority')
@@ -223,8 +225,6 @@ class MessageEncoder(json.JSONEncoder):
         result = {
             'analytics_label': _Validators.check_analytics_label(
                 'AndroidFCMOptions.analytics_label', fcm_options.analytics_label),
-            'direct_boot_ok': _Validators.check_boolean(
-                'AndroidFCMOptions.direct_boot_ok', fcm_options.direct_boot_ok)
         }
         result = cls.remove_null_values(result)
         return result

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -161,6 +161,15 @@ class _Validators:
         return value
 
     @classmethod
+    def check_boolean(cls, label, value):
+        """Checks if the given value is boolean."""
+        if value is None:
+            return None
+        if not isinstance(value, bool):
+            raise ValueError('{0} must be a boolean.'.format(label))
+        return value
+
+    @classmethod
     def check_datetime(cls, label, value):
         """Checks if the given value is a datetime."""
         if value is None:
@@ -214,6 +223,8 @@ class MessageEncoder(json.JSONEncoder):
         result = {
             'analytics_label': _Validators.check_analytics_label(
                 'AndroidFCMOptions.analytics_label', fcm_options.analytics_label),
+            'direct_boot_ok': _Validators.check_boolean(
+                'AndroidFCMOptions.direct_boot_ok', fcm_options.direct_boot_ok)
         }
         result = cls.remove_null_values(result)
         return result

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -203,10 +203,13 @@ class AndroidFCMOptions:
     Args:
         analytics_label: contains additional options for features provided by the FCM Android SDK
             (optional).
+        direct_boot_ok: A boolean indicating whether messages will be allowed to be delivered to
+            the app while the device is in direct boot mode.
     """
 
-    def __init__(self, analytics_label=None):
+    def __init__(self, analytics_label=None, direct_boot_ok=None):
         self.analytics_label = analytics_label
+        self.direct_boot_ok = direct_boot_ok
 
 
 class WebpushConfig:

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -49,10 +49,12 @@ class AndroidConfig:
             strings. When specified, overrides any data fields set via ``Message.data``.
         notification: A ``messaging.AndroidNotification`` to be included in the message (optional).
         fcm_options: A ``messaging.AndroidFCMOptions`` to be included in the message (optional).
+        direct_boot_ok: A boolean indicating whether messages will be allowed to be delivered to
+            the app while the device is in direct boot mode (optional).
     """
 
     def __init__(self, collapse_key=None, priority=None, ttl=None, restricted_package_name=None,
-                 data=None, notification=None, fcm_options=None):
+                 data=None, notification=None, fcm_options=None, direct_boot_ok=None):
         self.collapse_key = collapse_key
         self.priority = priority
         self.ttl = ttl
@@ -60,6 +62,7 @@ class AndroidConfig:
         self.data = data
         self.notification = notification
         self.fcm_options = fcm_options
+        self.direct_boot_ok = direct_boot_ok
 
 
 class AndroidNotification:
@@ -203,13 +206,10 @@ class AndroidFCMOptions:
     Args:
         analytics_label: contains additional options for features provided by the FCM Android SDK
             (optional).
-        direct_boot_ok: A boolean indicating whether messages will be allowed to be delivered to
-            the app while the device is in direct boot mode.
     """
 
-    def __init__(self, analytics_label=None, direct_boot_ok=None):
+    def __init__(self, analytics_label=None):
         self.analytics_label = analytics_label
-        self.direct_boot_ok = direct_boot_ok
 
 
 class WebpushConfig:

--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -149,7 +149,7 @@ class TestWriteOperations:
         python = testref.parent
         ref = python.child('users').push()
         assert ref.path == '/_adminsdk/python/users/' + ref.key
-        assert ref.get() == ''
+        assert ref.get() is None
 
     def test_push_with_value(self, testref):
         python = testref.parent
@@ -157,6 +157,25 @@ class TestWriteOperations:
         ref = python.child('users').push(value)
         assert ref.path == '/_adminsdk/python/users/' + ref.key
         assert ref.get() == value
+
+    def test_push_to_local_ref(self, testref):
+        python = testref.parent
+        ref1 = python.child('games').push()
+        assert ref1.get() is None
+        ref2 = ref1.push("card")
+        assert ref2.parent.key == ref1.key
+        assert ref1.get() == {ref2.key: 'card'}
+        assert ref2.get() == 'card'
+
+    def test_push_set_local_ref(self, testref):
+        python = testref.parent
+        ref1 = python.child('games').push().child('card')
+        ref2 = ref1.push()
+        assert ref2.get() is None
+        ref3 = ref1.push('heart')
+        ref2.set('spade')
+        assert ref2.get() == 'spade'
+        assert ref1.parent.get() == {'card': {ref2.key: 'spade', ref3.key: 'heart'}}
 
     def test_set_primitive_value(self, testref):
         python = testref.parent

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -250,7 +250,8 @@ class TestFcmOptionEncoder:
                 topic='topic',
                 fcm_options=messaging.FCMOptions('message-label'),
                 android=messaging.AndroidConfig(
-                    fcm_options=messaging.AndroidFCMOptions('android-label', False)),
+                    fcm_options=messaging.AndroidFCMOptions('android-label'),
+                    direct_boot_ok=False),
                 apns=messaging.APNSConfig(fcm_options=
                                           messaging.APNSFCMOptions(
                                               analytics_label='apns-label',
@@ -260,8 +261,8 @@ class TestFcmOptionEncoder:
             {
                 'topic': 'topic',
                 'fcm_options': {'analytics_label': 'message-label'},
-                'android': {'fcm_options': {'analytics_label': 'android-label',
-                                            'direct_boot_ok': False,}},
+                'android': {'fcm_options': {'analytics_label': 'android-label'},
+                            'direct_boot_ok': False},
                 'apns': {'fcm_options': {'analytics_label': 'apns-label',
                                          'image': 'https://images.unsplash.com/photo-14944386399'
                                                   '46-1ebd1d20bf85?fit=crop&w=900&q=60'}},
@@ -330,8 +331,7 @@ class TestAndroidConfigEncoder:
     def test_invalid_direct_boot_ok(self, data):
         with pytest.raises(ValueError):
             check_encoding(messaging.Message(
-                topic='topic', android=messaging.AndroidConfig(
-                    fcm_options=messaging.AndroidFCMOptions(direct_boot_ok=data))))
+                topic='topic', android=messaging.AndroidConfig(direct_boot_ok=data)))
 
 
     def test_android_config(self):
@@ -343,7 +343,8 @@ class TestAndroidConfigEncoder:
                 priority='high',
                 ttl=123,
                 data={'k1': 'v1', 'k2': 'v2'},
-                fcm_options=messaging.AndroidFCMOptions('analytics_label_v1', True)
+                fcm_options=messaging.AndroidFCMOptions('analytics_label_v1'),
+                direct_boot_ok=True,
             )
         )
         expected = {
@@ -359,8 +360,8 @@ class TestAndroidConfigEncoder:
                 },
                 'fcm_options': {
                     'analytics_label': 'analytics_label_v1',
-                    'direct_boot_ok': True,
                 },
+                'direct_boot_ok': True,
             },
         }
         check_encoding(msg, expected)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -33,6 +33,7 @@ NON_DICT_ARGS = ['', list(), tuple(), True, False, 1, 0, {1: 'foo'}, {'foo': 1}]
 NON_OBJECT_ARGS = [list(), tuple(), dict(), 'foo', 0, 1, True, False]
 NON_LIST_ARGS = ['', tuple(), dict(), True, False, 1, 0, [1], ['foo', 1]]
 NON_UINT_ARGS = ['1.23s', list(), tuple(), dict(), -1.23]
+NON_BOOL_ARGS = ['', list(), tuple(), dict(), 1, 0, [1], ['foo', 1], {1: 'foo'}, {'foo': 1}]
 HTTP_ERROR_CODES = {
     400: exceptions.InvalidArgumentError,
     403: exceptions.PermissionDeniedError,
@@ -249,7 +250,7 @@ class TestFcmOptionEncoder:
                 topic='topic',
                 fcm_options=messaging.FCMOptions('message-label'),
                 android=messaging.AndroidConfig(
-                    fcm_options=messaging.AndroidFCMOptions('android-label')),
+                    fcm_options=messaging.AndroidFCMOptions('android-label', False)),
                 apns=messaging.APNSConfig(fcm_options=
                                           messaging.APNSFCMOptions(
                                               analytics_label='apns-label',
@@ -259,7 +260,8 @@ class TestFcmOptionEncoder:
             {
                 'topic': 'topic',
                 'fcm_options': {'analytics_label': 'message-label'},
-                'android': {'fcm_options': {'analytics_label': 'android-label'}},
+                'android': {'fcm_options': {'analytics_label': 'android-label',
+                                            'direct_boot_ok': False,}},
                 'apns': {'fcm_options': {'analytics_label': 'apns-label',
                                          'image': 'https://images.unsplash.com/photo-14944386399'
                                                   '46-1ebd1d20bf85?fit=crop&w=900&q=60'}},
@@ -317,6 +319,21 @@ class TestAndroidConfigEncoder:
             check_encoding(messaging.Message(
                 topic='topic', android=messaging.AndroidConfig(data=data)))
 
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_analytics_label(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android=messaging.AndroidConfig(
+                    fcm_options=messaging.AndroidFCMOptions(analytics_label=data))))
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_direct_boot_ok(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android=messaging.AndroidConfig(
+                    fcm_options=messaging.AndroidFCMOptions(direct_boot_ok=data))))
+
+
     def test_android_config(self):
         msg = messaging.Message(
             topic='topic',
@@ -326,7 +343,7 @@ class TestAndroidConfigEncoder:
                 priority='high',
                 ttl=123,
                 data={'k1': 'v1', 'k2': 'v2'},
-                fcm_options=messaging.AndroidFCMOptions('analytics_label_v1')
+                fcm_options=messaging.AndroidFCMOptions('analytics_label_v1', True)
             )
         )
         expected = {
@@ -342,6 +359,7 @@ class TestAndroidConfigEncoder:
                 },
                 'fcm_options': {
                     'analytics_label': 'analytics_label_v1',
+                    'direct_boot_ok': True,
                 },
             },
         }


### PR DESCRIPTION
The optional value argument in push() can be used to provide an initial value for the child node. If no value is provided, child node will have an empty string as the default value.

This behaviour is inconsistent with the client SDKs. If no value is provided, push() should return a reference that can be used elsewhere and should not create an empty node on the server.