### PR TITLE
feat(fcm): Add support for AndroidConfigV2

### DIFF
--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -226,6 +226,23 @@ class _Validators:
         return value
 
     @classmethod
+    def check_vibrate_timings(cls, label, value):
+        """Checks if the given value is a list comprised of numbers or datetime.timedelta
+        instances.
+        """
+        if value is None or value == []:
+            return None
+        if not isinstance(value, list):
+            raise ValueError(f'{label} must be a list of numbers or datetime.timedelta instances.')
+        non_valid = [
+            k for k in value
+            if not isinstance(k, (numbers.Number, datetime.timedelta))
+        ]
+        if non_valid:
+            raise ValueError(f'{label} must not contain non-number or non-timedelta values.')
+        return value
+
+    @classmethod
     def check_analytics_label(cls, label, value):
         """Checks if the given value is a valid analytics label."""
         value = _Validators.check_string(label, value)
@@ -573,7 +590,7 @@ class MessageEncoder(json.JSONEncoder):
             'notification_priority': _Validators.check_string(
                 'AndroidNotificationV2.notification_priority', notification.notification_priority,
                 non_empty=True),
-            'vibrate_timings': _Validators.check_number_list(
+            'vibrate_timings': _Validators.check_vibrate_timings(
                 'AndroidNotificationV2.vibrate_timings_millis',
                 notification.vibrate_timings_millis),
             'default_vibrate_timings': notification.default_vibrate_timings,

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -14,11 +14,13 @@
 
 """Encoding and validation utils for the messaging (FCM) module."""
 
+from __future__ import annotations
 import datetime
 import json
 import math
 import numbers
 import re
+from typing import Dict, List, Optional
 import warnings
 
 from firebase_admin import _messaging_utils
@@ -34,7 +36,9 @@ class Message:
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings.
         notification: An instance of ``messaging.Notification`` (optional).
-        android: An instance of ``messaging.AndroidConfig`` (optional).
+        android: An instance of ``messaging.AndroidConfig`` (optional). Deprecated.
+            Use ``android_v2`` instead.
+        android_v2: An instance of ``messaging.AndroidConfigV2`` (optional).
         webpush: An instance of ``messaging.WebpushConfig`` (optional).
         apns: An instance of ``messaging.ApnsConfig`` (optional).
         fcm_options: An instance of ``messaging.FCMOptions`` (optional).
@@ -46,17 +50,36 @@ class Message:
         condition: The FCM condition to which the message should be sent (optional).
     """
 
-    def __init__(self, data=None, notification=None, android=None, webpush=None, apns=None,
-                 fcm_options=None, token=None, topic=None, condition=None, fid=None):
+    def __init__(
+        self,
+        data: Optional[Dict[str, str]] = None,
+        notification: Optional[_messaging_utils.Notification] = None,
+        android: Optional[_messaging_utils.AndroidConfig] = None,
+        webpush: Optional[_messaging_utils.WebpushConfig] = None,
+        apns: Optional[_messaging_utils.APNSConfig] = None,
+        fcm_options: Optional[_messaging_utils.FCMOptions] = None,
+        token: Optional[str] = None,
+        topic: Optional[str] = None,
+        condition: Optional[str] = None,
+        fid: Optional[str] = None,
+        android_v2: Optional[_messaging_utils.AndroidConfigV2] = None
+    ):
         if token is not None:
             warnings.warn(
                 "Message.token is deprecated. Use Message.fid instead.",
                 DeprecationWarning,
                 stacklevel=2
             )
+        if android is not None:
+            warnings.warn(
+                'The "android" parameter is deprecated. Use "android_v2" instead.',
+                DeprecationWarning,
+                stacklevel=2
+            )
         self.data = data
         self.notification = notification
         self.android = android
+        self.android_v2 = android_v2
         self.webpush = webpush
         self.apns = apns
         self.fcm_options = fcm_options
@@ -77,18 +100,35 @@ class MulticastMessage:
         data: A dictionary of data fields (optional). All keys and values in the dictionary must be
             strings.
         notification: An instance of ``messaging.Notification`` (optional).
-        android: An instance of ``messaging.AndroidConfig`` (optional).
+        android: An instance of ``messaging.AndroidConfig`` (optional). Deprecated.
+            Use ``android_v2`` instead.
+        android_v2: An instance of ``messaging.AndroidConfigV2`` (optional).
         webpush: An instance of ``messaging.WebpushConfig`` (optional).
         apns: An instance of ``messaging.ApnsConfig`` (optional).
         fcm_options: An instance of ``messaging.FCMOptions`` (optional).
         fids: A list of Firebase Installation IDs of targeted app instances (optional).
     """
     def __init__(
-            self, tokens=None, data=None, notification=None, android=None,
-            webpush=None, apns=None, fcm_options=None, fids=None):
+        self,
+        tokens: Optional[List[str]] = None,
+        data: Optional[Dict[str, str]] = None,
+        notification: Optional[_messaging_utils.Notification] = None,
+        android: Optional[_messaging_utils.AndroidConfig] = None,
+        webpush: Optional[_messaging_utils.WebpushConfig] = None,
+        apns: Optional[_messaging_utils.APNSConfig] = None,
+        fcm_options: Optional[_messaging_utils.FCMOptions] = None,
+        fids: Optional[List[str]] = None,
+        android_v2: Optional[_messaging_utils.AndroidConfigV2] = None
+    ):
         if tokens is not None:
             warnings.warn(
                 "MulticastMessage.tokens is deprecated. Use MulticastMessage.fids instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+        if android is not None:
+            warnings.warn(
+                'The "android" parameter is deprecated. Use "android_v2" instead.',
                 DeprecationWarning,
                 stacklevel=2
             )
@@ -113,6 +153,7 @@ class MulticastMessage:
         self.data = data
         self.notification = notification
         self.android = android
+        self.android_v2 = android_v2
         self.webpush = webpush
         self.apns = apns
         self.fcm_options = fcm_options
@@ -215,8 +256,12 @@ class MessageEncoder(json.JSONEncoder):
     """A custom ``JSONEncoder`` implementation for serializing Message instances into JSON."""
 
     @classmethod
-    def remove_null_values(cls, dict_value):
-        return {k: v for k, v in dict_value.items() if v not in [None, [], {}]}
+    def remove_null_values(cls, dict_value, ignore_keys=None):
+        ignore_keys = ignore_keys or []
+        return {
+            k: v for k, v in dict_value.items()
+            if v is not None and (k in ignore_keys or v not in ([], {}))
+        }
 
     @classmethod
     def encode_android(cls, android):
@@ -249,6 +294,55 @@ class MessageEncoder(json.JSONEncoder):
         if priority and priority not in ('high', 'normal'):
             raise ValueError('AndroidConfig.priority must be "high" or "normal".')
         return result
+
+    @classmethod
+    def encode_android_v2(cls, android_v2):
+        """Encodes an ``AndroidConfigV2`` instance into JSON."""
+        if android_v2 is None:
+            return None
+        if not isinstance(android_v2, _messaging_utils.AndroidConfigV2):
+            raise ValueError('Message.android_v2 must be an instance of AndroidConfigV2 class.')
+
+        count = sum(t is not None for t in [
+            android_v2.remote_notification, android_v2.background_sync])
+        if count != 1:
+            raise ValueError('AndroidConfigV2 must contain exactly one of remote_notification or '
+                             'background_sync.')
+
+        result = {
+            'collapse_key': _Validators.check_string(
+                'AndroidConfigV2.collapse_key', android_v2.collapse_key),
+            'data': _Validators.check_string_dict(
+                'AndroidConfigV2.data', android_v2.data),
+            'remote_notification': cls.encode_android_remote_notification(
+                android_v2.remote_notification),
+            'background_sync': cls.encode_background_sync(
+                android_v2.background_sync),
+            'restricted_package_name': _Validators.check_string(
+                'AndroidConfigV2.restricted_package_name', android_v2.restricted_package_name),
+            'ttl': cls.encode_ttl(android_v2.ttl),
+            'fcm_options': cls.encode_android_fcm_options(android_v2.fcm_options),
+            'direct_boot_ok': _Validators.check_boolean(
+                'AndroidConfigV2.direct_boot_ok', android_v2.direct_boot_ok),
+            'bandwidth_constrained_ok': _Validators.check_boolean(
+                'AndroidConfigV2.bandwidth_constrained_ok', android_v2.bandwidth_constrained_ok),
+            'restricted_satellite_ok': _Validators.check_boolean(
+                'AndroidConfigV2.restricted_satellite_ok', android_v2.restricted_satellite_ok),
+        }
+        return cls.remove_null_values(result, ignore_keys=['background_sync'])
+
+    @classmethod
+    def encode_background_sync(cls, background_sync):
+        """Encodes an ``AndroidBackgroundSyncMessage`` instance into JSON."""
+        if background_sync is None:
+            return None
+        if not isinstance(background_sync, _messaging_utils.AndroidBackgroundSyncMessage):
+            raise ValueError('AndroidConfigV2.background_sync must be an instance of '
+                             'AndroidBackgroundSyncMessage class.')
+        # Currently empty, but structured to be easily expandable for future fields.
+        result = {}
+        return result
+
 
     @classmethod
     def encode_android_fcm_options(cls, fcm_options):
@@ -408,6 +502,133 @@ class MessageEncoder(json.JSONEncoder):
                 raise ValueError(
                     'AndroidNotification.proxy must be "allow", "deny" or "if_priority_lowered".')
             result['proxy'] = proxy.upper()
+        return result
+
+    @classmethod
+    def encode_android_remote_notification(cls, remote_notification):
+        """Encodes an ``AndroidRemoteNotification`` instance into JSON."""
+        if remote_notification is None:
+            return None
+        if not isinstance(remote_notification, _messaging_utils.AndroidRemoteNotification):
+            raise ValueError('AndroidConfigV2.remote_notification must be an instance of '
+                             'AndroidRemoteNotification class.')
+
+        if remote_notification.notification is None:
+            raise ValueError(
+                'AndroidRemoteNotification.notification is required and cannot be None.')
+
+        result = {
+            'mutable_content': _Validators.check_boolean(
+                'AndroidRemoteNotification.mutable_content', remote_notification.mutable_content),
+            'use_as_v1_data_message': _Validators.check_boolean(
+                'AndroidRemoteNotification.use_as_v1_data_message',
+                remote_notification.use_as_v1_data_message),
+            'notification': cls.encode_android_notification_v2(remote_notification.notification),
+        }
+        return cls.remove_null_values(result)
+
+    @classmethod
+    def encode_android_notification_v2(cls, notification):
+        """Encodes an ``AndroidNotificationV2`` instance into JSON."""
+        if notification is None:
+            return None
+        if not isinstance(notification, _messaging_utils.AndroidNotificationV2):
+            raise ValueError('AndroidRemoteNotification.notification must be an instance of '
+                             'AndroidNotificationV2 class.')
+        result = {
+            'body': _Validators.check_string(
+                'AndroidNotificationV2.body', notification.body),
+            'body_loc_args': _Validators.check_string_list(
+                'AndroidNotificationV2.body_loc_args', notification.body_loc_args),
+            'body_loc_key': _Validators.check_string(
+                'AndroidNotificationV2.body_loc_key', notification.body_loc_key),
+            'click_action': _Validators.check_string(
+                'AndroidNotificationV2.click_action', notification.click_action),
+            'color': _Validators.check_string(
+                'AndroidNotificationV2.color', notification.color, non_empty=True),
+            'icon': _Validators.check_string(
+                'AndroidNotificationV2.icon', notification.icon),
+            'sound': _Validators.check_string(
+                'AndroidNotificationV2.sound', notification.sound),
+            'tag': _Validators.check_string(
+                'AndroidNotificationV2.tag', notification.tag),
+            'id': _Validators.check_number(
+                'AndroidNotificationV2.id', notification.id),
+            'title': _Validators.check_string(
+                'AndroidNotificationV2.title', notification.title),
+            'title_loc_args': _Validators.check_string_list(
+                'AndroidNotificationV2.title_loc_args', notification.title_loc_args),
+            'title_loc_key': _Validators.check_string(
+                'AndroidNotificationV2.title_loc_key', notification.title_loc_key),
+            'channel_id': _Validators.check_string(
+                'AndroidNotificationV2.channel_id', notification.channel_id),
+            'image': _Validators.check_string(
+                'AndroidNotificationV2.image', notification.image),
+            'ticker': _Validators.check_string(
+                'AndroidNotificationV2.ticker', notification.ticker),
+            'sticky': notification.sticky,
+            'event_time': _Validators.check_datetime(
+                'AndroidNotificationV2.event_time', notification.event_time),
+            'local_only': notification.local_only,
+            'notification_priority': _Validators.check_string(
+                'AndroidNotificationV2.notification_priority', notification.notification_priority,
+                non_empty=True),
+            'vibrate_timings': _Validators.check_number_list(
+                'AndroidNotificationV2.vibrate_timings_millis',
+                notification.vibrate_timings_millis),
+            'default_vibrate_timings': notification.default_vibrate_timings,
+            'default_sound': notification.default_sound,
+            'default_light_settings': notification.default_light_settings,
+            'light_settings': cls.encode_light_settings(notification.light_settings),
+            'visibility': _Validators.check_string(
+                'AndroidNotificationV2.visibility', notification.visibility, non_empty=True),
+            'notification_count': _Validators.check_number(
+                'AndroidNotificationV2.notification_count', notification.notification_count)
+        }
+        result = cls.remove_null_values(result)
+        color = result.get('color')
+        if color and not re.match(r'^#[0-9a-fA-F]{6}$', color):
+            raise ValueError(
+                'AndroidNotificationV2.color must be in the form #RRGGBB.')
+        if result.get('body_loc_args') and not result.get('body_loc_key'):
+            raise ValueError(
+                'AndroidNotificationV2.body_loc_key is required when specifying body_loc_args.')
+        if result.get('title_loc_args') and not result.get('title_loc_key'):
+            raise ValueError(
+                'AndroidNotificationV2.title_loc_key is required when specifying title_loc_args.')
+
+        event_time = result.get('event_time')
+        if event_time:
+            # if the datetime instance is not naive (tzinfo is present), convert to UTC
+            # otherwise (tzinfo is None) assume the datetime instance is already in UTC
+            if event_time.tzinfo is not None:
+                event_time = event_time.astimezone(datetime.timezone.utc)
+            result['event_time'] = event_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+        priority = result.get('notification_priority')
+        if priority:
+            if priority not in ('min', 'low', 'default', 'high', 'max'):
+                raise ValueError(
+                    'AndroidNotificationV2.notification_priority must be "default", "min", '
+                    '"low", "high" or "max".')
+            result['notification_priority'] = 'PRIORITY_' + priority.upper()
+
+        visibility = result.get('visibility')
+        if visibility:
+            if visibility not in ('private', 'public', 'secret'):
+                raise ValueError(
+                    'AndroidNotificationV2.visibility must be "private", "public" or "secret".')
+            result['visibility'] = visibility.upper()
+
+        vibrate_timings = result.get('vibrate_timings')
+        if vibrate_timings:
+            vibrate_timing_strings = []
+            for msec in vibrate_timings:
+                formated_string = cls.encode_milliseconds(
+                    'AndroidNotificationV2.vibrate_timings_millis', msec)
+                vibrate_timing_strings.append(formated_string)
+            result['vibrate_timings'] = vibrate_timing_strings
+
         return result
 
     @classmethod
@@ -720,8 +941,11 @@ class MessageEncoder(json.JSONEncoder):
     def default(self, o): # pylint: disable=method-hidden
         if not isinstance(o, Message):
             return json.JSONEncoder.default(self, o)
+        if o.android is not None and o.android_v2 is not None:
+            raise ValueError('android and android_v2 are mutually exclusive.')
         result = {
             'android': MessageEncoder.encode_android(o.android),
+            'androidV2': MessageEncoder.encode_android_v2(o.android_v2),
             'apns': MessageEncoder.encode_apns(o.apns),
             'condition': _Validators.check_string(
                 'Message.condition', o.condition, non_empty=True),

--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Encoding and validation utils for the messaging (FCM) module."""
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 import datetime
@@ -236,7 +237,7 @@ class _Validators:
             raise ValueError(f'{label} must be a list of numbers or datetime.timedelta instances.')
         non_valid = [
             k for k in value
-            if not isinstance(k, (numbers.Number, datetime.timedelta))
+            if isinstance(k, bool) or not isinstance(k, (numbers.Number, datetime.timedelta))
         ]
         if non_valid:
             raise ValueError(f'{label} must not contain non-number or non-timedelta values.')
@@ -583,19 +584,26 @@ class MessageEncoder(json.JSONEncoder):
                 'AndroidNotificationV2.image', notification.image),
             'ticker': _Validators.check_string(
                 'AndroidNotificationV2.ticker', notification.ticker),
-            'sticky': notification.sticky,
+            'sticky': _Validators.check_boolean(
+                'AndroidNotificationV2.sticky', notification.sticky),
             'event_time': _Validators.check_datetime(
                 'AndroidNotificationV2.event_time', notification.event_time),
-            'local_only': notification.local_only,
+            'local_only': _Validators.check_boolean(
+                'AndroidNotificationV2.local_only', notification.local_only),
             'notification_priority': _Validators.check_string(
                 'AndroidNotificationV2.notification_priority', notification.notification_priority,
                 non_empty=True),
             'vibrate_timings': _Validators.check_vibrate_timings(
                 'AndroidNotificationV2.vibrate_timings_millis',
                 notification.vibrate_timings_millis),
-            'default_vibrate_timings': notification.default_vibrate_timings,
-            'default_sound': notification.default_sound,
-            'default_light_settings': notification.default_light_settings,
+            'default_vibrate_timings': _Validators.check_boolean(
+                'AndroidNotificationV2.default_vibrate_timings',
+                notification.default_vibrate_timings),
+            'default_sound': _Validators.check_boolean(
+                'AndroidNotificationV2.default_sound', notification.default_sound),
+            'default_light_settings': _Validators.check_boolean(
+                'AndroidNotificationV2.default_light_settings',
+                notification.default_light_settings),
             'light_settings': cls.encode_light_settings(notification.light_settings),
             'visibility': _Validators.check_string(
                 'AndroidNotificationV2.visibility', notification.visibility, non_empty=True),

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -14,8 +14,10 @@
 
 """Types and utilities used by the messaging (FCM) module."""
 from __future__ import annotations
+from dataclasses import dataclass
 import datetime
 from typing import Dict, List, Optional, Union
+import warnings
 
 from firebase_admin import exceptions
 
@@ -37,6 +39,8 @@ class Notification:
 
 class AndroidConfig:
     """Android-specific options that can be included in a message.
+
+    AndroidConfig is deprecated. Use AndroidConfigV2 instead.
 
     Args:
         collapse_key: Collapse key string for the message (optional). This is an identifier for a
@@ -73,6 +77,11 @@ class AndroidConfig:
         bandwidth_constrained_ok: Optional[bool] = None,
         restricted_satellite_ok: Optional[bool] = None
     ):
+        warnings.warn(
+            'AndroidConfig is deprecated. Use AndroidConfigV2 instead.',
+            DeprecationWarning,
+            stacklevel=2
+        )
         self.collapse_key = collapse_key
         self.priority = priority
         self.ttl = ttl
@@ -85,6 +94,7 @@ class AndroidConfig:
         self.restricted_satellite_ok = restricted_satellite_ok
 
 
+@dataclass
 class AndroidConfigV2:
     """Android-specific options that can be included in a message (V2).
 
@@ -111,34 +121,22 @@ class AndroidConfigV2:
         restricted_satellite_ok: A boolean indicating whether messages will be allowed to be
             delivered to the app while the device is on a restricted satellite network (optional).
     """
-
-    def __init__(
-        self,
-        collapse_key: Optional[str] = None,
-        ttl: Optional[Union[int, float, datetime.timedelta]] = None,
-        restricted_package_name: Optional[str] = None,
-        data: Optional[Dict[str, str]] = None,
-        remote_notification: Optional[AndroidRemoteNotification] = None,
-        background_sync: Optional[AndroidBackgroundSyncMessage] = None,
-        fcm_options: Optional[AndroidFCMOptions] = None,
-        direct_boot_ok: Optional[bool] = None,
-        bandwidth_constrained_ok: Optional[bool] = None,
-        restricted_satellite_ok: Optional[bool] = None
-    ):
-        self.collapse_key = collapse_key
-        self.ttl = ttl
-        self.restricted_package_name = restricted_package_name
-        self.data = data
-        self.remote_notification = remote_notification
-        self.background_sync = background_sync
-        self.fcm_options = fcm_options
-        self.direct_boot_ok = direct_boot_ok
-        self.bandwidth_constrained_ok = bandwidth_constrained_ok
-        self.restricted_satellite_ok = restricted_satellite_ok
+    collapse_key: Optional[str] = None
+    ttl: Optional[Union[int, float, datetime.timedelta]] = None
+    restricted_package_name: Optional[str] = None
+    data: Optional[Dict[str, str]] = None
+    remote_notification: Optional[AndroidRemoteNotification] = None
+    background_sync: Optional[AndroidBackgroundSyncMessage] = None
+    fcm_options: Optional[AndroidFCMOptions] = None
+    direct_boot_ok: Optional[bool] = None
+    bandwidth_constrained_ok: Optional[bool] = None
+    restricted_satellite_ok: Optional[bool] = None
 
 
 class AndroidNotification:
     """Android-specific notification parameters.
+
+    AndroidNotification is deprecated. Use AndroidNotificationV2 instead.
 
     Args:
         title: Title of the notification (optional). If specified, overrides the title set via
@@ -232,6 +230,11 @@ class AndroidNotification:
                  default_vibrate_timings=None, default_sound=None, light_settings=None,
                  default_light_settings=None, visibility=None, notification_count=None,
                  proxy=None):
+        warnings.warn(
+            'AndroidNotification is deprecated. Use AndroidNotificationV2 instead.',
+            DeprecationWarning,
+            stacklevel=2
+        )
         self.title = title
         self.body = body
         self.icon = icon
@@ -260,6 +263,7 @@ class AndroidNotification:
         self.proxy = proxy
 
 
+@dataclass
 class AndroidNotificationV2:
     """Android-specific notification options (V2).
 
@@ -345,64 +349,35 @@ class AndroidNotificationV2:
             unspecified, systems that support badging use the default, which is to increment a
             number displayed on the long-press menu each time a new notification arrives.
     """
-
-    def __init__(
-        self,
-        title: Optional[str] = None,
-        body: Optional[str] = None,
-        icon: Optional[str] = None,
-        color: Optional[str] = None,
-        sound: Optional[str] = None,
-        tag: Optional[str] = None,
-        id: Optional[int] = None,  # pylint: disable=redefined-builtin,invalid-name
-        click_action: Optional[str] = None,
-        body_loc_key: Optional[str] = None,
-        body_loc_args: Optional[List[str]] = None,
-        title_loc_key: Optional[str] = None,
-        title_loc_args: Optional[List[str]] = None,
-        channel_id: Optional[str] = None,
-        image: Optional[str] = None,
-        ticker: Optional[str] = None,
-        sticky: Optional[bool] = None,
-        event_time: Optional[datetime.datetime] = None,
-        local_only: Optional[bool] = None,
-        notification_priority: Optional[str] = None,
-        vibrate_timings_millis: Optional[List[Union[int, float, datetime.timedelta]]] = None,
-        default_vibrate_timings: Optional[bool] = None,
-        default_sound: Optional[bool] = None,
-        light_settings: Optional[LightSettings] = None,
-        default_light_settings: Optional[bool] = None,
-        visibility: Optional[str] = None,
-        notification_count: Optional[int] = None
-    ):
-        self.title = title
-        self.body = body
-        self.icon = icon
-        self.color = color
-        self.sound = sound
-        self.tag = tag
-        self.id = id  # pylint: disable=invalid-name
-        self.click_action = click_action
-        self.body_loc_key = body_loc_key
-        self.body_loc_args = body_loc_args
-        self.title_loc_key = title_loc_key
-        self.title_loc_args = title_loc_args
-        self.channel_id = channel_id
-        self.image = image
-        self.ticker = ticker
-        self.sticky = sticky
-        self.event_time = event_time
-        self.local_only = local_only
-        self.notification_priority = notification_priority
-        self.vibrate_timings_millis = vibrate_timings_millis
-        self.default_vibrate_timings = default_vibrate_timings
-        self.default_sound = default_sound
-        self.light_settings = light_settings
-        self.default_light_settings = default_light_settings
-        self.visibility = visibility
-        self.notification_count = notification_count
+    title: Optional[str] = None
+    body: Optional[str] = None
+    icon: Optional[str] = None
+    color: Optional[str] = None
+    sound: Optional[str] = None
+    tag: Optional[str] = None
+    id: Optional[int] = None  # pylint: disable=redefined-builtin,invalid-name
+    click_action: Optional[str] = None
+    body_loc_key: Optional[str] = None
+    body_loc_args: Optional[List[str]] = None
+    title_loc_key: Optional[str] = None
+    title_loc_args: Optional[List[str]] = None
+    channel_id: Optional[str] = None
+    image: Optional[str] = None
+    ticker: Optional[str] = None
+    sticky: Optional[bool] = None
+    event_time: Optional[datetime.datetime] = None
+    local_only: Optional[bool] = None
+    notification_priority: Optional[str] = None
+    vibrate_timings_millis: Optional[List[Union[int, float, datetime.timedelta]]] = None
+    default_vibrate_timings: Optional[bool] = None
+    default_sound: Optional[bool] = None
+    light_settings: Optional[LightSettings] = None
+    default_light_settings: Optional[bool] = None
+    visibility: Optional[str] = None
+    notification_count: Optional[int] = None
 
 
+@dataclass
 class AndroidRemoteNotification:
     """Android remote notification options.
 
@@ -413,18 +388,12 @@ class AndroidRemoteNotification:
         use_as_v1_data_message: A boolean indicating whether to use as a V1 data message
             fallback (optional).
     """
-
-    def __init__(
-        self,
-        notification: AndroidNotificationV2,
-        mutable_content: Optional[bool] = None,
-        use_as_v1_data_message: Optional[bool] = None
-    ):
-        self.notification = notification
-        self.mutable_content = mutable_content
-        self.use_as_v1_data_message = use_as_v1_data_message
+    notification: AndroidNotificationV2
+    mutable_content: Optional[bool] = None
+    use_as_v1_data_message: Optional[bool] = None
 
 
+@dataclass
 class AndroidBackgroundSyncMessage:
     """Android background sync message options."""
 

--- a/firebase_admin/_messaging_utils.py
+++ b/firebase_admin/_messaging_utils.py
@@ -15,7 +15,7 @@
 """Types and utilities used by the messaging (FCM) module."""
 from __future__ import annotations
 import datetime
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from firebase_admin import exceptions
 
@@ -85,6 +85,58 @@ class AndroidConfig:
         self.restricted_satellite_ok = restricted_satellite_ok
 
 
+class AndroidConfigV2:
+    """Android-specific options that can be included in a message (V2).
+
+    Args:
+        collapse_key: Collapse key string for the message (optional). This is an identifier for a
+            group of messages that can be collapsed, so that only the last message is sent when
+            delivery can be resumed. A maximum of 4 different collapse keys may be active at a
+            given time.
+        ttl: The time-to-live duration of the message (optional). This can be specified
+            as a numeric seconds value or a ``datetime.timedelta`` instance.
+        restricted_package_name: The package name of the application where the registration
+            tokens must match in order to receive the message (optional).
+        data: A dictionary of data fields (optional). All keys and values in the dictionary must be
+            strings. When specified, overrides any data fields set via ``Message.data``.
+        remote_notification: A ``messaging.AndroidRemoteNotification`` to be included in the
+            message (optional).
+        background_sync: An ``messaging.AndroidBackgroundSyncMessage`` instance to be included in
+            the message (optional).
+        fcm_options: A ``messaging.AndroidFCMOptions`` to be included in the message (optional).
+        direct_boot_ok: A boolean indicating whether messages will be allowed to be delivered to
+            the app while the device is in direct boot mode (optional).
+        bandwidth_constrained_ok: A boolean indicating whether messages will be allowed to be
+            delivered to the app while the device is on a bandwidth constrained network (optional).
+        restricted_satellite_ok: A boolean indicating whether messages will be allowed to be
+            delivered to the app while the device is on a restricted satellite network (optional).
+    """
+
+    def __init__(
+        self,
+        collapse_key: Optional[str] = None,
+        ttl: Optional[Union[int, float, datetime.timedelta]] = None,
+        restricted_package_name: Optional[str] = None,
+        data: Optional[Dict[str, str]] = None,
+        remote_notification: Optional[AndroidRemoteNotification] = None,
+        background_sync: Optional[AndroidBackgroundSyncMessage] = None,
+        fcm_options: Optional[AndroidFCMOptions] = None,
+        direct_boot_ok: Optional[bool] = None,
+        bandwidth_constrained_ok: Optional[bool] = None,
+        restricted_satellite_ok: Optional[bool] = None
+    ):
+        self.collapse_key = collapse_key
+        self.ttl = ttl
+        self.restricted_package_name = restricted_package_name
+        self.data = data
+        self.remote_notification = remote_notification
+        self.background_sync = background_sync
+        self.fcm_options = fcm_options
+        self.direct_boot_ok = direct_boot_ok
+        self.bandwidth_constrained_ok = bandwidth_constrained_ok
+        self.restricted_satellite_ok = restricted_satellite_ok
+
+
 class AndroidNotification:
     """Android-specific notification parameters.
 
@@ -134,7 +186,7 @@ class AndroidNotification:
             ``AndroidMessagePriority``. This priority is processed by the client after the message
             has been delivered. Whereas ``AndroidMessagePriority`` is an FCM concept that controls
             when the message is delivered (optional). Must be one of ``default``, ``min``, ``low``,
-            ``high``, ``max`` or ``normal``.
+            ``high`` or ``max``.
         vibrate_timings_millis: Sets the vibration pattern to use. Pass in an array of milliseconds
             to turn the vibrator on or off. The first value indicates the duration to wait before
             turning the vibrator on. The next value indicates the duration to keep the vibrator on.
@@ -206,6 +258,175 @@ class AndroidNotification:
         self.visibility = visibility
         self.notification_count = notification_count
         self.proxy = proxy
+
+
+class AndroidNotificationV2:
+    """Android-specific notification options (V2).
+
+    Args:
+        title: Title of the notification (optional). If specified, overrides the title set via
+            ``messaging.Notification``.
+        body: Body of the notification (optional). If specified, overrides the body set via
+            ``messaging.Notification``.
+        icon: Icon of the notification (optional).
+        color: Color of the notification icon expressed in ``#rrggbb`` form (optional).
+        sound: Sound to be played when the device receives the notification (optional). This is
+            usually the file name of the sound resource.
+        tag: Tag of the notification (optional). This is an identifier used to replace existing
+            notifications in the notification drawer. If not specified, each request creates a new
+            notification.
+        id: Notification ID (optional).
+        click_action: The action associated with a user click on the notification (optional). If
+            specified, an activity with a matching intent filter is launched when a user clicks on
+            the notification.
+        body_loc_key: Key of the body string in the app's string resources to use to localize the
+            body text (optional).
+        body_loc_args: A list of resource keys that will be used in place of the format specifiers
+            in ``body_loc_key`` (optional).
+        title_loc_key: Key of the title string in the app's string resources to use to localize the
+            title text (optional).
+        title_loc_args: A list of resource keys that will be used in place of the format specifiers
+            in ``title_loc_key`` (optional).
+        channel_id: channel_id of the notification (optional).
+        image: Image URL of the notification (optional).
+        ticker: Sets the ``ticker`` text, which is sent to accessibility services. Prior to API
+            level 21 (Lollipop), sets the text that is displayed in the status bar when the
+            notification first arrives (optional).
+        sticky: When set to ``False`` or unset, the notification is automatically dismissed when the
+            user clicks it in the panel. When set to ``True``, the notification persists even when
+            the user clicks it (optional).
+        event_time: For notifications that inform users about events with an absolute time
+            reference, sets the time that the event in the notification occurred as a
+            ``datetime.datetime`` instance. If the ``datetime.datetime`` instance is naive, it
+            defaults to be in the UTC timezone. Notifications in the panel are sorted by this time
+            (optional).
+        local_only: Sets whether or not this notification is relevant only to the current device.
+            Some notifications can be bridged to other devices for remote display, such as a Wear OS
+            watch. This hint can be set to recommend this notification not be bridged (optional).
+            See Wear OS guides:
+            https://developer.android.com/training/wearables/notifications/bridger#existing-method-of-preventing-bridging
+        notification_priority: Sets the relative priority for this notification. Low-priority
+            notifications may be hidden from the user in certain situations. Note this priority
+            differs from ``AndroidMessagePriority``. This priority is processed by the client after
+            the message has been delivered. Whereas ``AndroidMessagePriority`` is an FCM concept
+            that controls when the message is delivered (optional). Must be one of ``default``,
+            ``min``, ``low``, ``high`` or ``max``.
+        vibrate_timings_millis: Sets the vibration pattern to use. Pass in an array of milliseconds
+            or ``datetime.timedelta`` instances (optional) to turn the vibrator on or off. The
+            first value indicates the duration to wait before turning the vibrator on. The next
+            value indicates the duration to keep the vibrator on. Subsequent values alternate
+            between duration to turn the vibrator off and to turn the vibrator on. If
+            ``vibrate_timings`` is set and ``default_vibrate_timings`` is set to ``True``,
+            the default value is used instead of the user-specified ``vibrate_timings``.
+        default_vibrate_timings: If set to ``True``, use the Android framework's default vibrate
+            pattern for the notification (optional). Default values are specified in ``config.xml``
+            https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml.
+            If ``default_vibrate_timings`` is set to ``True`` and ``vibrate_timings`` is
+            also set, the default value is used instead of the user-specified
+            ``vibrate_timings``.
+        default_sound: If set to ``True``, use the Android framework's default sound for the
+            notification (optional). Default values are specified in ``config.xml``
+            https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml
+        light_settings: Settings to control the notification's LED blinking rate and color if LED is
+            available on the device. The total blinking time is controlled by the OS (optional).
+        default_light_settings: If set to ``True``, use the Android framework's default LED light
+            settings for the notification. Default values are specified in ``config.xml``
+            https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml.
+            If ``default_light_settings`` is set to ``True`` and ``light_settings`` is also set, the
+            user-specified ``light_settings`` is used instead of the default value.
+        visibility: Sets the visibility of the notification. Must be either ``private``, ``public``,
+            or ``secret``. If unspecified, it remains undefined in the Admin SDK, and defers to
+            the FCM backend's default mapping.
+        notification_count: Sets the number of items this notification represents. May be displayed
+            as a badge count for Launchers that support badging. See ``NotificationBadge``
+            https://developer.android.com/training/notify-user/badges. For example, this might be
+            useful if you're using just one notification to represent multiple new messages but you
+            want the count here to represent the number of total new messages. If zero or
+            unspecified, systems that support badging use the default, which is to increment a
+            number displayed on the long-press menu each time a new notification arrives.
+    """
+
+    def __init__(
+        self,
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+        icon: Optional[str] = None,
+        color: Optional[str] = None,
+        sound: Optional[str] = None,
+        tag: Optional[str] = None,
+        id: Optional[int] = None,  # pylint: disable=redefined-builtin,invalid-name
+        click_action: Optional[str] = None,
+        body_loc_key: Optional[str] = None,
+        body_loc_args: Optional[List[str]] = None,
+        title_loc_key: Optional[str] = None,
+        title_loc_args: Optional[List[str]] = None,
+        channel_id: Optional[str] = None,
+        image: Optional[str] = None,
+        ticker: Optional[str] = None,
+        sticky: Optional[bool] = None,
+        event_time: Optional[datetime.datetime] = None,
+        local_only: Optional[bool] = None,
+        notification_priority: Optional[str] = None,
+        vibrate_timings_millis: Optional[List[Union[int, float, datetime.timedelta]]] = None,
+        default_vibrate_timings: Optional[bool] = None,
+        default_sound: Optional[bool] = None,
+        light_settings: Optional[LightSettings] = None,
+        default_light_settings: Optional[bool] = None,
+        visibility: Optional[str] = None,
+        notification_count: Optional[int] = None
+    ):
+        self.title = title
+        self.body = body
+        self.icon = icon
+        self.color = color
+        self.sound = sound
+        self.tag = tag
+        self.id = id  # pylint: disable=invalid-name
+        self.click_action = click_action
+        self.body_loc_key = body_loc_key
+        self.body_loc_args = body_loc_args
+        self.title_loc_key = title_loc_key
+        self.title_loc_args = title_loc_args
+        self.channel_id = channel_id
+        self.image = image
+        self.ticker = ticker
+        self.sticky = sticky
+        self.event_time = event_time
+        self.local_only = local_only
+        self.notification_priority = notification_priority
+        self.vibrate_timings_millis = vibrate_timings_millis
+        self.default_vibrate_timings = default_vibrate_timings
+        self.default_sound = default_sound
+        self.light_settings = light_settings
+        self.default_light_settings = default_light_settings
+        self.visibility = visibility
+        self.notification_count = notification_count
+
+
+class AndroidRemoteNotification:
+    """Android remote notification options.
+
+    Args:
+        notification: An ``AndroidNotificationV2`` instance.
+        mutable_content: A boolean indicating whether the notification content can be updated by the
+            app after the notification is received on the device (optional).
+        use_as_v1_data_message: A boolean indicating whether to use as a V1 data message
+            fallback (optional).
+    """
+
+    def __init__(
+        self,
+        notification: AndroidNotificationV2,
+        mutable_content: Optional[bool] = None,
+        use_as_v1_data_message: Optional[bool] = None
+    ):
+        self.notification = notification
+        self.mutable_content = mutable_content
+        self.use_as_v1_data_message = use_as_v1_data_message
+
+
+class AndroidBackgroundSyncMessage:
+    """Android background sync message options."""
 
 
 class LightSettings:

--- a/firebase_admin/messaging.py
+++ b/firebase_admin/messaging.py
@@ -41,8 +41,12 @@ _MESSAGING_ATTRIBUTE = '_messaging'
 
 __all__ = [
     'AndroidConfig',
+    'AndroidConfigV2',
     'AndroidFCMOptions',
     'AndroidNotification',
+    'AndroidNotificationV2',
+    'AndroidRemoteNotification',
+    'AndroidBackgroundSyncMessage',
     'APNSConfig',
     'APNSFCMOptions',
     'APNSPayload',
@@ -78,8 +82,12 @@ __all__ = [
 
 
 AndroidConfig = _messaging_utils.AndroidConfig
+AndroidConfigV2 = _messaging_utils.AndroidConfigV2
 AndroidFCMOptions = _messaging_utils.AndroidFCMOptions
 AndroidNotification = _messaging_utils.AndroidNotification
+AndroidNotificationV2 = _messaging_utils.AndroidNotificationV2
+AndroidRemoteNotification = _messaging_utils.AndroidRemoteNotification
+AndroidBackgroundSyncMessage = _messaging_utils.AndroidBackgroundSyncMessage
 APNSConfig = _messaging_utils.APNSConfig
 APNSFCMOptions = _messaging_utils.APNSFCMOptions
 APNSPayload = _messaging_utils.APNSPayload
@@ -186,6 +194,7 @@ def _get_messages_from_multicast(multicast_message: MulticastMessage) -> List[Me
                 data=multicast_message.data,
                 notification=multicast_message.notification,
                 android=multicast_message.android,
+                android_v2=multicast_message.android_v2,
                 webpush=multicast_message.webpush,
                 apns=multicast_message.apns,
                 fcm_options=multicast_message.fcm_options,
@@ -197,6 +206,7 @@ def _get_messages_from_multicast(multicast_message: MulticastMessage) -> List[Me
             data=multicast_message.data,
             notification=multicast_message.notification,
             android=multicast_message.android,
+            android_v2=multicast_message.android_v2,
             webpush=multicast_message.webpush,
             apns=multicast_message.apns,
             fcm_options=multicast_message.fcm_options,

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -479,6 +479,406 @@ class TestAndroidConfigEncoder:
         check_encoding(msg, expected)
 
 
+class TestAndroidConfigV2Encoder:
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_collapse_key(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(collapse_key=data)))
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_restricted_package_name(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(restricted_package_name=data)))
+
+    @pytest.mark.parametrize('ttl', NON_UINT_ARGS + [
+        -1, -1.0, datetime.timedelta(seconds=-1), datetime.timedelta(days=-1)])
+    def test_invalid_ttl(self, ttl):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(ttl=ttl)))
+
+    @pytest.mark.parametrize('data', NON_OBJECT_ARGS)
+    def test_invalid_fcm_options(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(fcm_options=data)))
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_analytics_label(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(
+                    fcm_options=messaging.AndroidFCMOptions(analytics_label=data))))
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_direct_boot_ok(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(direct_boot_ok=data)))
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_bandwidth_constrained_ok(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(bandwidth_constrained_ok=data)))
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_restricted_satellite_ok(self, data):
+        with pytest.raises(ValueError):
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(restricted_satellite_ok=data)))
+
+    @pytest.mark.parametrize('kwargs, expected_error', [
+        ({}, 'AndroidConfigV2 must contain exactly one of remote_notification or background_sync.'),
+        ({'remote_notification': messaging.AndroidRemoteNotification(
+            notification=messaging.AndroidNotificationV2()),
+          'background_sync': messaging.AndroidBackgroundSyncMessage()},
+         'AndroidConfigV2 must contain exactly one of remote_notification or background_sync.')
+    ])
+    def test_mutual_exclusivity_within_android_config_v2(self, kwargs, expected_error):
+        with pytest.raises(ValueError) as excinfo:
+            check_encoding(messaging.Message(
+                topic='topic', android_v2=messaging.AndroidConfigV2(**kwargs)
+            ))
+        assert str(excinfo.value) == expected_error
+
+    def test_mutual_exclusivity_android_and_android_v2(self):
+        with pytest.raises(ValueError) as excinfo:
+            check_encoding(messaging.Message(
+                topic='topic',
+                android=messaging.AndroidConfig(),
+                android_v2=messaging.AndroidConfigV2(
+                    background_sync=messaging.AndroidBackgroundSyncMessage()
+                )
+            ))
+        assert str(excinfo.value) == 'android and android_v2 are mutually exclusive.'
+
+    def test_android_v2_background_sync(self):
+        msg = messaging.Message(
+            topic='topic',
+            android_v2=messaging.AndroidConfigV2(
+                collapse_key='key',
+                restricted_package_name='package',
+                ttl=123,
+                data={'k1': 'v1', 'k2': 'v2'},
+                fcm_options=messaging.AndroidFCMOptions('analytics_label_v2'),
+                direct_boot_ok=True,
+                bandwidth_constrained_ok=True,
+                restricted_satellite_ok=True,
+                background_sync=messaging.AndroidBackgroundSyncMessage()
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'androidV2': {
+                'collapse_key': 'key',
+                'restricted_package_name': 'package',
+                'ttl': '123s',
+                'data': {
+                    'k1': 'v1',
+                    'k2': 'v2',
+                },
+                'fcm_options': {
+                    'analytics_label': 'analytics_label_v2',
+                },
+                'direct_boot_ok': True,
+                'bandwidth_constrained_ok': True,
+                'restricted_satellite_ok': True,
+                'background_sync': {},
+            },
+        }
+        check_encoding(msg, expected)
+
+    def test_android_v2_remote_notification(self):
+        notif = messaging.AndroidNotificationV2(
+            title='title',
+            body='body',
+            icon='icon',
+            color='#123456',
+            sound='sound',
+            tag='tag',
+            id=123,
+            click_action='click',
+            body_loc_key='body_key',
+            body_loc_args=['arg1'],
+            title_loc_key='title_key',
+            title_loc_args=['arg2'],
+            channel_id='channel',
+            ticker='ticker',
+            sticky=True,
+            event_time=datetime.datetime(2026, 7, 14, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            local_only=True,
+            notification_priority='high',
+            default_sound=True,
+            default_vibrate_timings=True,
+            default_light_settings=True,
+            vibrate_timings_millis=[500, 1000],
+            visibility='private',
+            notification_count=5,
+            light_settings=messaging.LightSettings('#ff0000', 500, 1000),
+            image='image_url'
+        )
+        msg = messaging.Message(
+            topic='topic',
+            android_v2=messaging.AndroidConfigV2(
+                remote_notification=messaging.AndroidRemoteNotification(
+                    notification=notif,
+                    mutable_content=True,
+                    use_as_v1_data_message=True
+                )
+            )
+        )
+        expected = {
+            'topic': 'topic',
+            'androidV2': {
+                'remote_notification': {
+                    'mutable_content': True,
+                    'use_as_v1_data_message': True,
+                    'notification': {
+                        'title': 'title',
+                        'body': 'body',
+                        'icon': 'icon',
+                        'color': '#123456',
+                        'sound': 'sound',
+                        'tag': 'tag',
+                        'id': 123,
+                        'click_action': 'click',
+                        'body_loc_key': 'body_key',
+                        'body_loc_args': ['arg1'],
+                        'title_loc_key': 'title_key',
+                        'title_loc_args': ['arg2'],
+                        'channel_id': 'channel',
+                        'ticker': 'ticker',
+                        'sticky': True,
+                        'event_time': '2026-07-14T12:00:00.000000Z',
+                        'local_only': True,
+                        'notification_priority': 'PRIORITY_HIGH',
+                        'default_sound': True,
+                        'default_vibrate_timings': True,
+                        'default_light_settings': True,
+                        'vibrate_timings': ['0.500000000s', '1s'],
+                        'visibility': 'PRIVATE',
+                        'notification_count': 5,
+                        'light_settings': {
+                            'color': {
+                                'red': 1.0,
+                                'green': 0.0,
+                                'blue': 0.0,
+                                'alpha': 1.0
+                            },
+                            'light_on_duration': '0.500000000s',
+                            'light_off_duration': '1s'
+                        },
+                        'image': 'image_url'
+                    }
+                }
+            }
+        }
+        check_encoding(msg, expected)
+
+
+class TestAndroidNotificationV2Encoder:
+
+    def _check_notification(self, notification):
+        with pytest.raises(ValueError) as excinfo:
+            check_encoding(messaging.Message(
+                topic='topic',
+                android_v2=messaging.AndroidConfigV2(
+                    remote_notification=messaging.AndroidRemoteNotification(
+                        notification=notification
+                    )
+                )
+            ))
+        return excinfo
+
+    @pytest.mark.parametrize('data', NON_OBJECT_ARGS)
+    def test_invalid_android_remote_notification(self, data):
+        with pytest.raises(ValueError) as excinfo:
+            check_encoding(messaging.Message(
+                topic='topic',
+                android_v2=messaging.AndroidConfigV2(
+                    remote_notification=data
+                )
+            ))
+        expected = (
+            'AndroidConfigV2.remote_notification must be an instance of '
+            'AndroidRemoteNotification class.'
+        )
+        assert str(excinfo.value) == expected
+
+    def test_missing_notification_in_remote_notification(self):
+        with pytest.raises(ValueError) as excinfo:
+            check_encoding(messaging.Message(
+                topic='topic',
+                android_v2=messaging.AndroidConfigV2(
+                    remote_notification=messaging.AndroidRemoteNotification(
+                        notification=None
+                    )
+                )
+            ))
+        expected = 'AndroidRemoteNotification.notification is required and cannot be None.'
+        assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_title(self, data):
+        notification = messaging.AndroidNotificationV2(title=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.title must be a string.'
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS)
+    def test_invalid_body(self, data):
+        notification = messaging.AndroidNotificationV2(body=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.body must be a string.'
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS + ['foo'])
+    def test_invalid_color(self, data):
+        notification = messaging.AndroidNotificationV2(color=data)
+        excinfo = self._check_notification(notification)
+        if isinstance(data, str):
+            assert str(excinfo.value) == 'AndroidNotificationV2.color must be in the form #RRGGBB.'
+        else:
+            assert str(excinfo.value) == 'AndroidNotificationV2.color must be a non-empty string.'
+
+    @pytest.mark.parametrize('data', ['', 'foo', [], tuple(), {}])
+    def test_invalid_id(self, data):
+        notification = messaging.AndroidNotificationV2(id=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.id must be a number.'
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS + ['foo'])
+    def test_invalid_priority(self, data):
+        notification = messaging.AndroidNotificationV2(notification_priority=data)
+        excinfo = self._check_notification(notification)
+        if isinstance(data, str):
+            assert str(excinfo.value) == (
+                'AndroidNotificationV2.notification_priority must be "default", "min", '
+                '"low", "high" or "max".'
+            )
+        else:
+            assert str(excinfo.value) == (
+                'AndroidNotificationV2.notification_priority must be a non-empty string.'
+            )
+
+    @pytest.mark.parametrize('data', NON_STRING_ARGS + ['foo'])
+    def test_invalid_visibility(self, data):
+        notification = messaging.AndroidNotificationV2(visibility=data)
+        excinfo = self._check_notification(notification)
+        if isinstance(data, str):
+            assert str(excinfo.value) == (
+                'AndroidNotificationV2.visibility must be "private", "public" or "secret".'
+            )
+        else:
+            assert str(excinfo.value) == (
+                'AndroidNotificationV2.visibility must be a non-empty string.'
+            )
+
+    def test_invalid_body_loc_args(self):
+        notification = messaging.AndroidNotificationV2(body_loc_args=['arg'])
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == (
+            'AndroidNotificationV2.body_loc_key is required when specifying body_loc_args.'
+        )
+
+    def test_invalid_title_loc_args(self):
+        notification = messaging.AndroidNotificationV2(title_loc_args=['arg'])
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == (
+            'AndroidNotificationV2.title_loc_key is required when specifying title_loc_args.'
+        )
+
+    @pytest.mark.parametrize('data', NON_LIST_ARGS)
+    def test_invalid_vibrate_timings_millis(self, data):
+        notification = messaging.AndroidNotificationV2(vibrate_timings_millis=data)
+        if isinstance(data, list) and not [x for x in data if not isinstance(x, numbers.Number)]:
+            return
+        excinfo = self._check_notification(notification)
+        if isinstance(data, list):
+            expected = (
+                'AndroidNotificationV2.vibrate_timings_millis must not contain '
+                'non-number values.'
+            )
+        else:
+            expected = (
+                'AndroidNotificationV2.vibrate_timings_millis must be a list of '
+                'numbers.'
+            )
+        assert str(excinfo.value) == expected
+
+    def test_android_notification_v2_key_order(self):
+        notif = messaging.AndroidNotificationV2(
+            title='title',
+            body='body',
+            icon='icon',
+            color='#123456',
+            sound='sound',
+            tag='tag',
+            id=123,
+            click_action='click',
+            body_loc_key='body_key',
+            body_loc_args=['arg1'],
+            title_loc_key='title_key',
+            title_loc_args=['arg2'],
+            channel_id='channel',
+            ticker='ticker',
+            sticky=True,
+            event_time=datetime.datetime(2026, 7, 14, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            local_only=True,
+            notification_priority='high',
+            default_sound=True,
+            default_vibrate_timings=True,
+            default_light_settings=True,
+            vibrate_timings_millis=[500, 1000],
+            visibility='private',
+            notification_count=5,
+            light_settings=messaging.LightSettings('#ff0000', 500, 1000),
+            image='image_url'
+        )
+        msg = messaging.Message(
+            topic='topic',
+            android_v2=messaging.AndroidConfigV2(
+                remote_notification=messaging.AndroidRemoteNotification(
+                    notification=notif
+                )
+            )
+        )
+        encoded = messaging._MessagingService.encode_message(msg)
+        encoded_notif = encoded['androidV2']['remote_notification']['notification']
+        expected_order = [
+            'body',
+            'body_loc_args',
+            'body_loc_key',
+            'click_action',
+            'color',
+            'icon',
+            'sound',
+            'tag',
+            'id',
+            'title',
+            'title_loc_args',
+            'title_loc_key',
+            'channel_id',
+            'image',
+            'ticker',
+            'sticky',
+            'event_time',
+            'local_only',
+            'notification_priority',
+            'vibrate_timings',
+            'default_vibrate_timings',
+            'default_sound',
+            'default_light_settings',
+            'light_settings',
+            'visibility',
+            'notification_count'
+        ]
+        assert list(encoded_notif.keys()) == expected_order
+
+
+
 class TestAndroidNotificationEncoder:
 
     def _check_notification(self, notification):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -615,7 +615,7 @@ class TestAndroidConfigV2Encoder:
             default_sound=True,
             default_vibrate_timings=True,
             default_light_settings=True,
-            vibrate_timings_millis=[500, 1000],
+            vibrate_timings_millis=[500, datetime.timedelta(seconds=1)],
             visibility='private',
             notification_count=5,
             light_settings=messaging.LightSettings('#ff0000', 500, 1000),
@@ -793,18 +793,22 @@ class TestAndroidNotificationV2Encoder:
     @pytest.mark.parametrize('data', NON_LIST_ARGS)
     def test_invalid_vibrate_timings_millis(self, data):
         notification = messaging.AndroidNotificationV2(vibrate_timings_millis=data)
-        if isinstance(data, list) and not [x for x in data if not isinstance(x, numbers.Number)]:
+        is_valid_list = (
+            isinstance(data, list)
+            and not [x for x in data if not isinstance(x, (numbers.Number, datetime.timedelta))]
+        )
+        if is_valid_list:
             return
         excinfo = self._check_notification(notification)
         if isinstance(data, list):
             expected = (
                 'AndroidNotificationV2.vibrate_timings_millis must not contain '
-                'non-number values.'
+                'non-number or non-timedelta values.'
             )
         else:
             expected = (
                 'AndroidNotificationV2.vibrate_timings_millis must be a list of '
-                'numbers.'
+                'numbers or datetime.timedelta instances.'
             )
         assert str(excinfo.value) == expected
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -36,6 +36,7 @@ NON_OBJECT_ARGS = [[], tuple(), {}, 'foo', 0, 1, True, False]
 NON_LIST_ARGS = ['', tuple(), {}, True, False, 1, 0, [1], ['foo', 1]]
 NON_UINT_ARGS = ['1.23s', [], tuple(), {}, -1.23]
 NON_BOOL_ARGS = ['', [], tuple(), {}, 1, 0, [1], ['foo', 1], {1: 'foo'}, {'foo': 1}]
+NON_NUMBER_LIST_ARGS = ['', tuple(), {}, True, False, 1, 0, ['foo'], [True], ['foo', 1]]
 HTTP_ERROR_CODES = {
     400: exceptions.InvalidArgumentError,
     403: exceptions.PermissionDeniedError,
@@ -790,15 +791,9 @@ class TestAndroidNotificationV2Encoder:
             'AndroidNotificationV2.title_loc_key is required when specifying title_loc_args.'
         )
 
-    @pytest.mark.parametrize('data', NON_LIST_ARGS)
+    @pytest.mark.parametrize('data', NON_NUMBER_LIST_ARGS)
     def test_invalid_vibrate_timings_millis(self, data):
         notification = messaging.AndroidNotificationV2(vibrate_timings_millis=data)
-        is_valid_list = (
-            isinstance(data, list)
-            and not [x for x in data if not isinstance(x, (numbers.Number, datetime.timedelta))]
-        )
-        if is_valid_list:
-            return
         excinfo = self._check_notification(notification)
         if isinstance(data, list):
             expected = (
@@ -811,6 +806,40 @@ class TestAndroidNotificationV2Encoder:
                 'numbers or datetime.timedelta instances.'
             )
         assert str(excinfo.value) == expected
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_sticky(self, data):
+        notification = messaging.AndroidNotificationV2(sticky=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.sticky must be a boolean.'
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_local_only(self, data):
+        notification = messaging.AndroidNotificationV2(local_only=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.local_only must be a boolean.'
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_default_vibrate_timings(self, data):
+        notification = messaging.AndroidNotificationV2(default_vibrate_timings=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == (
+            'AndroidNotificationV2.default_vibrate_timings must be a boolean.'
+        )
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_default_sound(self, data):
+        notification = messaging.AndroidNotificationV2(default_sound=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == 'AndroidNotificationV2.default_sound must be a boolean.'
+
+    @pytest.mark.parametrize('data', NON_BOOL_ARGS)
+    def test_invalid_default_light_settings(self, data):
+        notification = messaging.AndroidNotificationV2(default_light_settings=data)
+        excinfo = self._check_notification(notification)
+        assert str(excinfo.value) == (
+            'AndroidNotificationV2.default_light_settings must be a boolean.'
+        )
 
     def test_android_notification_v2_key_order(self):
         notif = messaging.AndroidNotificationV2(


### PR DESCRIPTION
This change implements support for the Android v2 API and it deprecates v1 AndroidConfig structures and replaces them with the new AndroidConfigV2 structures.

Adds AndroidConfigV2, AndroidNotificationV2, AndroidRemoteNotification, and AndroidBackgroundSyncMessage data classes.
Deprecates AndroidConfig and AndroidNotification.