### PR TITLE
chore(deps): Resolved CI test failures caused by unmocked universe_domain lookups

### DIFF
--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -159,6 +159,10 @@ class MockGoogleComputeEngineCredential(compute_engine.Credentials):
         self._service_account_email = None
         self._token_state = credentials.TokenState.INVALID
 
+    @property
+    def universe_domain(self):
+        return 'googleapis.com'
+
     def refresh(self, request):
         self.token = 'mock-compute-engine-token'
         self._service_account_email = 'mock-gce-email'


### PR DESCRIPTION
Recent releases of `google-auth` introduced universe domain verification during `before_request` calls. For Compute Engine credentials, this verifies `universe_domain`, which attempts to query the Google Compute Engine metadata service at `http://metadata.google.internal/computeMetadata/v1/universe/universe-domain`.

Because `MockGoogleComputeEngineCredential` did not mock the `universe_domain` property, CI test runners failed to resolve `metadata.google.internal`, causing network timeout errors during test execution.

This change overrides the `universe_domain` property on `MockGoogleComputeEngineCredential` in `tests/testutils.py` to return `'googleapis.com'`, preventing external metadata server lookups during unit tests.
