### PR TITLE
chore: Skip integration test for deprecated FCM API and bump pypy CI to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.8']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9']
 
     steps:
     - uses: actions/checkout@v4

--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -197,6 +197,7 @@ def test_send_all_500():
         assert response.exception is None
         assert re.match('^projects/.*/messages/.*$', response.message_id)
 
+@pytest.mark.skip(reason="Replaced with test_send_each_for_multicast")
 def test_send_multicast():
     multicast = messaging.MulticastMessage(
         notification=messaging.Notification('Title', 'Body'),


### PR DESCRIPTION
Resolving nightly failures with the following:
* Skip integration test for deprecated FCM API
* Bump pypy CI test version to 3.9