### PR TITLE
feat(dataconnect): add "X-Client-Version" header for cloud monitoring

### DIFF
--- a/firebase_admin/dataconnect.py
+++ b/firebase_admin/dataconnect.py
@@ -333,4 +333,5 @@ class _DataConnectApiClient:
         return {
             "X-Firebase-Client": f"fire-admin-python/{firebase_admin.__version__}",
             "x-goog-api-client": _utils.get_metrics_header(),
+            "X-Client-Version": f"python/{firebase_admin.__version__}",
         }

--- a/tests/test_data_connect.py
+++ b/tests/test_data_connect.py
@@ -724,3 +724,4 @@ class TestDataConnectApiClientGetHeaders:
         assert isinstance(headers, dict)
         assert headers.get("X-Firebase-Client") == f"fire-admin-python/{firebase_admin.__version__}"
         assert headers.get("x-goog-api-client") == _utils.get_metrics_header()
+        assert headers.get("X-Client-Version") == f"python/{firebase_admin.__version__}"


### PR DESCRIPTION
This PR adds the `X-Client-Version` request header (formatted as `python/<version>`) to `_DataConnectApiClient` to enable metrics collection in Cloud Monitoring.

### Highlights

* **Cloud Monitoring Metrics Header**: Added the `X-Client-Version` header (set to `python/{firebase_admin.__version__}`) to outgoing requests in `_DataConnectApiClient` to enable Cloud Monitoring telemetry.
* **Test Updates**: Updated unit test suites to verify that `X-Client-Version` is correctly attached to API client requests.

<details>

<summary><b>Changelog</b></summary>

* **dataconnect.py**
  * Updated `_headers` to include the `X-Client-Version` header formatted as `python/{firebase_admin.__version__}` in default request headers.
* **test_data_connect.py**
  * Updated unit test assertions in `TestDataConnectApiClientGetHeaders` to verify `X-Client-Version` is included in request headers.

</details>
