### PR TITLE
dataconnect.py: add "X-Firebase-Sqlconnect-Affinity" header for GSLB soft stickiness

### DIFF
--- a/firebase_admin/dataconnect.py
+++ b/firebase_admin/dataconnect.py
@@ -361,6 +361,9 @@ class _DataConnectApiClient:
             "X-Firebase-Client": f"fire-admin-python/{firebase_admin.__version__}",
             "x-goog-api-client": _utils.get_metrics_header(),
             "X-Client-Version": f"python/{firebase_admin.__version__}",
+            "X-Firebase-Sqlconnect-Affinity": (
+                f"{self._project_id}{self._connector_config.service_id}"
+            ),
         }
 
     @staticmethod

--- a/tests/test_data_connect.py
+++ b/tests/test_data_connect.py
@@ -741,6 +741,7 @@ class TestDataConnectApiClientGetHeaders:
         assert headers.get("X-Firebase-Client") == f"fire-admin-python/{firebase_admin.__version__}"
         assert headers.get("x-goog-api-client") == _utils.get_metrics_header()
         assert headers.get("X-Client-Version") == f"python/{firebase_admin.__version__}"
+        assert headers.get("X-Firebase-Sqlconnect-Affinity") == "test-projectstarterproject"
 
 
 class TestDataConnectApiClientMakeGqlRequest:


### PR DESCRIPTION
This PR adds the `X-Firebase-Sqlconnect-Affinity` HTTP request header to outgoing Data Connect HTTP requests. This header enables backend server affinity routing for SQL Connect to improve server resource usage efficiency and performance.

### Highlights

* **SQL Connect Server Affinity Header**: Added the `X-Firebase-Sqlconnect-Affinity` header containing `f"{self._project_id}{self._connector_config.service_id}"` to Data Connect API client requests.
* **Unit Test Coverage**: Updated `test_get_headers()` in `test_data_connect.py` to verify the header key and formatted value.

<details>
<summary>Changelog</summary>

* **dataconnect.py**
  * Added `X-Firebase-Sqlconnect-Affinity` header (`f"{self._project_id}{self._connector_config.service_id}"`) in `_DataConnectApiClient._get_headers()`.
* **test_data_connect.py**
  * Added assertion for `X-Firebase-Sqlconnect-Affinity` header in `test_get_headers()`.

</details>
