### PR TITLE
feat(appcheck): Verify one-time tokens for replay protection

### DIFF
--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -27,7 +27,7 @@ def _get_app_check_service(app) -> Any:
     return _utils.get_app_service(app, _APP_CHECK_ATTRIBUTE, _AppCheckService)
 
 def verify_token(token: str, app=None, consume: bool = False) -> Dict[str, Any]:
-    """Verifies a Firebase App Check token.
+    """Verifies a Firebase App Check token, optionally consuming limited-use tokens.
 
     Args:
         token: A token from App Check.
@@ -83,7 +83,7 @@ class _AppCheckService:
 
 
     def verify_token(self, token: str, consume: bool = False) -> Dict[str, Any]:
-        """Verifies a Firebase App Check token."""
+        """Verifies a Firebase App Check token, optionally consuming limited-use tokens."""
         _Validators.check_string("app check token", token)
 
         # Obtain the Firebase App Check Public Keys

--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -107,7 +107,9 @@ class _AppCheckService:
             except requests.exceptions.RequestException as error:
                 raise _utils.handle_requests_error(error)
 
-            already_consumed = body.get('alreadyConsumed', False) if isinstance(body, dict) else False
+            already_consumed = False
+            if isinstance(body, dict):
+                already_consumed = body.get('alreadyConsumed', False)
             verified_claims['already_consumed'] = bool(already_consumed)
 
         return verified_claims

--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -100,6 +100,8 @@ class _AppCheckService:
 
         verified_claims['app_id'] = verified_claims.get('sub')
 
+        if not isinstance(consume, bool):
+            raise ValueError('consume must be a boolean.')
         if consume:
             url = self._VERIFY_URL_FORMAT.format(project_id=self._project_id)
             try:

--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -15,38 +15,47 @@
 """Firebase App Check module."""
 
 from typing import Any, Dict
+import requests
 import jwt
 from jwt import PyJWKClient, ExpiredSignatureError, InvalidTokenError, DecodeError
 from jwt import InvalidAudienceError, InvalidIssuerError, InvalidSignatureError
-from firebase_admin import _utils
+from firebase_admin import _http_client, _utils
 
 _APP_CHECK_ATTRIBUTE = '_app_check'
 
 def _get_app_check_service(app) -> Any:
     return _utils.get_app_service(app, _APP_CHECK_ATTRIBUTE, _AppCheckService)
 
-def verify_token(token: str, app=None) -> Dict[str, Any]:
+def verify_token(token: str, app=None, consume: bool = False) -> Dict[str, Any]:
     """Verifies a Firebase App Check token.
 
     Args:
         token: A token from App Check.
         app: An App instance (optional).
+        consume: If set to ``True``, performs stateful verification with the App Check
+            backend to mark the token as consumed for replay protection. Defaults to ``False``.
 
     Returns:
-        Dict[str, Any]: The token's decoded claims.
+        Dict[str, Any]: The token's decoded claims. If ``consume`` is ``True``, the dictionary
+            also includes an ``already_consumed`` boolean key indicating whether the token was
+            previously consumed.
 
     Raises:
         ValueError: If the app's ``project_id`` is invalid or unspecified,
-        or if the token's headers or payload are invalid.
+            or if the token's headers or payload are invalid.
+        FirebaseError: If an error occurs while communicating with the App Check service.
         PyJWKClientError: If PyJWKClient fails to fetch a valid signing key.
     """
-    return _get_app_check_service(app).verify_token(token)
+    return _get_app_check_service(app).verify_token(token, consume=consume)
 
 class _AppCheckService:
     """Service class that implements Firebase App Check functionality."""
 
     _APP_CHECK_ISSUER = 'https://firebaseappcheck.googleapis.com/'
     _JWKS_URL = 'https://firebaseappcheck.googleapis.com/v1/jwks'
+    _VERIFY_URL_FORMAT = (
+        'https://firebaseappcheck.googleapis.com/v1/projects/{project_id}:verifyAppCheckToken'
+    )
     _project_id = None
     _scoped_project_id = None
     _jwks_client = None
@@ -68,9 +77,12 @@ class _AppCheckService:
         # Default lifespan is 300 seconds (5 minutes) so we change it to 21600 seconds (6 hours).
         self._jwks_client = PyJWKClient(
             self._JWKS_URL, lifespan=21600, headers=self._APP_CHECK_HEADERS)
+        timeout = app.options.get('httpTimeout', _http_client.DEFAULT_TIMEOUT_SECONDS)
+        self._http_client = _http_client.JsonHttpClient(
+            credential=app.credential.get_credential(), timeout=timeout)
 
 
-    def verify_token(self, token: str) -> Dict[str, Any]:
+    def verify_token(self, token: str, consume: bool = False) -> Dict[str, Any]:
         """Verifies a Firebase App Check token."""
         _Validators.check_string("app check token", token)
 
@@ -87,6 +99,17 @@ class _AppCheckService:
                 ) from exception
 
         verified_claims['app_id'] = verified_claims.get('sub')
+
+        if consume:
+            url = self._VERIFY_URL_FORMAT.format(project_id=self._project_id)
+            try:
+                body = self._http_client.body('post', url, json={'app_check_token': token})
+            except requests.exceptions.RequestException as error:
+                raise _utils.handle_requests_error(error)
+
+            already_consumed = body.get('alreadyConsumed', False) if isinstance(body, dict) else False
+            verified_claims['already_consumed'] = bool(already_consumed)
+
         return verified_claims
 
     def _has_valid_token_headers(self, headers: Any) -> None:

--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -105,7 +105,7 @@ class _AppCheckService:
             try:
                 body = self._http_client.body('post', url, json={'app_check_token': token})
             except requests.exceptions.RequestException as error:
-                raise _utils.handle_requests_error(error)
+                raise _utils.handle_platform_error_from_requests(error)
 
             already_consumed = False
             if isinstance(body, dict):

--- a/firebase_admin/app_check.py
+++ b/firebase_admin/app_check.py
@@ -32,8 +32,8 @@ def verify_token(token: str, app=None, consume: bool = False) -> Dict[str, Any]:
     Args:
         token: A token from App Check.
         app: An App instance (optional).
-        consume: If set to ``True``, performs stateful verification with the App Check
-            backend to mark the token as consumed for replay protection. Defaults to ``False``.
+        consume: Set to ``True`` only if the token is a limited-use (one-time) token
+            that should be consumed upon verification (optional, defaults to ``False``).
 
     Returns:
         Dict[str, Any]: The token's decoded claims. If ``consume`` is ``True``, the dictionary

--- a/tests/test_app_check.py
+++ b/tests/test_app_check.py
@@ -19,7 +19,7 @@ import pytest
 from jwt import PyJWK, InvalidAudienceError, InvalidIssuerError
 from jwt import ExpiredSignatureError, InvalidSignatureError
 import firebase_admin
-from firebase_admin import app_check
+from firebase_admin import app_check, exceptions
 from tests import testutils
 
 NON_STRING_ARGS = [[], tuple(), {}, True, False, 1, 0]
@@ -273,3 +273,51 @@ class TestVerifyToken(TestBatch):
 
         expected = 'Token does not contain the correct "iss" (issuer).'
         assert str(excinfo.value) == expected
+
+    def test_verify_token_with_consume_true_not_consumed(self, mocker):
+        mocker.patch("jwt.decode", return_value=JWT_PAYLOAD_SAMPLE)
+        mocker.patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=PyJWK(signing_key))
+        mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))
+        app = firebase_admin.get_app()
+        app_check_service = app_check._get_app_check_service(app)
+        mock_body = mocker.patch.object(app_check_service._http_client, "body", return_value={"alreadyConsumed": False})
+
+        payload = app_check.verify_token("encoded", app=app, consume=True)
+        expected = JWT_PAYLOAD_SAMPLE.copy()
+        expected["app_id"] = APP_ID
+        expected["already_consumed"] = False
+        assert payload == expected
+
+        expected_url = f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
+        mock_body.assert_called_once_with("post", expected_url, json={"app_check_token": "encoded"})
+
+    def test_verify_token_with_consume_true_already_consumed(self, mocker):
+        mocker.patch("jwt.decode", return_value=JWT_PAYLOAD_SAMPLE)
+        mocker.patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=PyJWK(signing_key))
+        mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))
+        app = firebase_admin.get_app()
+        app_check_service = app_check._get_app_check_service(app)
+        mock_body = mocker.patch.object(app_check_service._http_client, "body", return_value={"alreadyConsumed": True})
+
+        payload = app_check.verify_token("encoded", app=app, consume=True)
+        expected = JWT_PAYLOAD_SAMPLE.copy()
+        expected["app_id"] = APP_ID
+        expected["already_consumed"] = True
+        assert payload == expected
+
+        expected_url = f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
+        mock_body.assert_called_once_with("post", expected_url, json={"app_check_token": "encoded"})
+
+    def test_verify_token_with_consume_true_backend_error(self, mocker):
+        import requests
+        mocker.patch("jwt.decode", return_value=JWT_PAYLOAD_SAMPLE)
+        mocker.patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=PyJWK(signing_key))
+        mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))
+        app = firebase_admin.get_app()
+        app_check_service = app_check._get_app_check_service(app)
+
+        req_exc = requests.exceptions.RequestException("Backend error")
+        mocker.patch.object(app_check_service._http_client, "body", side_effect=req_exc)
+
+        with pytest.raises(exceptions.FirebaseError):
+            app_check.verify_token("encoded", app=app, consume=True)

--- a/tests/test_app_check.py
+++ b/tests/test_app_check.py
@@ -15,6 +15,7 @@
 """Test cases for the firebase_admin.app_check module."""
 import base64
 import pytest
+import requests
 
 from jwt import PyJWK, InvalidAudienceError, InvalidIssuerError
 from jwt import ExpiredSignatureError, InvalidSignatureError
@@ -280,7 +281,9 @@ class TestVerifyToken(TestBatch):
         mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))
         app = firebase_admin.get_app()
         app_check_service = app_check._get_app_check_service(app)
-        mock_body = mocker.patch.object(app_check_service._http_client, "body", return_value={"alreadyConsumed": False})
+        mock_body = mocker.patch.object(
+            app_check_service._http_client, "body", return_value={"alreadyConsumed": False}
+        )
 
         payload = app_check.verify_token("encoded", app=app, consume=True)
         expected = JWT_PAYLOAD_SAMPLE.copy()
@@ -288,8 +291,12 @@ class TestVerifyToken(TestBatch):
         expected["already_consumed"] = False
         assert payload == expected
 
-        expected_url = f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
-        mock_body.assert_called_once_with("post", expected_url, json={"app_check_token": "encoded"})
+        expected_url = (
+            f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
+        )
+        mock_body.assert_called_once_with(
+            "post", expected_url, json={"app_check_token": "encoded"}
+        )
 
     def test_verify_token_with_consume_true_already_consumed(self, mocker):
         mocker.patch("jwt.decode", return_value=JWT_PAYLOAD_SAMPLE)
@@ -297,7 +304,9 @@ class TestVerifyToken(TestBatch):
         mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))
         app = firebase_admin.get_app()
         app_check_service = app_check._get_app_check_service(app)
-        mock_body = mocker.patch.object(app_check_service._http_client, "body", return_value={"alreadyConsumed": True})
+        mock_body = mocker.patch.object(
+            app_check_service._http_client, "body", return_value={"alreadyConsumed": True}
+        )
 
         payload = app_check.verify_token("encoded", app=app, consume=True)
         expected = JWT_PAYLOAD_SAMPLE.copy()
@@ -305,11 +314,14 @@ class TestVerifyToken(TestBatch):
         expected["already_consumed"] = True
         assert payload == expected
 
-        expected_url = f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
-        mock_body.assert_called_once_with("post", expected_url, json={"app_check_token": "encoded"})
+        expected_url = (
+            f"https://firebaseappcheck.googleapis.com/v1/projects/{PROJECT_ID}:verifyAppCheckToken"
+        )
+        mock_body.assert_called_once_with(
+            "post", expected_url, json={"app_check_token": "encoded"}
+        )
 
     def test_verify_token_with_consume_true_backend_error(self, mocker):
-        import requests
         mocker.patch("jwt.decode", return_value=JWT_PAYLOAD_SAMPLE)
         mocker.patch("jwt.PyJWKClient.get_signing_key_from_jwt", return_value=PyJWK(signing_key))
         mocker.patch("jwt.get_unverified_header", return_value=JWT_PAYLOAD_SAMPLE.get("headers"))


### PR DESCRIPTION
This PR adds support for App Check one-time token verification for replay protection by adding an optional `consume` parameter to `app_check.verify_token()`. The returned claims dictionary will contain an `already_consumed` boolean key indicating whether the token was previously consumed. 