### PR TITLE
Refactored retry config into `_retry.py` and added support for exponential backoff and `Retry-After` header

### DIFF
--- a/firebase_admin/_retry.py
+++ b/firebase_admin/_retry.py
@@ -1,0 +1,246 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal retry logic module
+
+This module provides utilities for adding retry logic to HTTPX requests
+"""
+
+from __future__ import annotations
+import copy
+import email.utils
+import random
+import re
+import time
+from types import CoroutineType
+from typing import Any, Callable, List, Optional, Tuple
+import logging
+import asyncio
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class HttpxRetry:
+    """HTTPX based retry config"""
+    # TODO: Decide
+    # urllib3.Retry ignores the status_forcelist and only respects Retry-After header
+    # for 413, 429 and 503 errors.
+    # Should we do the same?
+    # Default status codes to be used for ``status_forcelist``
+    RETRY_AFTER_STATUS_CODES = frozenset([413, 429, 503])
+
+    #: Default maximum backoff time.
+    DEFAULT_BACKOFF_MAX = 120
+
+    def __init__(
+            self,
+            status: int = 10,
+            status_forcelist: Optional[List[int]] = None,
+            backoff_factor: float = 0,
+            backoff_max: float = DEFAULT_BACKOFF_MAX,
+            raise_on_status: bool = False,
+            backoff_jitter: float = 0,
+            history: Optional[List[Tuple[
+                httpx.Request,
+                Optional[httpx.Response],
+                Optional[Exception]
+            ]]] = None,
+            respect_retry_after_header: bool = False,
+    ) -> None:
+        self.status = status
+        self.status_forcelist = status_forcelist
+        self.backoff_factor = backoff_factor
+        self.backoff_max = backoff_max
+        self.raise_on_status = raise_on_status
+        self.backoff_jitter = backoff_jitter
+        if history:
+            self.history = history
+        else:
+            self.history = []
+        self.respect_retry_after_header = respect_retry_after_header
+
+    def copy(self) -> HttpxRetry:
+        """Creates a deep copy of this instance."""
+        return copy.deepcopy(self)
+
+    def is_retryable_response(self, response: httpx.Response) -> bool:
+        """Determine if a response implies that the request should be retried if possible."""
+        if self.status_forcelist and response.status_code in self.status_forcelist:
+            return True
+
+        has_retry_after = bool(response.headers.get("Retry-After"))
+        if (
+                self.respect_retry_after_header
+                and has_retry_after
+                and response.status_code in self.RETRY_AFTER_STATUS_CODES
+        ):
+            return True
+
+        return False
+
+    # Placeholder for exception retrying
+    def is_retryable_error(self, error: Exception):
+        """Determine if the error implies that the request should be retired if possible."""
+        logger.debug(error)
+        return False
+
+    def is_exhausted(self) -> bool:
+        """Determine if there are anymore more retires."""
+        # status count is negative
+        return self.status < 0
+
+    # Identical implementation of `urllib3.Retry.parse_retry_after()`
+    def _parse_retry_after(self, retry_after_header: str) -> float | None:
+        """Parses Retry-After string into a float with unit seconds."""
+        seconds: float
+        # Whitespace: https://tools.ietf.org/html/rfc7230#section-3.2.4
+        if re.match(r"^\s*[0-9]+\s*$", retry_after_header):
+            seconds = int(retry_after_header)
+        else:
+            retry_date_tuple = email.utils.parsedate_tz(retry_after_header)
+            if retry_date_tuple is None:
+                # TODO: Verify if this is the appropriate way to handle this.
+                raise httpx.RemoteProtocolError(f"Invalid Retry-After header: {retry_after_header}")
+
+            retry_date = email.utils.mktime_tz(retry_date_tuple)
+            seconds = retry_date - time.time()
+
+        seconds = max(seconds, 0)
+
+        return seconds
+
+    def get_retry_after(self, response: httpx.Response) -> float | None:
+        """Determine the Retry-After time needed before sending the next request."""
+        retry_after_header = response.headers.get('Retry_After', None)
+        if retry_after_header:
+            # Convert retry header to a float in seconds
+            return self._parse_retry_after(retry_after_header)
+        return None
+
+    def get_backoff_time(self):
+        """Determine the backoff time needed before sending the next request."""
+        # request_count is the number of previous request attempts
+        request_count = len(self.history)
+        backoff = self.backoff_factor * (2 ** (request_count-1))
+        if self.backoff_jitter:
+            backoff += random.random() * self.backoff_jitter
+        return float(max(0, min(self.backoff_max, backoff)))
+
+    async def sleep_for_backoff(self) -> None:
+        """Determine and wait the backoff time needed before sending the next request."""
+        backoff = self.get_backoff_time()
+        logger.debug('Sleeping for %f seconds following failed request', backoff)
+        await asyncio.sleep(backoff)
+
+    async def sleep(self, response: httpx.Response) -> None:
+        """Determine and wait the time needed before sending the next request."""
+        if self.respect_retry_after_header:
+            retry_after = self.get_retry_after(response)
+            if retry_after:
+                await asyncio.sleep(retry_after)
+                return
+        await self.sleep_for_backoff()
+
+    def increment(
+            self,
+            request: httpx.Request,
+            response: Optional[httpx.Response] = None,
+            error: Optional[Exception] = None
+    ) -> None:
+        """Update the retry state based on request attempt."""
+        if response and self.is_retryable_response(response):
+            self.status -= 1
+        self.history.append((request, response, error))
+
+
+# TODO: Remove comments
+# Note - This implementation currently covers:
+#   - basic retires for pre-defined status errors
+#   - applying retry backoff and backoff jitter
+#   - ability to respect a response's retry-after header
+class HttpxRetryTransport(httpx.AsyncBaseTransport):
+    """HTTPX transport with retry logic."""
+
+    # DEFAULT_RETRY = HttpxRetry(
+    #     connect=1, read=1, status=4, status_forcelist=[500, 503],
+    #     raise_on_status=False, backoff_factor=0.5, allowed_methods=None
+    # )
+    DEFAULT_RETRY = HttpxRetry(status=4, status_forcelist=[500, 503], backoff_factor=0.5)
+
+    # We could also support passing kwargs here
+    def __init__(self, retry: HttpxRetry = DEFAULT_RETRY, **kwargs) -> None:
+        self._retry = retry
+
+        transport_kwargs = kwargs.copy()
+        transport_kwargs.update({'retries': 0, 'http2': True})
+        # We should use a full AsyncHTTPTransport under the hood since that is
+        # fully implemented. We could consider making this class extend a
+        # AsyncHTTPTransport instead and use the parent class's methods to handle
+        # requests. We sould also ensure that that transport's internal retry is
+        # not enabled.
+        self._wrapped_transport = httpx.AsyncHTTPTransport(**transport_kwargs)
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return await self._dispatch_with_retry(
+            request, self._wrapped_transport.handle_async_request)
+
+    # Two types of retries
+    # - Status code (500s, redirect)
+    # - Error code (read, connect, other)
+    async def _dispatch_with_retry(
+            self,
+            request: httpx.Request,
+            dispatch_method: Callable[[httpx.Request], CoroutineType[Any, Any, httpx.Response]]
+    ) -> httpx.Response:
+        """Sends a request with retry logic using a provided dispatch method."""
+        # This request config is used across all requests that use this transport and therefore
+        # needs to be copied to be used for just this request ans it's retries.
+        retry = self._retry.copy()
+        # First request
+        response, error = None, None
+
+        while not retry.is_exhausted():
+
+            # First retry
+            if response:
+                await retry.sleep(response)
+
+            # Need to reset here so only last attempt's error or response is saved.
+            response, error = None, None
+
+            try:
+                logger.debug('Sending request in _dispatch_with_retry(): %r', request)
+                response = await dispatch_method(request)
+                logger.debug('Received response: %r', response)
+            except httpx.HTTPError as err:
+                logger.debug('Received error: %r', err)
+                error = err
+
+            if response and not retry.is_retryable_response(response):
+                return response
+
+            if error and not retry.is_retryable_error(error):
+                raise error
+
+            retry.increment(request, response)
+
+        if response:
+            return response
+        if error:
+            raise error
+        raise Exception('_dispatch_with_retry() ended with no response or exception')
+
+    async def aclose(self) -> None:
+        await self._wrapped_transport.aclose()

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -379,15 +379,6 @@ class SendResponse:
         """A ``FirebaseError`` if an error occurs while sending the message to the FCM service."""
         return self._exception
 
-# Auth Flow
-# TODO: Remove comments
-# The aim here is to be able to get auth credentials right before the request is sent.
-# This is similar to what is done in transport.requests.AuthorizedSession().
-# We can then pass this in at the client level.
-
-# Notes:
-# - This implementations does not cover timeouts on requests sent to refresh credentials.
-# - Uses HTTP/1 and a blocking credential for refreshing.
 class GoogleAuthCredentialFlow(httpx.Auth):
     """Google Auth Credential Auth Flow"""
     def __init__(self, credential: credentials.Credentials):
@@ -679,11 +670,6 @@ class _MessagingService:
         return _gapic_utils.handle_platform_error_from_googleapiclient(
             error, _MessagingService._build_fcm_error_googleapiclient)
 
-    # TODO: Remove comments
-    # We should be careful to clean up the httpx clients.
-    # Since we are using an async client we must also close in async. However we can sync wrap this.
-    # The close method is called by the app on shutdown/clean-up of each service. We don't seem to
-    # make use of this much elsewhere.
     def close(self) -> None:
         asyncio.run(self._async_client.aclose())
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -17,6 +17,7 @@ import datetime
 from itertools import chain, repeat
 import json
 import numbers
+import httpx
 import respx
 
 from googleapiclient import http
@@ -2100,54 +2101,26 @@ class TestSendEach(TestBatch):
         assert all([r.success for r in batch_response.responses])
         assert not any([r.exception for r in batch_response.responses])
 
-    # @respx.mock
-    # @pytest.mark.asyncio
-    # async def test_send_each_async_error_request(self):
-    #     payload = json.dumps({
-    #         'error': {
-    #             'status': 'INTERNAL',
-    #             'message': 'test INTERNAL error',
-    #             'details': [
-    #                 {
-    #                     '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
-    #                     'errorCode': 'SOME_UNKNOWN_CODE',
-    #                 },
-    #             ],
-    #         }
-    #     })
-    #     responses = chain(
-    #         [
-    #             httpx.ConnectError("Test request error", request=httpx.Request('POST', 'URL'))
-    #             # respx.MockResponse(500, http_version='HTTP/2', content=payload),
-    #         ],
-    #         # repeat(
-        #           respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id1'})),
-    #         # respx.MockResponse(200, http_version='HTTP/2', json={'name': 'message-id3'}),
-    #     )
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_send_each_async_request_error(self):
+        responses = httpx.ConnectError("Test request error", request=httpx.Request(
+            'POST',
+            'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send'))
 
-    #     # responses = repeat(respx.MockResponse(500, http_version='HTTP/2', content=payload))
+        msg1 = messaging.Message(topic='foo1')
+        route = respx.request(
+            'POST',
+            'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send'
+        ).mock(side_effect=responses)
+        batch_response = await messaging.send_each_async([msg1], dry_run=True)
 
-    #     msg1 = messaging.Message(topic='foo1')
-        # route = respx.request(
-        #     'POST',
-        #     'https://fcm.googleapis.com/v1/projects/explicit-project-id/messages:send'
-        # ).mock(side_effect=responses)
-    #     batch_response = await messaging.send_each_async([msg1], dry_run=True)
-
-    #     assert route.call_count == 1
-    #     assert batch_response.success_count == 0
-    #     assert batch_response.failure_count == 1
-    #     assert len(batch_response.responses) == 1
-    #     exception = batch_response.responses[0].exception
-    #     assert isinstance(exception, exceptions.UnavailableError)
-
-    #     # assert route.call_count == 4
-    #     # assert batch_response.success_count == 1
-    #     # assert batch_response.failure_count == 0
-    #     # assert len(batch_response.responses) == 1
-    #     # assert [r.message_id for r in batch_response.responses] == ['message-id1']
-    #     # assert all([r.success for r in batch_response.responses])
-    #     # assert not any([r.exception for r in batch_response.responses])
+        assert route.call_count == 1
+        assert batch_response.success_count == 0
+        assert batch_response.failure_count == 1
+        assert len(batch_response.responses) == 1
+        exception = batch_response.responses[0].exception
+        assert isinstance(exception, exceptions.UnavailableError)
 
     @pytest.mark.parametrize('status', HTTP_ERROR_CODES)
     def test_send_each_detailed_error(self, status):

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,451 @@
+# Copyright 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for the firebase_admin._retry module."""
+
+import time
+import email.utils
+from itertools import repeat
+from unittest.mock import call
+import pytest
+import httpx
+from pytest_mock import MockerFixture
+import respx
+
+from firebase_admin._retry import HttpxRetry, HttpxRetryTransport
+
+_TEST_URL = 'http://firebase.test.url/'
+
+@pytest.fixture
+def base_url() -> str:
+    """Provides a consistent base URL for tests."""
+    return _TEST_URL
+
+class TestHttpxRetryTransport():
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_retry_on_success(self, base_url: str, mocker: MockerFixture):
+        """Test that a successful response doesn't trigger retries."""
+        retry_config = HttpxRetry(status=3, status_forcelist=[500])
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(return_value=httpx.Response(200, text="Success"))
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert response.text == "Success"
+        assert route.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_retry_on_non_retryable_status(self, base_url: str, mocker: MockerFixture):
+        """Test that a non-retryable error status doesn't trigger retries."""
+        retry_config = HttpxRetry(status=3, status_forcelist=[500, 503])
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(return_value=httpx.Response(404, text="Not Found"))
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 404
+        assert response.text == "Not Found"
+        assert route.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_on_status_code_success_on_last_retry(
+            self, base_url: str, mocker: MockerFixture
+    ):
+        """Test retry on status code from status_forcelist, succeeding on the last attempt."""
+        retry_config = HttpxRetry(status=2, status_forcelist=[503, 500], backoff_factor=0.5)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(503, text="Attempt 1 Failed"),
+            httpx.Response(500, text="Attempt 2 Failed"),
+            httpx.Response(200, text="Attempt 3 Success"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert response.text == "Attempt 3 Success"
+        assert route.call_count == 3
+        assert mock_sleep.call_count == 2
+        # Check sleep calls (backoff_factor is 0.5)
+        mock_sleep.assert_has_calls([call(0.0), call(1.0)])
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_exhausted_returns_last_response(
+            self, base_url: str, mocker: MockerFixture
+    ):
+        """Test that the last response is returned when retries are exhausted."""
+        retry_config = HttpxRetry(status=1, status_forcelist=[500], backoff_factor=0)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(500, text="Attempt 1 Failed"),
+            httpx.Response(500, text="Attempt 2 Failed (Final)"),
+            # Should stop after previous response
+            httpx.Response(200, text="This should not be reached"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 500
+        assert response.text == "Attempt 2 Failed (Final)"
+        assert route.call_count == 2 # Initial call + 1 retry
+        assert mock_sleep.call_count == 1 # Slept before the single retry
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_after_header_seconds(self, base_url: str, mocker: MockerFixture):
+        """Test respecting Retry-After header with seconds value."""
+        retry_config = HttpxRetry(status=1, respect_retry_after_header=True, backoff_factor=100)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(429, text="Too Many Requests", headers={'Retry-After': '10'}),
+            httpx.Response(200, text="OK"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 2
+        assert mock_sleep.call_count == 1
+        # Assert sleep was called with the value from Retry-After header
+        mock_sleep.assert_called_once_with(10.0)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_after_header_http_date(self, base_url: str, mocker: MockerFixture):
+        """Test respecting Retry-After header with an HTTP-date value."""
+        retry_config = HttpxRetry(status=1, respect_retry_after_header=True, backoff_factor=100)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        # Calculate a future time and format as HTTP-date
+        retry_delay_seconds = 60
+        time_at_request = time.time()
+        retry_time = time_at_request + retry_delay_seconds
+        http_date = email.utils.formatdate(retry_time)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(503, text="Maintenance", headers={'Retry-After': http_date}),
+            httpx.Response(200, text="OK"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        # Patch time.time() within the test context to control the baseline for date calculation
+        # Set the mock time to be *just before* the Retry-After time
+        mocker.patch('time.time', return_value=time_at_request)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 2
+        assert mock_sleep.call_count == 1
+        # Check that sleep was called with approximately the correct delay
+        # Allow for small floating point inaccuracies
+        mock_sleep.assert_called_once()
+        args, _ = mock_sleep.call_args
+        assert args[0] == pytest.approx(retry_delay_seconds, abs=2)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_after_ignored_when_disabled(self, base_url: str, mocker: MockerFixture):
+        """Test Retry-After header is ignored if `respect_retry_after_header` is `False`."""
+        retry_config = HttpxRetry(
+            status=3, respect_retry_after_header=False, status_forcelist=[429],
+            backoff_factor=0.5, backoff_max=10)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(429, text="Too Many Requests", headers={'Retry-After': '60'}),
+            httpx.Response(429, text="Too Many Requests", headers={'Retry-After': '60'}),
+            httpx.Response(429, text="Too Many Requests", headers={'Retry-After': '60'}),
+            httpx.Response(200, text="OK"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 4
+        assert mock_sleep.call_count == 3
+
+        # Assert sleep was called with the calculated backoff times:
+        # After first attempt: delay = 0
+        # After retry 1 (attempt 2): delay = 0.5 * (2**(2-1)) = 0.5 * 2 = 1.0
+        # After retry 2 (attempt 3): delay = 0.5 * (2**(3-1)) = 0.5 * 4 = 2.0
+        expected_sleeps = [call(0), call(1.0), call(2.0)]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_retry_after_header_missing_backoff_fallback(
+            self, base_url: str, mocker: MockerFixture
+    ):
+        """Test Retry-After header is ignored if `respect_retry_after_header`is `True` but header is
+        not set."""
+        retry_config = HttpxRetry(
+            status=3, respect_retry_after_header=True, status_forcelist=[429],
+            backoff_factor=0.5, backoff_max=10)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(429, text="Too Many Requests"),
+            httpx.Response(429, text="Too Many Requests"),
+            httpx.Response(429, text="Too Many Requests"),
+            httpx.Response(200, text="OK"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 4
+        assert mock_sleep.call_count == 3
+
+        # Assert sleep was called with the calculated backoff times:
+        # After first attempt: delay = 0
+        # After retry 1 (attempt 2): delay = 0.5 * (2**(2-1)) = 0.5 * 2 = 1.0
+        # After retry 2 (attempt 3): delay = 0.5 * (2**(3-1)) = 0.5 * 4 = 2.0
+        expected_sleeps = [call(0), call(1.0), call(2.0)]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_exponential_backoff(self, base_url: str, mocker: MockerFixture):
+        """Test that sleep time increases exponentially with `backoff_factor`."""
+        # status=3 allows 3 retries (attempts 2, 3, 4)
+        retry_config = HttpxRetry(
+            status=3, status_forcelist=[500], backoff_factor=0.1, backoff_max=10.0)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(500, text="Fail 1"),
+            httpx.Response(500, text="Fail 2"),
+            httpx.Response(500, text="Fail 3"),
+            httpx.Response(200, text="Success"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 4
+        assert mock_sleep.call_count == 3
+
+        # Check expected backoff times:
+        # After first attempt: delay = 0
+        # After retry 1 (attempt 2): delay = 0.1 * (2**(2-1)) = 0.1 * 2 = 0.2
+        # After retry 2 (attempt 3): delay = 0.1 * (2**(3-1)) = 0.1 * 4 = 0.4
+        expected_sleeps = [call(0), call(0.2), call(0.4)]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_backoff_max(self, base_url: str, mocker: MockerFixture):
+        """Test that backoff time respects `backoff_max`."""
+        # status=4 allows 4 retries. backoff_factor=1 causes rapid increase.
+        retry_config = HttpxRetry(
+            status=4, status_forcelist=[500], backoff_factor=1, backoff_max=3.0)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(500, text="Fail 1"),
+            httpx.Response(500, text="Fail 2"),
+            httpx.Response(500, text="Fail 2"),
+            httpx.Response(500, text="Fail 4"),
+            httpx.Response(200, text="Success"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 5
+        assert mock_sleep.call_count == 4
+
+        # Check expected backoff times:
+        # After first attempt: delay = 0
+        # After retry 1 (attempt 2): delay = 1*(2**(2-1)) = 2. Clamped by max(0, min(3.0, 2)) = 2.0
+        # After retry 2 (attempt 3): delay = 1*(2**(3-1)) = 4. Clamped by max(0, min(3.0, 4)) = 3.0
+        # After retry 3 (attempt 4): delay = 1*(2**(4-1)) = 8. Clamped by max(0, min(3.0, 8)) = 3.0
+        expected_sleeps = [call(0.0), call(2.0), call(3.0), call(3.0)]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_backoff_jitter(self, base_url: str, mocker: MockerFixture):
+        """Test that `backoff_jitter` adds randomness within bounds."""
+        retry_config = HttpxRetry(
+            status=3, status_forcelist=[500], backoff_factor=0.2, backoff_jitter=0.1)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        route = respx.post(base_url).mock(side_effect=[
+            httpx.Response(500, text="Fail 1"),
+            httpx.Response(500, text="Fail 2"),
+            httpx.Response(500, text="Fail 3"),
+            httpx.Response(200, text="Success"),
+        ])
+
+        mock_sleep = mocker.patch('asyncio.sleep', return_value=None)
+        response = await client.post(base_url)
+
+        assert response.status_code == 200
+        assert route.call_count == 4
+        assert mock_sleep.call_count == 3
+
+        # Check expected backoff times are within the expected range [base - jitter, base + jitter]
+        # After first attempt: delay = 0
+        # After retry 1 (attempt 2): delay = 0.2 * (2**(2-1)) = 0.2 * 2 = 0.4 +/- 0.1
+        # After retry 2 (attempt 3): delay = 0.2 * (2**(3-1)) = 0.2 * 4 = 0.8 +/- 0.1
+        expected_sleeps = [
+            call(pytest.approx(0.0, abs=0.1)),
+            call(pytest.approx(0.4, abs=0.1)),
+            call(pytest.approx(0.8, abs=0.1))
+        ]
+        mock_sleep.assert_has_calls(expected_sleeps)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_not_retryable(self, base_url):
+        """Test that non-HTTP errors are raised immediately if not retryable."""
+        retry_config = HttpxRetry(status=3)
+        transport = HttpxRetryTransport(retry=retry_config)
+        client = httpx.AsyncClient(transport=transport)
+
+        # Mock a connection error
+        route = respx.post(base_url).mock(
+            side_effect=repeat(httpx.ConnectError("Connection failed")))
+
+        with pytest.raises(httpx.ConnectError, match="Connection failed"):
+            await client.post(base_url)
+
+        assert route.call_count == 1
+
+
+class TestHttpxRetry():
+    _TEST_REQUEST = httpx.Request('POST', _TEST_URL)
+
+    def test_httpx_retry_copy(self, base_url):
+        """Test that `HttpxRetry.copy()` creates a deep copy."""
+        original = HttpxRetry(status=5, status_forcelist=[500, 503], backoff_factor=0.5)
+        original.history.append((base_url, None, None)) # Add something mutable
+
+        copied = original.copy()
+
+        # Assert they are different objects
+        assert original is not copied
+        assert original.history is not copied.history
+
+        # Assert values are the same initially
+        assert copied.status == original.status
+        assert copied.status_forcelist == original.status_forcelist
+        assert copied.backoff_factor == original.backoff_factor
+        assert len(copied.history) == 1
+
+        # Modify the copy and check original is unchanged
+        copied.status = 1
+        copied.status_forcelist = [404]
+        copied.history.append((base_url, None, None))
+
+        assert original.status == 5
+        assert original.status_forcelist == [500, 503]
+        assert len(original.history) == 1
+
+    def test_parse_retry_after_seconds(self):
+        retry = HttpxRetry()
+        assert retry._parse_retry_after('10') == 10.0
+        assert retry._parse_retry_after('  30  ') == 30.0
+
+
+    def test_parse_retry_after_http_date(self, mocker: MockerFixture):
+        mocker.patch('time.time', return_value=1000.0)
+        retry = HttpxRetry()
+        # Date string representing 1015 seconds since epoch
+        http_date = email.utils.formatdate(1015.0)
+        # time.time() is mocked to 1000.0, so delay should be 15s
+        assert retry._parse_retry_after(http_date) == pytest.approx(15.0)
+
+    def test_parse_retry_after_past_http_date(self, mocker: MockerFixture):
+        """Test that a past date results in 0 seconds."""
+        mocker.patch('time.time', return_value=1000.0)
+        retry = HttpxRetry()
+        http_date = email.utils.formatdate(990.0) # 10s in the past
+        assert retry._parse_retry_after(http_date) == 0.0
+
+    def test_parse_retry_after_invalid_date(self):
+        retry = HttpxRetry()
+        with pytest.raises(httpx.RemoteProtocolError, match='Invalid Retry-After header'):
+            retry._parse_retry_after('Invalid Date Format')
+
+    def test_get_backoff_time_calculation(self):
+        retry = HttpxRetry(status=6, status_forcelist=[503], backoff_factor=0.5, backoff_max=10.0)
+        response = httpx.Response(503)
+        # No history -> attempt 1 -> no backoff before first request
+        # Note: get_backoff_time() is typically called *before* the *next* request,
+        # so history length reflects completed attempts.
+        assert retry.get_backoff_time() == 0.0
+
+        # Simulate attempt 1 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 1, attempt 2 -> base case 0
+        assert retry.get_backoff_time() == pytest.approx(0)
+
+        # Simulate attempt 2 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 2, attempt 3 -> 0.5*(2^1) = 1.0
+        assert retry.get_backoff_time() == pytest.approx(1.0)
+
+        # Simulate attempt 3 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 3, attempt 4 -> 0.5*(2^2) = 2.0
+        assert retry.get_backoff_time() == pytest.approx(2.0)
+
+        # Simulate attempt 4 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 4, attempt 5 -> 0.5*(2^3) = 4.0
+        assert retry.get_backoff_time() == pytest.approx(4.0)
+
+        # Simulate attempt 5 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 5, attempt 6 -> 0.5*(2^4) = 8.0
+        assert retry.get_backoff_time() == pytest.approx(8.0)
+
+        # Simulate attempt 6 completed
+        retry.increment(self._TEST_REQUEST, response)
+        # History len 6, attempt 7 -> 0.5*(2^4) = 10.0
+        assert retry.get_backoff_time() == pytest.approx(10.0)


### PR DESCRIPTION
Adds more retry logic support

This PR covers:
- Moving  and refactoring `HttpxRetryTransport` to `_retry.py`
- Adding new class `HttpxRetry` to manage retry state
- Adding support for setting some retry configurations on `HttpxRetryTransport` creation
- Performing exponential backoff before request retries
- Respecting `Retry-After` headers from request responses
- Unit tests for `HttpxRetry` and `HttpxRetryTransport`
- Unit test for handing HTTPX request errors