### PR TITLE
feat: add impersonated credential handler

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -17,10 +17,11 @@ import datetime
 import json
 import os
 import pathlib
+from unittest import mock
 
 import google.auth
-from google.auth import crypt
-from google.auth import exceptions
+
+from google.auth import crypt, exceptions, impersonated_credentials
 from google.oauth2 import credentials as gcredentials
 from google.oauth2 import service_account
 import pytest
@@ -191,3 +192,19 @@ class TestRefreshToken:
         access_token = credential.get_access_token()
         assert access_token.access_token == 'mock_access_token'
         assert isinstance(access_token.expiry, datetime.datetime)
+
+
+class TestImpersonatedCredentials:
+    def test_init_from_valid_credentials(self) -> None:
+        mock_tcreds = mock.Mock(spec=impersonated_credentials.Credentials)
+        credential = credentials.ImpersonatedCredentials(mock_tcreds)
+        assert credential._g_credential == mock_tcreds
+
+    def test_init_from_invalid_credentials(self) -> None:
+        with pytest.raises(ValueError):
+            credentials.ImpersonatedCredentials(None)
+
+    def test_get_credential(self) -> None:
+        mock_tcreds = mock.Mock(spec=impersonated_credentials.Credentials)
+        credential = credentials.ImpersonatedCredentials(mock_tcreds)
+        assert credential.get_credential() == mock_tcreds


### PR DESCRIPTION
Hi Firebase Team!

Currently Firebase SDK cannot handle impersonated credentials, it happens that I need to impersonalize the service account to be able to access the Firestore of another project id, which, for me, the impersonated of the service account is necessary, since in the company we have disabled the json keys for security reasons

So this PR has the solution to be used with impersonated credentials without errors.

I also leave an example in docstring how to use

