### PR TITLE
Added minimal support for sending FCM messages in async using HTTP/2

### DIFF
--- a/firebase_admin/_utils.py
+++ b/firebase_admin/_utils.py
@@ -16,9 +16,11 @@
 
 import json
 from platform import python_version
+from typing import Callable, Optional, Union
 
 import google.auth
 import requests
+import httpx
 
 import firebase_admin
 from firebase_admin import exceptions
@@ -128,6 +130,37 @@ def handle_platform_error_from_requests(error, handle_func=None):
 
     return exc if exc else _handle_func_requests(error, message, error_dict)
 
+def handle_platform_error_from_httpx(
+    error: httpx.HTTPError,
+    handle_func: Optional[Callable[...,Optional[exceptions.FirebaseError]]] = None
+) -> exceptions.FirebaseError:
+    """Constructs a ``FirebaseError`` from the given httpx error.
+
+    This can be used to handle errors returned by Google Cloud Platform (GCP) APIs.
+
+    Args:
+        error: An error raised by the httpx module while making an HTTP call to a GCP API.
+        handle_func: A function that can be used to handle platform errors in a custom way. When
+            specified, this function will be called with three arguments. It has the same
+            signature as ```_handle_func_httpx``, but may return ``None``.
+
+    Returns:
+        FirebaseError: A ``FirebaseError`` that can be raised to the user code.
+    """
+
+    if isinstance(error, httpx.HTTPStatusError):
+        response = error.response
+        content = response.content.decode()
+        status_code = response.status_code
+        error_dict, message = _parse_platform_error(content, status_code)
+        exc = None
+        if handle_func:
+            exc = handle_func(error, message, error_dict)
+
+        return exc if exc else _handle_func_httpx(error, message, error_dict)
+    else:
+        return handle_httpx_error(error)
+
 
 def handle_operation_error(error):
     """Constructs a ``FirebaseError`` from the given operation error.
@@ -204,6 +237,60 @@ def handle_requests_error(error, message=None, code=None):
     err_type = _error_code_to_exception_type(code)
     return err_type(message=message, cause=error, http_response=error.response)
 
+def _handle_func_httpx(error: httpx.HTTPError, message, error_dict) -> exceptions.FirebaseError:
+    """Constructs a ``FirebaseError`` from the given GCP error.
+
+    Args:
+        error: An error raised by the httpx module while making an HTTP call.
+        message: A message to be included in the resulting ``FirebaseError``.
+        error_dict: Parsed GCP error response.
+
+    Returns:
+        FirebaseError: A ``FirebaseError`` that can be raised to the user code or None.
+    """
+    code = error_dict.get('status')
+    return handle_httpx_error(error, message, code)
+
+
+def handle_httpx_error(error: httpx.HTTPError, message=None, code=None) -> exceptions.FirebaseError:
+    """Constructs a ``FirebaseError`` from the given httpx error.
+
+    This method is agnostic of the remote service that produced the error, whether it is a GCP
+    service or otherwise. Therefore, this method does not attempt to parse the error response in
+    any way.
+
+    Args:
+        error: An error raised by the httpx module while making an HTTP call.
+        message: A message to be included in the resulting ``FirebaseError`` (optional). If not
+            specified the string representation of the ``error`` argument is used as the message.
+        code: A GCP error code that will be used to determine the resulting error type (optional).
+            If not specified the HTTP status code on the error response is used to determine a
+            suitable error code.
+
+    Returns:
+        FirebaseError: A ``FirebaseError`` that can be raised to the user code.
+    """
+    if isinstance(error, httpx.TimeoutException):
+        return exceptions.DeadlineExceededError(
+            message='Timed out while making an API call: {0}'.format(error),
+            cause=error)
+    if isinstance(error, httpx.ConnectError):
+        return exceptions.UnavailableError(
+            message='Failed to establish a connection: {0}'.format(error),
+            cause=error)
+    if isinstance(error, httpx.HTTPStatusError):
+        print("printing status error", error)
+        if not code:
+            code = _http_status_to_error_code(error.response.status_code)
+        if not message:
+            message = str(error)
+
+        err_type = _error_code_to_exception_type(code)
+        return err_type(message=message, cause=error, http_response=error.response)
+
+    return exceptions.UnknownError(
+        message='Unknown error while making a remote service call: {0}'.format(error),
+        cause=error)
 
 def _http_status_to_error_code(status):
     """Maps an HTTP status to a platform error code."""

--- a/firebase_admin/_utils.py
+++ b/firebase_admin/_utils.py
@@ -16,7 +16,7 @@
 
 import json
 from platform import python_version
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 import google.auth
 import requests
@@ -131,8 +131,8 @@ def handle_platform_error_from_requests(error, handle_func=None):
     return exc if exc else _handle_func_requests(error, message, error_dict)
 
 def handle_platform_error_from_httpx(
-    error: httpx.HTTPError,
-    handle_func: Optional[Callable[...,Optional[exceptions.FirebaseError]]] = None
+        error: httpx.HTTPError,
+        handle_func: Optional[Callable[..., Optional[exceptions.FirebaseError]]] = None
 ) -> exceptions.FirebaseError:
     """Constructs a ``FirebaseError`` from the given httpx error.
 
@@ -158,8 +158,7 @@ def handle_platform_error_from_httpx(
             exc = handle_func(error, message, error_dict)
 
         return exc if exc else _handle_func_httpx(error, message, error_dict)
-    else:
-        return handle_httpx_error(error)
+    return handle_httpx_error(error)
 
 
 def handle_operation_error(error):

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -492,7 +492,7 @@ class _MessagingService:
         """Sends the given messages to FCM via the FCM v1 API."""
         if not isinstance(messages, list):
             raise ValueError('messages must be a list of messaging.Message instances.')
-        if len(messages) > 1000:
+        if len(messages) > 500:
             raise ValueError('messages must not contain more than 500 elements.')
 
         def send_data(data):
@@ -521,7 +521,7 @@ class _MessagingService:
         """Sends the given messages to FCM via the FCM v1 API."""
         if not isinstance(messages, list):
             raise ValueError('messages must be a list of messaging.Message instances.')
-        if len(messages) > 1000:
+        if len(messages) > 500:
             raise ValueError('messages must not contain more than 500 elements.')
 
         async def send_data(data):

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -82,7 +82,6 @@ def api_key(request):
 #     yield loop
 #     loop.close()
 
-# 
 def pytest_collection_modifyitems(items):
     pytest_asyncio_tests = (item for item in items if is_async_test(item))
     session_scope_marker = pytest.mark.asyncio(loop_scope="session")

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -15,8 +15,9 @@
 """pytest configuration and global fixtures for integration tests."""
 import json
 
-import asyncio
+# import asyncio
 import pytest
+from pytest_asyncio import is_async_test
 
 import firebase_admin
 from firebase_admin import credentials
@@ -72,11 +73,18 @@ def api_key(request):
     with open(path) as keyfile:
         return keyfile.read().strip()
 
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create an instance of the default event loop for test session.
-    This avoids early eventloop closure.
-    """
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
+# @pytest.fixture(scope="session")
+# def event_loop():
+#     """Create an instance of the default event loop for test session.
+#     This avoids early eventloop closure.
+#     """
+#     loop = asyncio.get_event_loop_policy().new_event_loop()
+#     yield loop
+#     loop.close()
+
+# 
+def pytest_collection_modifyitems(items):
+    pytest_asyncio_tests = (item for item in items if is_async_test(item))
+    session_scope_marker = pytest.mark.asyncio(loop_scope="session")
+    for async_test in pytest_asyncio_tests:
+        async_test.add_marker(session_scope_marker, append=False)

--- a/integration/test_messaging.py
+++ b/integration/test_messaging.py
@@ -14,7 +14,6 @@
 
 """Integration tests for firebase_admin.messaging module."""
 
-import asyncio
 import re
 from datetime import datetime
 
@@ -224,7 +223,7 @@ def test_unsubscribe():
     assert resp.success_count + resp.failure_count == 1
 
 @pytest.mark.asyncio
-async def test_async_send_each():
+async def test_send_each_async():
     messages = [
         messaging.Message(
             topic='foo-bar', notification=messaging.Notification('Title', 'Body')),
@@ -234,7 +233,7 @@ async def test_async_send_each():
             token='not-a-token', notification=messaging.Notification('Title', 'Body')),
     ]
 
-    batch_response = await messaging.async_send_each(messages, dry_run=True)
+    batch_response = await messaging.send_each_async(messages, dry_run=True)
 
     assert batch_response.success_count == 2
     assert batch_response.failure_count == 1
@@ -257,7 +256,7 @@ async def test_async_send_each():
 
 
 # @pytest.mark.asyncio
-# async def test_async_send_each_error():
+# async def test_send_each_async_error():
 #     messages = [
 #         messaging.Message(
 #             topic='foo-bar', notification=messaging.Notification('Title', 'Body')),
@@ -267,7 +266,7 @@ async def test_async_send_each():
 #             token='not-a-token', notification=messaging.Notification('Title', 'Body')),
 #     ]
 
-#     batch_response = await messaging.async_send_each(messages, dry_run=True)
+#     batch_response = await messaging.send_each_async(messages, dry_run=True)
 
 #     assert batch_response.success_count == 2
 #     assert batch_response.failure_count == 1
@@ -289,13 +288,13 @@ async def test_async_send_each():
 #     assert response.message_id is None
 
 @pytest.mark.asyncio
-async def test_async_send_each_500():
+async def test_send_each_async_500():
     messages = []
     for msg_number in range(500):
         topic = 'foo-bar-{0}'.format(msg_number % 10)
         messages.append(messaging.Message(topic=topic))
 
-    batch_response = await messaging.async_send_each(messages, dry_run=True)
+    batch_response = await messaging.send_each_async(messages, dry_run=True)
 
     assert batch_response.success_count == 500
     assert batch_response.failure_count == 0
@@ -304,4 +303,3 @@ async def test_async_send_each_500():
         assert response.success is True
         assert response.exception is None
         assert re.match('^projects/.*/messages/.*$', response.message_id)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ google-api-python-client >= 1.7.8
 google-cloud-firestore >= 2.19.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.37.1
 pyjwt[crypto] >= 2.5.0
-httpx == 0.28.1
+httpx[http2] == 0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest-cov >= 2.4.0
 pytest-localserver >= 0.4.1
 pytest-asyncio >= 0.16.0
 pytest-mock >= 3.6.1
+respx == 0.22.0
 
 cachecontrol >= 0.12.14
 google-api-core[grpc] >= 1.22.1, < 3.0.0dev; platform.python_implementation != 'PyPy'
@@ -12,3 +13,4 @@ google-api-python-client >= 1.7.8
 google-cloud-firestore >= 2.19.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 1.37.1
 pyjwt[crypto] >= 2.5.0
+httpx == 0.28.1

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'google-cloud-firestore>=2.19.0; platform.python_implementation != "PyPy"',
     'google-cloud-storage>=1.37.1',
     'pyjwt[crypto] >= 2.5.0',
+    'httpx[http2] == 0.28.1',
 ]
 
 setup(

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -14,12 +14,15 @@
 
 """Test cases for the firebase_admin.messaging module."""
 import datetime
+from itertools import chain, repeat
 import json
 import numbers
+import respx
 
 from googleapiclient import http
 from googleapiclient import _helpers
 import pytest
+import httpx
 
 import firebase_admin
 from firebase_admin import exceptions
@@ -1923,6 +1926,209 @@ class TestSendEach(TestBatch):
         assert [r.message_id for r in batch_response.responses] == ['message-id1', 'message-id2']
         assert all([r.success for r in batch_response.responses])
         assert not any([r.exception for r in batch_response.responses])
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_send_each(self):
+        responses = [
+            respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id1'}),
+            respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id2'}),
+            respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id3'}),
+        ]
+        msg1 = messaging.Message(topic='foo1')
+        msg2 = messaging.Message(topic='foo2')
+        msg3 = messaging.Message(topic='foo3')
+        route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+        
+        batch_response = await messaging.async_send_each([msg1, msg2, msg3], dry_run=True)
+        
+        # try:
+        #     batch_response = await messaging.async_send_each([msg1, msg2], dry_run=True)
+        # except Exception as error:
+        #     if isinstance(error.cause.__cause__, StopIteration):
+        #         raise Exception('Received more requests than mocks')
+        
+        assert batch_response.success_count == 3
+        assert batch_response.failure_count == 0
+        assert len(batch_response.responses) == 3
+        assert [r.message_id for r in batch_response.responses] == ['message-id1', 'message-id2', 'message-id3']
+        assert all([r.success for r in batch_response.responses])
+        assert not any([r.exception for r in batch_response.responses])
+
+        assert route.call_count == 3
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_send_each_error_401_fail_auth_retry(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'UNAUTHENTICATED',
+                'message': 'test unauthenticated error',
+                'details': [
+                    {
+                        '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode': 'SOME_UNKNOWN_CODE',
+                    },
+                ],
+            }
+        })
+        
+        responses = repeat(respx.MockResponse(401, http_version='HTTP/2', content=payload))
+        
+        msg1 = messaging.Message(topic='foo1')
+        route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+        batch_response = await messaging.async_send_each([msg1], dry_run=True)
+        
+        assert route.call_count == 2
+        assert batch_response.success_count == 0
+        assert batch_response.failure_count == 1
+        assert len(batch_response.responses) == 1
+        exception = batch_response.responses[0].exception
+        assert isinstance(exception, exceptions.UnauthenticatedError)
+        
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_send_each_error_401_pass_on_auth_retry(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'UNAUTHENTICATED',
+                'message': 'test unauthenticated error',
+                'details': [
+                    {
+                        '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode': 'SOME_UNKNOWN_CODE',
+                    },
+                ],
+            }
+        })
+        responses = [
+            respx.MockResponse(401, http_version='HTTP/2', content=payload),
+            respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id1'}),
+        ]
+        
+        msg1 = messaging.Message(topic='foo1')
+        route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+        batch_response = await messaging.async_send_each([msg1], dry_run=True)
+        
+        assert route.call_count == 2
+        assert batch_response.success_count == 1
+        assert batch_response.failure_count == 0
+        assert len(batch_response.responses) == 1
+        assert [r.message_id for r in batch_response.responses] == ['message-id1']
+        assert all([r.success for r in batch_response.responses])
+        assert not any([r.exception for r in batch_response.responses])
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_send_each_error_500_fail_retry_config(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'INTERNAL',
+                'message': 'test INTERNAL error',
+                'details': [
+                    {
+                        '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode': 'SOME_UNKNOWN_CODE',
+                    },
+                ],
+            }
+        })
+        
+        responses = repeat(respx.MockResponse(500, http_version='HTTP/2', content=payload))
+        
+        msg1 = messaging.Message(topic='foo1')
+        route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+        batch_response = await messaging.async_send_each([msg1], dry_run=True)
+        
+        assert route.call_count == 5
+        assert batch_response.success_count == 0
+        assert batch_response.failure_count == 1
+        assert len(batch_response.responses) == 1
+        exception = batch_response.responses[0].exception
+        assert isinstance(exception, exceptions.InternalError)
+
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_send_each_error_500_pass_on_retry_config(self):
+        payload = json.dumps({
+            'error': {
+                'status': 'INTERNAL',
+                'message': 'test INTERNAL error',
+                'details': [
+                    {
+                        '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode': 'SOME_UNKNOWN_CODE',
+                    },
+                ],
+            }
+        })
+        responses = chain(
+            [
+                respx.MockResponse(500, http_version='HTTP/2', content=payload),
+                respx.MockResponse(500, http_version='HTTP/2', content=payload),
+                respx.MockResponse(500, http_version='HTTP/2', content=payload),
+                respx.MockResponse(500, http_version='HTTP/2', content=payload),
+                respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id1'}),
+            ],
+        )
+        
+        msg1 = messaging.Message(topic='foo1')
+        route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+        batch_response = await messaging.async_send_each([msg1], dry_run=True)
+        
+        assert route.call_count == 5
+        assert batch_response.success_count == 1
+        assert batch_response.failure_count == 0
+        assert len(batch_response.responses) == 1
+        assert [r.message_id for r in batch_response.responses] == ['message-id1']
+        assert all([r.success for r in batch_response.responses])
+        assert not any([r.exception for r in batch_response.responses])
+
+    # @respx.mock
+    # @pytest.mark.asyncio
+    # async def test_async_send_each_error_request(self):
+    #     payload = json.dumps({
+    #         'error': {
+    #             'status': 'INTERNAL',
+    #             'message': 'test INTERNAL error',
+    #             'details': [
+    #                 {
+    #                     '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+    #                     'errorCode': 'SOME_UNKNOWN_CODE',
+    #                 },
+    #             ],
+    #         }
+    #     })
+    #     responses = chain(
+    #         [
+    #             httpx.ConnectError("Test request error", request=httpx.Request('POST', 'URL'))
+    #             # respx.MockResponse(500, http_version='HTTP/2', content=payload),
+    #         ],
+    #         # repeat(respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id1'})),
+    #         # respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id3'}),
+    #     )
+        
+    #     # responses = repeat(respx.MockResponse(500, http_version='HTTP/2', content=payload))
+        
+    #     msg1 = messaging.Message(topic='foo1')
+    #     route = respx.request('POST', 'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send').mock(side_effect=responses)
+    #     batch_response = await messaging.async_send_each([msg1], dry_run=True)
+        
+    #     assert route.call_count == 1
+    #     assert batch_response.success_count == 0
+    #     assert batch_response.failure_count == 1
+    #     assert len(batch_response.responses) == 1
+    #     exception = batch_response.responses[0].exception
+    #     assert isinstance(exception, exceptions.UnavailableError)
+        
+    #     # assert route.call_count == 4
+    #     # assert batch_response.success_count == 1
+    #     # assert batch_response.failure_count == 0
+    #     # assert len(batch_response.responses) == 1
+    #     # assert [r.message_id for r in batch_response.responses] == ['message-id1']
+    #     # assert all([r.success for r in batch_response.responses])
+    #     # assert not any([r.exception for r in batch_response.responses])
 
     @pytest.mark.parametrize('status', HTTP_ERROR_CODES)
     def test_send_each_detailed_error(self, status):


### PR DESCRIPTION
Adds basic logic for sending FCM messages in async using HTTP/2

This initial PR covers:
- Exporting async method `send_each_async()`
- Handling refreshing of google.auth credentials and retrying refresh on 401 errors
- Basic retry logic for 503 and 500 errors (no backoff)
- Status and request error mapping to FirebaseErrors
- Simple unit and integration tests