### PR TITLE
feat(ml): deprecate Machine Learning APIs

### DIFF
--- a/firebase_admin/ml.py
+++ b/firebase_admin/ml.py
@@ -14,16 +14,24 @@
 
 """Firebase ML module.
 
+.. deprecated::
+    Firebase ML is deprecated and will be shut down on June 15, 2027.
+    To host custom models, you must migrate to another solution. You can use Cloud Storage for
+    Firebase as an alternative for hosting custom models. For more info, see
+    https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
 This module contains functions for creating, updating, getting, listing,
 deleting, publishing and unpublishing Firebase ML models.
 """
 
+# pylint: disable=too-many-lines
 
 import datetime
 import re
 import time
 import os
 from urllib import parse
+import warnings
 
 import requests
 
@@ -45,6 +53,13 @@ try:
     _TF_ENABLED = True
 except ImportError:
     _TF_ENABLED = False
+
+_DEPRECATION_WARNING = (
+    'Firebase ML is deprecated and will be shut down on June 15, 2027. '
+    'To host custom models, you must migrate to another solution. You can use Cloud Storage for '
+    'Firebase as an alternative for hosting custom models. For more info, see '
+    'https://firebase.google.com/docs/ml/migrate-to-cloud-storage'
+)
 
 _ML_ATTRIBUTE = '_ml'
 _MAX_PAGE_SIZE = 100
@@ -77,6 +92,12 @@ def _get_ml_service(app):
 def create_model(model, app=None):
     """Creates a model in the current Firebase project.
 
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
     Args:
         model: An ml.Model to create.
         app: A Firebase app instance (or None to use the default app).
@@ -84,12 +105,19 @@ def create_model(model, app=None):
     Returns:
         Model: The model that was created in Firebase ML.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.create_model(model), app=app)
 
 
 def update_model(model, app=None):
     """Updates a model's metadata or model file.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
 
     Args:
         model: The ml.Model to update.
@@ -98,12 +126,19 @@ def update_model(model, app=None):
     Returns:
         Model: The updated model.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.update_model(model), app=app)
 
 
 def publish_model(model_id, app=None):
     """Publishes a Firebase ML model.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
 
     A published model can be downloaded to client apps.
 
@@ -114,12 +149,19 @@ def publish_model(model_id, app=None):
     Returns:
         Model: The published model.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.set_published(model_id, publish=True), app=app)
 
 
 def unpublish_model(model_id, app=None):
     """Unpublishes a Firebase ML model.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
 
     Args:
         model_id: The id of the model to unpublish.
@@ -128,12 +170,19 @@ def unpublish_model(model_id, app=None):
     Returns:
         Model: The unpublished model.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.set_published(model_id, publish=False), app=app)
 
 
 def get_model(model_id, app=None):
     """Gets the model specified by the given ID.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
 
     Args:
         model_id: The id of the model to get.
@@ -142,12 +191,19 @@ def get_model(model_id, app=None):
     Returns:
      Model: The requested model.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.get_model(model_id), app=app)
 
 
 def list_models(list_filter=None, page_size=None, page_token=None, app=None):
     """Lists the current project's models.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
 
     Args:
         list_filter: a list filter string such as ``tags:'tag_1'``. None will return all models.
@@ -160,6 +216,7 @@ def list_models(list_filter=None, page_size=None, page_token=None, app=None):
     Returns:
         ListModelsPage: A (filtered) list of models.
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return ListModelsPage(
         ml_service.list_models, list_filter, page_size, page_token, app=app)
@@ -168,10 +225,17 @@ def list_models(list_filter=None, page_size=None, page_token=None, app=None):
 def delete_model(model_id, app=None):
     """Deletes a model from the current project.
 
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
     Args:
         model_id: The id of the model you wish to delete.
         app: A Firebase app instance (or None to use the default app).
     """
+    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     ml_service.delete_model(model_id)
 
@@ -179,12 +243,19 @@ def delete_model(model_id, app=None):
 class Model:
     """A Firebase ML Model object.
 
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
     Args:
         display_name: The display name of your model - used to identify your model in code.
         tags: Optional list of strings associated with your model. Can be used in list queries.
         model_format: A subclass of ModelFormat. (e.g. TFLiteFormat) Specifies the model details.
     """
     def __init__(self, display_name=None, tags=None, model_format=None):
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._app = None  # Only needed for wait_for_unlo
         self._data = {}
         self._model_format = None
@@ -342,7 +413,14 @@ class Model:
 
 
 class ModelFormat:
-    """Abstract base class representing a Model Format such as TFLite."""
+    """Abstract base class representing a Model Format such as TFLite.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+    """
     def as_dict(self, for_upload=False):
         """Returns a serializable representation of the object."""
         raise NotImplementedError
@@ -351,10 +429,17 @@ class ModelFormat:
 class TFLiteFormat(ModelFormat):
     """Model format representing a TFLite model.
 
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
     Args:
         model_source: A TFLiteModelSource sub class. Specifies the details of the model source.
     """
     def __init__(self, model_source=None):
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._data = {}
         self._model_source = None
 
@@ -412,7 +497,14 @@ class TFLiteFormat(ModelFormat):
 
 
 class TFLiteModelSource:
-    """Abstract base class representing a model source for TFLite format models."""
+    """Abstract base class representing a model source for TFLite format models.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+    """
     def as_dict(self, for_upload=False):
         """Returns a serializable representation of the object."""
         raise NotImplementedError
@@ -466,11 +558,19 @@ class _CloudStorageClient:
 
 
 class TFLiteGCSModelSource(TFLiteModelSource):
-    """TFLite model source representing a tflite model file stored in GCS."""
+    """TFLite model source representing a tflite model file stored in GCS.
+
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+    """
 
     _STORAGE_CLIENT = _CloudStorageClient()
 
     def __init__(self, gcs_tflite_uri, app=None):
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._app = app
         self._gcs_tflite_uri = _validate_gcs_tflite_uri(gcs_tflite_uri)
 
@@ -600,12 +700,19 @@ class TFLiteGCSModelSource(TFLiteModelSource):
 class ListModelsPage:
     """Represents a page of models in a Firebase project.
 
+    .. deprecated::
+        Firebase ML is deprecated and will be shut down on June 15, 2027.
+        To host custom models, you must migrate to another solution. You can use Cloud Storage for
+        Firebase as an alternative for hosting custom models. For more info, see
+        https://firebase.google.com/docs/ml/migrate-to-cloud-storage
+
     Provides methods for traversing the models included in this page, as well as
     retrieving subsequent pages of models. The iterator returned by
     ``iterate_all()`` can be used to iterate through all the models in the
     Firebase project starting from this page.
     """
     def __init__(self, list_models_func, list_filter, page_size, page_token, app):
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._list_models_func = list_models_func
         self._list_filter = list_filter
         self._page_size = page_size

--- a/firebase_admin/ml.py
+++ b/firebase_admin/ml.py
@@ -27,9 +27,10 @@ deleting, publishing and unpublishing Firebase ML models.
 # pylint: disable=too-many-lines
 
 import datetime
-import re
-import time
 import os
+import re
+import sys
+import time
 from urllib import parse
 import warnings
 
@@ -60,6 +61,23 @@ _DEPRECATION_WARNING = (
     'Firebase as an alternative for hosting custom models. For more info, see '
     'https://firebase.google.com/docs/ml/migrate-to-cloud-storage'
 )
+
+
+def _is_internal_call():
+    """Checks if the current call originated from within the ML module."""
+    try:
+        # pylint: disable=protected-access
+        frame = sys._getframe(2)
+        while frame:
+            if frame.f_code.co_name in (
+                'from_dict', '_update_from_dict', 'handle_operation', 'list_models'
+            ):
+                return True
+            frame = frame.f_back
+    except (AttributeError, ValueError):
+        pass
+    return False
+
 
 _ML_ATTRIBUTE = '_ml'
 _MAX_PAGE_SIZE = 100
@@ -105,7 +123,8 @@ def create_model(model, app=None):
     Returns:
         Model: The model that was created in Firebase ML.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.create_model(model), app=app)
 
@@ -126,7 +145,8 @@ def update_model(model, app=None):
     Returns:
         Model: The updated model.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.update_model(model), app=app)
 
@@ -149,7 +169,8 @@ def publish_model(model_id, app=None):
     Returns:
         Model: The published model.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.set_published(model_id, publish=True), app=app)
 
@@ -170,7 +191,8 @@ def unpublish_model(model_id, app=None):
     Returns:
         Model: The unpublished model.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.set_published(model_id, publish=False), app=app)
 
@@ -191,7 +213,8 @@ def get_model(model_id, app=None):
     Returns:
      Model: The requested model.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return Model.from_dict(ml_service.get_model(model_id), app=app)
 
@@ -216,7 +239,8 @@ def list_models(list_filter=None, page_size=None, page_token=None, app=None):
     Returns:
         ListModelsPage: A (filtered) list of models.
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     return ListModelsPage(
         ml_service.list_models, list_filter, page_size, page_token, app=app)
@@ -235,7 +259,8 @@ def delete_model(model_id, app=None):
         model_id: The id of the model you wish to delete.
         app: A Firebase app instance (or None to use the default app).
     """
-    warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+    if not _is_internal_call():
+        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
     ml_service = _get_ml_service(app)
     ml_service.delete_model(model_id)
 
@@ -255,7 +280,8 @@ class Model:
         model_format: A subclass of ModelFormat. (e.g. TFLiteFormat) Specifies the model details.
     """
     def __init__(self, display_name=None, tags=None, model_format=None):
-        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+        if not _is_internal_call():
+            warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._app = None  # Only needed for wait_for_unlo
         self._data = {}
         self._model_format = None
@@ -439,7 +465,8 @@ class TFLiteFormat(ModelFormat):
         model_source: A TFLiteModelSource sub class. Specifies the details of the model source.
     """
     def __init__(self, model_source=None):
-        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+        if not _is_internal_call():
+            warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._data = {}
         self._model_source = None
 
@@ -570,7 +597,8 @@ class TFLiteGCSModelSource(TFLiteModelSource):
     _STORAGE_CLIENT = _CloudStorageClient()
 
     def __init__(self, gcs_tflite_uri, app=None):
-        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+        if not _is_internal_call():
+            warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._app = app
         self._gcs_tflite_uri = _validate_gcs_tflite_uri(gcs_tflite_uri)
 
@@ -712,7 +740,8 @@ class ListModelsPage:
     Firebase project starting from this page.
     """
     def __init__(self, list_models_func, list_filter, page_size, page_token, app):
-        warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
+        if not _is_internal_call():
+            warnings.warn(_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
         self._list_models_func = list_models_func
         self._list_filter = list_filter
         self._page_size = page_size

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1086,3 +1086,72 @@ class TestListModels:
         assert len(page.models) == 0
         models = list(page.iterate_all())
         assert len(models) == 0
+
+
+class TestMLDeprecation:
+    """Tests for verifying deprecation warnings in the ML module."""
+
+    DEPRECATION_MSG = (
+        r'Firebase ML is deprecated and will be shut down on June 15, 2027\. '
+        r'To host custom models, you must migrate to another solution\. '
+        r'You can use Cloud Storage for Firebase as an alternative for hosting custom models\. '
+        r'For more info, see https://firebase\.google\.com/docs/ml/migrate-to-cloud-storage'
+    )
+
+    @classmethod
+    def setup_class(cls):
+        cred = testutils.MockCredential()
+        firebase_admin.initialize_app(cred, {'projectId': PROJECT_ID})
+        ml._MLService.POLL_BASE_WAIT_TIME_SECONDS = 0.1
+        ml.TFLiteGCSModelSource._STORAGE_CLIENT = _TestStorageClient()
+
+    @classmethod
+    def teardown_class(cls):
+        testutils.cleanup_apps()
+
+    def test_model_init_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.Model()
+
+    def test_tflite_format_init_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.TFLiteFormat()
+
+    def test_tflite_gcs_model_source_init_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.TFLiteGCSModelSource('gs://bucket/model.tflite')
+
+    def test_get_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=DEFAULT_GET_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.get_model(MODEL_ID_1)
+
+    def test_list_models_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=ONE_PAGE_LIST_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.list_models()
+
+    def test_delete_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=EMPTY_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.delete_model(MODEL_ID_1)
+
+    def test_create_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=OPERATION_DONE_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.create_model(ml.Model(display_name=DISPLAY_NAME_1))
+
+    def test_update_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=OPERATION_DONE_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.update_model(ml.Model(display_name=DISPLAY_NAME_1))
+
+    def test_publish_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=OPERATION_DONE_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.publish_model(MODEL_ID_1)
+
+    def test_unpublish_model_deprecation_warning(self):
+        instrument_ml_service(status=200, payload=OPERATION_DONE_RESPONSE)
+        with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
+            ml.unpublish_model(MODEL_ID_1)

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -15,6 +15,7 @@
 """Test cases for the firebase_admin.ml module."""
 
 import json
+import warnings
 
 import pytest
 
@@ -1119,7 +1120,7 @@ class TestMLDeprecation:
 
     def test_tflite_gcs_model_source_init_deprecation_warning(self):
         with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
-            ml.TFLiteGCSModelSource('gs://bucket/model.tflite')
+            ml.TFLiteGCSModelSource(GCS_TFLITE_URI)
 
     def test_get_model_deprecation_warning(self):
         instrument_ml_service(status=200, payload=DEFAULT_GET_RESPONSE)
@@ -1155,3 +1156,20 @@ class TestMLDeprecation:
         instrument_ml_service(status=200, payload=OPERATION_DONE_RESPONSE)
         with pytest.warns(DeprecationWarning, match=self.DEPRECATION_MSG):
             ml.unpublish_model(MODEL_ID_1)
+
+    def test_single_warning_on_get_model(self):
+        instrument_ml_service(status=200, payload=DEFAULT_GET_RESPONSE)
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter('always')
+            ml.get_model(MODEL_ID_1)
+            assert len(captured_warnings) == 1
+            assert issubclass(captured_warnings[0].category, DeprecationWarning)
+
+    def test_single_warning_on_list_models(self):
+        instrument_ml_service(status=200, payload=ONE_PAGE_LIST_RESPONSE)
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            warnings.simplefilter('always')
+            page = ml.list_models()
+            _ = page.models
+            assert len(captured_warnings) == 1
+            assert issubclass(captured_warnings[0].category, DeprecationWarning)


### PR DESCRIPTION
The PR deprecates the Firebase Machine Learning module, functions, and classes ahead of the service turndown on June 15, 2027. Developers are instructed to migrate their custom model hosting workflows directly to Cloud Storage for Firebase. Unit tests are added to verify that `DeprecationWarning` is triggered with the expected message.