### PR TITLE
chore: Update README to deprecate Python 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Python Versions
 
-We currently support Python 3.7+. However, Python 3.7 support is deprecated,
-and developers are strongly advised to use Python 3.8 or higher. Firebase
+We currently support Python 3.7+. However, Python 3.7 and Python 3.8 support is deprecated,
+and developers are strongly advised to use Python 3.9 or higher. Firebase
 Admin Python SDK is also tested on PyPy and
 [Google App Engine](https://cloud.google.com/appengine/) environments.
 


### PR DESCRIPTION
Python 3.8 has EoL'ed. Update README to deprecate Python 3.8 support

Updated the 'Supported Python Versions' section in README.md to indicate that Python 3.7 and Python 3.8 support is deprecated, advising users to use Python 3.9 or higher.