### PR TITLE
handle more iterable types for messaging tokens

### DIFF
--- a/firebase_admin/_messaging_encoder.py
+++ b/firebase_admin/_messaging_encoder.py
@@ -20,6 +20,7 @@ import math
 import numbers
 import re
 import warnings
+from collections.abc import Collection
 
 from firebase_admin import _messaging_utils
 
@@ -165,7 +166,7 @@ class _Validators:
         """Checks if the given value is a list comprised only of strings."""
         if value is None or value == []:
             return None
-        if not isinstance(value, list):
+        if not isinstance(value, Collection) or isinstance(value, str) or isinstance(value, dict):
             raise ValueError(f'{label} must be a list of strings.')
         non_str = [k for k in value if not isinstance(k, str)]
         if non_str:
@@ -177,7 +178,7 @@ class _Validators:
         """Checks if the given value is a list comprised only of numbers."""
         if value is None or value == []:
             return None
-        if not isinstance(value, list):
+        if not isinstance(value, Collection) or isinstance(value, str) or isinstance(value, dict):
             raise ValueError(f'{label} must be a list of numbers.')
         non_number = [k for k in value if not isinstance(k, numbers.Number)]
         if non_number:

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -33,7 +33,7 @@ from tests import testutils
 NON_STRING_ARGS = [[], tuple(), {}, True, False, 1, 0]
 NON_DICT_ARGS = ['', [], tuple(), True, False, 1, 0, {1: 'foo'}, {'foo': 1}]
 NON_OBJECT_ARGS = [[], tuple(), {}, 'foo', 0, 1, True, False]
-NON_LIST_ARGS = ['', tuple(), {}, True, False, 1, 0, [1], ['foo', 1]]
+NON_LIST_ARGS = ['', {}, True, False, 1, 0, [1], ['foo', 1], iter([])]
 NON_UINT_ARGS = ['1.23s', [], tuple(), {}, -1.23]
 NON_BOOL_ARGS = ['', [], tuple(), {}, 1, 0, [1], ['foo', 1], {1: 'foo'}, {'foo': 1}]
 HTTP_ERROR_CODES = {
@@ -128,6 +128,12 @@ class TestMulticastMessage:
 
         message = messaging.MulticastMessage(tokens=['token' for _ in range(0, 500)])
         assert len(message.tokens) == 500
+
+        message = messaging.MulticastMessage(tokens=tuple(['token' for _ in range(0, 500)]))
+        assert len(message.tokens) == 500
+
+        message = messaging.MulticastMessage(tokens=set(['token']))
+        assert len(message.tokens) == 1
 
     @pytest.mark.parametrize('fids', NON_LIST_ARGS)
     def test_invalid_fids_type(self, fids):


### PR DESCRIPTION
The messaging tokens could only be a python `list`

This PR allows to pass tuples, sets, or event django querysets.