### PR TITLE
APNSConfig live_activity_token field

### DIFF
--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -529,6 +529,7 @@ class MessageEncoder(json.JSONEncoder):
                 'APNSConfig.headers', apns.headers),
             'payload': cls.encode_apns_payload(apns.payload),
             'fcm_options': cls.encode_apns_fcm_options(apns.fcm_options),
+            'live_activity_token': _Validators.check_string('APNSConfig.live_activity_token', apns.live_activity_token),
         }
         return cls.remove_null_values(result)
 

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -332,7 +332,7 @@ class APNSConfig:
     Args:
         headers: A dictionary of headers (optional).
         payload: A ``messaging.APNSPayload`` to be included in the message (optional).
-        live_activity_token: A push to start live activity token (optional).
+        live_activity_token: A push to start live activity (optional).
         fcm_options: A ``messaging.APNSFCMOptions`` instance to be included in the message
             (optional).
 

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -332,6 +332,7 @@ class APNSConfig:
     Args:
         headers: A dictionary of headers (optional).
         payload: A ``messaging.APNSPayload`` to be included in the message (optional).
+        live_activity_token: A push to start live activity token (optional).
         fcm_options: A ``messaging.APNSFCMOptions`` instance to be included in the message
             (optional).
 
@@ -339,9 +340,10 @@ class APNSConfig:
         /NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
     """
 
-    def __init__(self, headers=None, payload=None, fcm_options=None):
+    def __init__(self, headers=None, payload=None, live_activity_token=None, fcm_options=None):
         self.headers = headers
         self.payload = payload
+        self.live_activity_token = live_activity_token
         self.fcm_options = fcm_options
 
 


### PR DESCRIPTION
Issue: https://github.com/firebase/firebase-admin-python/issues/857

Docs: https://firebase.google.com/docs/cloud-messaging/ios/live-activity

With this field and this configuration I am able to send LiveActivity start messages:

```
messaging.Message(
        apns=messaging.APNSConfig(
            live_activity_token=live_activity_token,
            payload=messaging.APNSPayload(
                aps=messaging.Aps(
                    alert=messaging.ApsAlert(
                        title="Live Activity Started",
                        body="Your live activity has been started",
                    ),
                    custom_data = {
                        "input-push-token": 1,
                        "event": "start",
                        "timestamp": int(time.time()),
                        "content-state": {
                            "myAttribute": False
                        },
                        "attributes-type": "LiveActivityAttributes",
                        "attributes": {
                            "myAttribute": False
                        },
                    }
                ),
                headers={
                    "apns-priority": "5",
                },
            ),
        ),
        token=cloud_messaging_token,
    )
```