### PR TITLE
chore: Update PyPi to use trusted publisher for authentication and correctly escape change log body.

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -173,7 +173,7 @@ echo "$CHANGELOG"
 # and https://github.com/github/docs/issues/21529#issue-1418590935
 FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"`
 echo "changelog<<CHANGELOGEOF" >> $GITHUB_OUTPUT
-echo "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
+echo -e "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
 echo "CHANGELOGEOF" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,11 @@ jobs:
       startsWith(github.event.pull_request.title, '[chore] Release ')
 
     runs-on: ubuntu-latest
+    permissions:
+      # Used to create a short-lived OICD token which is given to PyPi to identify this workflow job
+      # See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+      # and https://docs.pypi.org/trusted-publishers/using-a-publisher/
+      id-token: write
 
     steps:
     - name: Checkout source for publish
@@ -116,10 +121,7 @@ jobs:
             --notes "${{ steps.preflight.outputs.changelog }}"
 
     - name: Publish to Pypi
-      uses: pypa/gh-action-pypi-publish@v1.0.0a0
-      with:
-        user: firebase
-        password: ${{ secrets.PYPI_PASSWORD }}
+      uses: pypa/gh-action-pypi-publish@release/v1
 
     # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
     - name: Post to Twitter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      # Used to create a short-lived OICD token which is given to PyPi to identify this workflow job
+      # Used to create a short-lived OIDC token which is given to PyPi to identify this workflow job
       # See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
       # and https://docs.pypi.org/trusted-publishers/using-a-publisher/
       id-token: write


### PR DESCRIPTION
PyPi no longer accepts username and password authentication for publishing with 2FA enabled accounts. They have additionally made the change to require 2FA on all accounts starting January 1st 2024:
- https://blog.pypi.org/posts/2023-06-01-2fa-enforcement-for-upload/
- https://blog.pypi.org/posts/2024-01-01-2fa-enforced/

Switching our release to use PyPi's [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) method for authentication.

---
Escaped change log body to allow it to correctly show in in the release tag body.
