### PR TITLE
chore: Removed invalid `asyncio_default_fixture_loop_scope` config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [tool:pytest]
 testpaths = tests
 asyncio_default_test_loop_scope = class
-asyncio_default_fixture_loop_scope = None


### PR DESCRIPTION
Previously `asyncio_default_fixture_loop_scope` was set to None which was an invalid configuration. In [pytest-asyncio v1.2.0](https://github.com/pytest-dev/pytest-asyncio/releases/tag/v1.2.0), these misconfigurations now return errors. By removing this configuration, the default scope is set to session.