### PR TITLE
chore: Add tests for `Reference.listen()`

### DIFF
--- a/integration/test_db.py
+++ b/integration/test_db.py
@@ -260,10 +260,10 @@ class TestListenOperations:
             ref = python.child('users').push()
             assert ref.path == '/_adminsdk/python/users/' + ref.key
             assert ref.get() == ''
-            
+
             self.wait_for(self.events, count=2)
             assert len(self.events) == 2
-            
+
             assert self.events[1].event_type == 'put'
             assert self.events[1].path == '/users/' + ref.key
             assert self.events[1].data == ''


### PR DESCRIPTION
Follow up PR for #845 with unit and integration tests.

These tests ensure that the `sseClient` is setup with the necessary parameters in both production and emulator mode.