### PR TITLE
chore: Remove Python 3.7 from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.8']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.8']
 
     steps:
     - uses: actions/checkout@v4
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install dependencies
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ information on using pull requests.
 
 ### Initial Setup
 
-You need Python 3.7+ to build and test the code in this repo.
+You need Python 3.8+ to build and test the code in this repo.
 
 We recommend using [pip](https://pypi.python.org/pypi/pip) for installing the necessary tools and
 project dependencies. Most recent versions of Python ship with pip. If your development environment

--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -148,6 +148,7 @@ def test_send_each_for_multicast():
         assert response.exception is not None
         assert response.message_id is None
 
+@pytest.mark.skip(reason="Replaced with test_send_each")
 def test_send_all():
     messages = [
         messaging.Message(
@@ -179,6 +180,7 @@ def test_send_all():
     assert isinstance(response.exception, exceptions.InvalidArgumentError)
     assert response.message_id is None
 
+@pytest.mark.skip(reason="Replaced with test_send_each_500")
 def test_send_all_500():
     messages = []
     for msg_number in range(500):


### PR DESCRIPTION
- GCP auth libraries have dropped support for Python 3.7
- Our CIs and nightly builds are failing as a result
- Since Python 3.7 is deprecated in the SDK we are removing it from the workflows
- We will drop support for Python 3.7 in the next major release
- Additionally, skip integration tests on batch send APIs