### PR TITLE
Add type hints to FirebaseError in exceptions.py

### DIFF
--- a/firebase_admin/exceptions.py
+++ b/firebase_admin/exceptions.py
@@ -30,6 +30,8 @@ conditions like connection timeouts and other I/O errors as instances of ``Fireb
 Therefore it is always a good idea to have a handler specified for ``FirebaseError``, after all the
 subtype error handlers.
 """
+from typing import Optional
+from requests import Response
 
 
 #: Error code for ``InvalidArgumentError`` type.
@@ -95,7 +97,11 @@ class FirebaseError(Exception):
             this object.
     """
 
-    def __init__(self, code, message, cause=None, http_response=None):
+    def __init__(self,
+    code: str,
+    message: str,
+    cause: Optional[Exception] = None,
+    http_response: Optional[Response] = None,):
         Exception.__init__(self, message)
         self._code = code
         self._cause = cause


### PR DESCRIPTION
Just added few type hints to the FirebaseError class in exceptions.py to make it easier to work with IDEs and catch type issues. The constructor now clearly shows the types for code, message, cause, and http_response. No functionality has changed, and all existing tests still pass. This is a small quality-of-life improvement that should help anyone using this module in their projects.

Related issue: #860