### PR TITLE
chore: Use GitHub CLI to create release tag in `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,19 +107,13 @@ jobs:
       id: preflight
       run: ./.github/scripts/publish_preflight_check.sh
 
-    # We pull this action from a custom fork of a contributor until
-    # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
-    # this action does not support the "body" parameter.
+    # See: https://cli.github.com/manual/gh_release_create
     - name: Create release tag
-      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.preflight.outputs.version }}
-        release_name: Firebase Admin Python SDK ${{ steps.preflight.outputs.version }}
-        body: ${{ steps.preflight.outputs.changelog }}
-        draft: false
-        prerelease: false
+      run: gh release create ${{ steps.preflight.outputs.version }}
+            --title "Firebase Admin Python SDK ${{ steps.preflight.outputs.version }}"
+            --notes "${{ steps.preflight.outputs.changelog }}"
 
     - name: Publish to Pypi
       uses: pypa/gh-action-pypi-publish@v1.0.0a0


### PR DESCRIPTION
`actions/create-release` is deprecated: https://github.com/actions/create-release/issues/119

Github CLI supports creating a release: https://cli.github.com/manual/gh_release_create