### PR TITLE
[chore] Release 6.4.0 Take 2

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -172,6 +172,7 @@ echo "$CHANGELOG"
 # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
 # and https://github.com/github/docs/issues/21529#issue-1418590935
 FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"`
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\''/'"'}"
 echo "changelog<<CHANGELOGEOF" >> $GITHUB_OUTPUT
 echo -e "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
 echo "CHANGELOGEOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release create ${{ steps.preflight.outputs.version }}
             --title "Firebase Admin Python SDK ${{ steps.preflight.outputs.version }}"
-            --notes "${{ steps.preflight.outputs.changelog }}"
+            --notes '${{ steps.preflight.outputs.changelog }}'
 
     - name: Publish to Pypi
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- Passing the change log within single quotes so that it does not try to interpret back ticks.
- Convert all single quotes to double quotes so that they are not interpreted.