### PR TITLE
fix(auth): Fixed auth error code parsing

### DIFF
--- a/firebase_admin/_auth_utils.py
+++ b/firebase_admin/_auth_utils.py
@@ -479,7 +479,7 @@ def _parse_error_body(response):
         separator = code.find(':')
         if separator != -1:
             custom_message = code[separator + 1:].strip()
-            code = code[:separator]
+            code = code[:separator].strip()
 
     return code, custom_message
 

--- a/integration/test_auth.py
+++ b/integration/test_auth.py
@@ -724,6 +724,19 @@ def test_email_sign_in_with_settings(new_user_email_unverified, api_key):
     assert id_token is not None and len(id_token) > 0
     assert auth.get_user(new_user_email_unverified.uid).email_verified
 
+def test_auth_error_parse(new_user_email_unverified):
+    action_code_settings = auth.ActionCodeSettings(
+        ACTION_LINK_CONTINUE_URL, handle_code_in_app=True, link_domain="cool.link")
+    with pytest.raises(auth.InvalidHostingLinkDomainError) as excinfo:
+        auth.generate_sign_in_with_email_link(new_user_email_unverified.email,
+                                            action_code_settings=action_code_settings)
+    assert str(excinfo.value) == ('The provided hosting link domain is not configured in Firebase '
+                                  'Hosting or is not owned by the current project '
+                                  '(INVALID_HOSTING_LINK_DOMAIN). The provided hosting link '
+                                  'domain is not configured in Firebase Hosting or is not owned '
+                                  'by the current project. This cannot be a default hosting domain '
+                                  '(web.app or firebaseapp.com).')
+
 
 @pytest.fixture(scope='module')
 def oidc_provider():


### PR DESCRIPTION
The auth error code parser incorrectly mapped known error codes to unknown errors due to additional whitespace from the expected auth error message. This whitespace is now trimmed and correctly mapped to the corresponding auth error code.