### PR TITLE
fix(rtdb) Pass database name to `sseClient` to allow listening to events from `Reference.listen()` when using firebase emulator

### DIFF
--- a/firebase_admin/db.py
+++ b/firebase_admin/db.py
@@ -467,7 +467,7 @@ class Reference:
             session = self._client.create_listener_session()
 
         try:
-            sse = _sseclient.SSEClient(url, session)
+            sse = _sseclient.SSEClient(url, session, **{"params": self._client.params})
             return ListenerRegistration(callback, sse)
         except requests.exceptions.RequestException as error:
             raise _Client.handle_rtdb_error(error)


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
