### PR TITLE
[chore] Rename pytest teardown methods from deprecated `teardown` to `teardown_method`

### DIFF
--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1586,7 +1586,7 @@ class TestApsAlertEncoder:
 
 class TestTimeout:
 
-    def teardown(self):
+    def teardown_method(self):
         testutils.cleanup_apps()
 
     def _instrument_service(self, url, response):

--- a/tests/test_token_gen.py
+++ b/tests/test_token_gen.py
@@ -853,5 +853,5 @@ class TestCertificateFetchTimeout:
         request.session.mount('https://', testutils.MockAdapter(MOCK_PUBLIC_CERTS, 200, recorder))
         return recorder
 
-    def teardown(self):
+    def teardown_method(self):
         testutils.cleanup_apps()


### PR DESCRIPTION
- `teardown` deprecation warning is now an error in pytest 8.0.0
   - https://github.com/pytest-dev/pytest/releases

- Renamed to suggested `teardown_method`
   - https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose