### PR TITLE
[chore] Release 6.4.0 Take 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
       # See: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
       # and https://docs.pypi.org/trusted-publishers/using-a-publisher/
       id-token: write
+      contents: write
 
     steps:
     - name: Checkout source for publish


### PR DESCRIPTION
Issue
- Setting Github actions permissions using the `permissions` syntax sets all unlisted permissions to none.
- By adding the id-token permission needed for PyPi Trusted Publishers authentication, all other permissions at the job level were set to none

Fix
- Adding contents write permission which is needed to create a release tag.
