### PR TITLE
chore: Resolved CI build failures on PyPy 3.9 by pinning `cryptography`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ google-api-core[grpc] >= 2.25.1, < 3.0.0dev; platform.python_implementation != '
 google-cloud-firestore >= 2.21.0; platform.python_implementation != 'PyPy'
 google-cloud-storage >= 3.1.1
 pyjwt[crypto] >= 2.10.1
+cryptography < 44.0.0; platform.python_implementation == 'PyPy' and python_version < '3.11'
 httpx[http2] == 0.28.1

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ install_requires = [
     'google-cloud-firestore>=2.21.0; platform.python_implementation != "PyPy"',
     'google-cloud-storage>=3.1.1',
     'pyjwt[crypto] >= 2.10.1',
+    'cryptography < 44.0.0; platform.python_implementation == "PyPy" and python_version < "3.11"',
     'httpx[http2] == 0.28.1',
 ]
 


### PR DESCRIPTION
Newer versions of the `cryptography` package (>= 44.0.0) upgraded their internal Rust `PyO3` dependency to a version that requires PyPy >= 3.11. Consequently, building `cryptography` from source fails in older PyPy environments like `pypy3.9`. 

This PR introduces an environment marker constraint to restrict `cryptography < 44.0.0` on PyPy interpreters older than 3.11, ensuring stable dependency resolution and restoring successful builds.
